### PR TITLE
Fix typos in README.md

### DIFF
--- a/packages/requestNetwork.js/README.md
+++ b/packages/requestNetwork.js/README.md
@@ -96,7 +96,6 @@ As is the convention with promise-based libraries, if an error occurs, it is thr
 ### Versioning
 The library adheres to the Semantic Versioning 2.0.0 specification. 
 Note that major version zero (0.y.z) is for initial development. Anything may change at any time. The public API should not be considered stable since the library is still an alpha and we will introduce backward incompatible changes to the interface without incrementing the major version until the 1.0.0 release. Our convention until then will be to increment the minor version whenever we introduce backward incompatible changes to the public interface, and to increment the patch version otherwise. 
-Functions
 
 ## Functions
 ### Create a request as the payee

--- a/packages/requestNetworkSmartContracts/README.md
+++ b/packages/requestNetworkSmartContracts/README.md
@@ -19,7 +19,7 @@ No tutorial available yet. Feel free to suggest yours and we will refer to it.
 ### Develop on test-rpc
 You can deploy your own contracts on testrpc thanks to the truffle project:
 ```git clone https://github.com/RequestNetwork/requestNetwork 
-cd package/requestNetworkSmartContracts 
+cd packages/requestNetworkSmartContracts 
 truffle deploy --network development
 ```
 


### PR DESCRIPTION
As discussed with @vrolland:
- duplicate word "Functions" in requestNetwork.js/README.md
- "packages" instead of "package" in requestNetworkSmartContracts/README.md