### PR TITLE
Fixed grammar in comments, improved a function name, changed purchase reason in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10.6.0-stretch
+      - image: ipfs/go-ipfs:v0.4.16
+      - image: trufflesuite/ganache-cli:v6.1.6
+        command: [
+          "-l", "90000000",
+          "-m", "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"]
+    environment:
+      NODE_ENV: test
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-node-modules-cache-{{ checksum "package.json" }}-{{ checksum "packages/requestNetwork.js/package.json" }}
+      - run:
+          name: Clone RequestNetwork repo and install depedencies
+          command: |
+            npm install .
+            cd packages/requestNetwork.js/ && npm install . && cd -
+      - save_cache:
+          key: v1-node-modules-cache-{{ checksum "package.json" }}-{{ checksum "packages/requestNetwork.js/package.json" }}
+          paths:
+            - "node_modules"
+            - "packages/requestNetwork.js/node_modules"
+      - run:
+          name: Deploy test contracts and run Request unit tests
+          command: |
+            ./node_modules/lerna/bin/lerna.js run --scope @requestnetwork/request-network.js testdeploy
+            ./node_modules/lerna/bin/lerna.js run --scope @requestnetwork/request-network.js test --stream

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.6.0-stretch
+      - image: circleci/node:8.11.3-stretch
       - image: ipfs/go-ipfs:v0.4.16
       - image: trufflesuite/ganache-cli:v6.1.6
         command: [
@@ -15,7 +15,7 @@ jobs:
       - restore_cache:
           key: v1-node-modules-cache-{{ checksum "package.json" }}-{{ checksum "packages/requestNetwork.js/package.json" }}
       - run:
-          name: Clone RequestNetwork repo and install depedencies
+          name: Install depedencies
           command: |
             npm install .
             cd packages/requestNetwork.js/ && npm install . && cd -

--- a/packages/requestNetwork.js/README.md
+++ b/packages/requestNetwork.js/README.md
@@ -242,7 +242,7 @@ Example:
 ### Check a signed request
 
 ```js
-public isSignedRequestHasError(_signedRequest: any, _payer: string): string;
+public validateSignedRequest(_signedRequest: any, _payer: string): string;
 ```
 
 Check if a signed request is valid
@@ -510,7 +510,7 @@ Example:
 ### Check a signed request
 
 ```js
-public isSignedRequestHasError(_signedRequest: any, _payer: string): string;
+public validateSignedRequest(_signedRequest: any, _payer: string): string;
 ```
 
 Check if a signed request is valid
@@ -777,7 +777,7 @@ Example:
 ### Check a signed request
 
 ```js
-public isSignedRequestHasError(_signedRequest: any, _payer: string): string;
+public validateSignedRequest(_signedRequest: any, _payer: string): string;
 ```
 
 Check if a signed request is valid

--- a/packages/requestNetwork.js/src/api/signed-request.ts
+++ b/packages/requestNetwork.js/src/api/signed-request.ts
@@ -69,7 +69,7 @@ export default class SignedRequest {
             this.signedRequestData.currencyContract,
         );
 
-        return currencyUtils.serviceForCurrency(currency).isSignedRequestHasError(this.signedRequestData, payer.idAddress);
+        return currencyUtils.serviceForCurrency(currency).validateSignedRequest(this.signedRequestData, payer.idAddress);
     }
 
     /**

--- a/packages/requestNetwork.js/src/servicesContracts/requestBitcoinNodesValidation-service.ts
+++ b/packages/requestNetwork.js/src/servicesContracts/requestBitcoinNodesValidation-service.ts
@@ -144,7 +144,7 @@ export default class RequestBitcoinNodesValidationService {
             }
 
             if (_expectedAmounts.some((amount: any) => amount.isNeg())) {
-                return promiEvent.reject(Error('_expectedAmounts must be positives integer'));
+                return promiEvent.reject(Error('_expectedAmounts must be positive integers'));
             }
 
             if (!this.web3Single.isAddressNoChecksum(_payer)) {
@@ -251,7 +251,7 @@ export default class RequestBitcoinNodesValidationService {
             }
 
             if (_expectedAmounts.some((amount: any) => amount.isNeg())) {
-                return promiEvent.reject(Error('_expectedAmounts must be positives integer'));
+                return promiEvent.reject(Error('_expectedAmounts must be positive integers'));
             }
             if ( !this.web3Single.areSameAddressesNoChecksum(account, _payeesIdAddress[0]) ) {
                 return promiEvent.reject(Error('account broadcaster must be the main payee'));
@@ -332,7 +332,7 @@ export default class RequestBitcoinNodesValidationService {
                 return promiEvent.reject(Error('payeesRefundAddress must be valid bitcoin addresses'));
             }
             if (additionalsParsed.some((amount: any) => amount.isNeg())) {
-                return promiEvent.reject(Error('_additionals must be positives integer'));
+                return promiEvent.reject(Error('_additionals must be positive integers'));
             }
             if (this.web3Single.areSameAddressesNoChecksum(account, _signedRequest.payeesIdAddress[0]) ) {
                 return promiEvent.reject(Error('_from must be different than the main payee'));
@@ -558,7 +558,7 @@ export default class RequestBitcoinNodesValidationService {
                     return promiEvent.reject(Error('_subtracts cannot be bigger than _payeesIdAddress'));
                 }
                 if (subtractsParsed.some((amount: any) => amount.isNeg())) {
-                    return promiEvent.reject(Error('subtracts must be positives integer'));
+                    return promiEvent.reject(Error('subtracts must be positive integers'));
                 }
                 if ( request.state === Types.State.Canceled ) {
                     return promiEvent.reject(Error('request must be accepted or created'));
@@ -657,7 +657,7 @@ export default class RequestBitcoinNodesValidationService {
                     return promiEvent.reject(Error('_additionals cannot be bigger than _payeesIdAddress'));
                 }
                 if (additionalsParsed.some((amount: any) => amount.isNeg())) {
-                    return promiEvent.reject(Error('additionals must be positives integer'));
+                    return promiEvent.reject(Error('additionals must be positive integers'));
                 }
                 if ( request.state === Types.State.Canceled ) {
                     return promiEvent.reject(Error('request must be accepted or created'));
@@ -891,7 +891,7 @@ export default class RequestBitcoinNodesValidationService {
             return '_payeesIdAddress, payeesPaymentAddress and _expectedAmounts must have the same size';
         }
         if (_signedRequest.expectedAmounts.some((amount: any) => amount.isNeg())) {
-            return '_expectedAmounts must be positives integer';
+            return '_expectedAmounts must be positive integers';
         }
         if (!this.web3Single.areSameAddressesNoChecksum(this.addressRequestBitcoinNodesValidationLast, _signedRequest.currencyContract)) {
             return 'currencyContract must be the last currencyContract of requestBitcoinNodesValidation';

--- a/packages/requestNetwork.js/src/servicesContracts/requestBitcoinNodesValidation-service.ts
+++ b/packages/requestNetwork.js/src/servicesContracts/requestBitcoinNodesValidation-service.ts
@@ -319,7 +319,7 @@ export default class RequestBitcoinNodesValidationService {
         this.web3Single.getDefaultAccountCallback(async (err, defaultAccount) => {
             if (!_options.from && err) return promiEvent.reject(err);
             const account = _options.from || defaultAccount;
-            const error = this.isSignedRequestHasError(_signedRequest, account);
+            const error = this.validateSignedRequest(_signedRequest, account);
             if (error !== '') return promiEvent.reject(Error(error));
 
             if (_additionals && _signedRequest.payeesIdAddress.length < _additionals.length) {
@@ -870,7 +870,7 @@ export default class RequestBitcoinNodesValidationService {
      * @param   _payer             Payer of the request
      * @return  return a string with the error, or ''
      */
-    public isSignedRequestHasError(_signedRequest: any, _payer: string): string {
+    public validateSignedRequest(_signedRequest: any, _payer: string): string {
         _signedRequest.expectedAmounts = _signedRequest.expectedAmounts.map((amount: any) => new BN(amount));
 
         const hashComputed = this.hashRequest(

--- a/packages/requestNetwork.js/src/servicesContracts/requestERC20-service.ts
+++ b/packages/requestNetwork.js/src/servicesContracts/requestERC20-service.ts
@@ -500,7 +500,7 @@ export default class RequestERC20Service {
                     return promiEvent.reject(Error('token not supported'));
                 }
 
-                await this.isSignedRequestHasError(_signedRequest, account);
+                await this.validateSignedRequest(_signedRequest, account);
 
                 if (_amountsToPay && _signedRequest.payeesIdAddress.length < _amountsToPay.length) {
                     return promiEvent.reject(Error('_amountsToPay cannot be bigger than _payeesIdAddress'));
@@ -1360,7 +1360,7 @@ export default class RequestERC20Service {
      * @param   _payer             Payer of the request
      * @return  return a string with the error, or ''
      */
-    public isSignedRequestHasError(_signedRequest: any, _payer: string): Promise<string> {
+    public validateSignedRequest(_signedRequest: any, _payer: string): Promise<string> {
         return new Promise(async (resolve, reject) => {
             _signedRequest.expectedAmounts = _signedRequest.expectedAmounts.map((amount: any) => new BN(amount));
 

--- a/packages/requestNetwork.js/src/servicesContracts/requestERC20-service.ts
+++ b/packages/requestNetwork.js/src/servicesContracts/requestERC20-service.ts
@@ -133,7 +133,7 @@ export default class RequestERC20Service {
                 return promiEvent.reject(Error('account broadcaster must be the main payee'));
             }
             if (_expectedAmounts.filter((amount) => amount.isNeg()).length !== 0) {
-                return promiEvent.reject(Error('_expectedAmounts must be positives integer'));
+                return promiEvent.reject(Error('_expectedAmounts must be positive integers'));
             }
             if (!this.web3Single.isAddressNoChecksum(_payer)) {
                 return promiEvent.reject(Error('_payer must be a valid eth address'));
@@ -263,13 +263,13 @@ export default class RequestERC20Service {
                 return promiEvent.reject(Error('_payeesIdAddress must be valid eth addresses'));
             }
             if (_expectedAmounts.filter((amount) => amount.isNeg()).length !== 0) {
-                return promiEvent.reject(Error('_expectedAmounts must be positives integer'));
+                return promiEvent.reject(Error('_expectedAmounts must be positive integers'));
             }
             if (amountsToPayParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                return promiEvent.reject(Error('_amountsToPay must be positives integer'));
+                return promiEvent.reject(Error('_amountsToPay must be positive integers'));
             }
             if (additionalsParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                return promiEvent.reject(Error('_additionals must be positives integer'));
+                return promiEvent.reject(Error('_additionals must be positive integers'));
             }
             if (_extension) {
                 return promiEvent.reject(Error('extensions are disabled for now'));
@@ -403,7 +403,7 @@ export default class RequestERC20Service {
                 return promiEvent.reject(Error('_expirationDate must be greater than now'));
             }
             if (_expectedAmounts.filter((amount) => amount.isNeg()).length !== 0) {
-                return promiEvent.reject(Error('_expectedAmounts must be positives integer'));
+                return promiEvent.reject(Error('_expectedAmounts must be positive integers'));
             }
             if ( !this.web3Single.areSameAddressesNoChecksum(account, _payeesIdAddress[0]) ) {
                 return promiEvent.reject(Error('account broadcaster must be the main payee'));
@@ -509,10 +509,10 @@ export default class RequestERC20Service {
                     return promiEvent.reject(Error('_additionals cannot be bigger than _payeesIdAddress'));
                 }
                 if (amountsToPayParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                    return promiEvent.reject(Error('_amountsToPay must be positives integer'));
+                    return promiEvent.reject(Error('_amountsToPay must be positive integers'));
                 }
                 if (additionalsParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                    return promiEvent.reject(Error('_additionals must be positives integer'));
+                    return promiEvent.reject(Error('_additionals must be positive integers'));
                 }
                 if (this.web3Single.areSameAddressesNoChecksum(account, _signedRequest.payeesIdAddress[0]) ) {
                     return promiEvent.reject(Error('_from must be different than the main payee'));
@@ -758,7 +758,7 @@ export default class RequestERC20Service {
                     return promiEvent.reject(Error('_additionals cannot be bigger than _payeesIdAddress'));
                 }
                 if (additionalsParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                    return promiEvent.reject(Error('additionals must be positives integer'));
+                    return promiEvent.reject(Error('additionals must be positive integers'));
                 }
                 if ( request.state === Types.State.Canceled ) {
                     return promiEvent.reject(Error('request must be accepted or created'));
@@ -848,7 +848,7 @@ export default class RequestERC20Service {
                     return promiEvent.reject(Error('_subtracts cannot be bigger than _payeesIdAddress'));
                 }
                 if (subtractsParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                    return promiEvent.reject(Error('subtracts must be positives integer'));
+                    return promiEvent.reject(Error('subtracts must be positive integers'));
                 }
                 if ( request.state === Types.State.Canceled ) {
                     return promiEvent.reject(Error('request must be accepted or created'));
@@ -958,10 +958,10 @@ export default class RequestERC20Service {
                     return promiEvent.reject(Error('_additionals cannot be bigger than _payeesIdAddress'));
                 }
                 if (amountsToPayParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                    return promiEvent.reject(Error('_amountsToPay must be positives integer'));
+                    return promiEvent.reject(Error('_amountsToPay must be positive integers'));
                 }
                 if (additionalsParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                    return promiEvent.reject(Error('_additionals must be positives integer'));
+                    return promiEvent.reject(Error('_additionals must be positive integers'));
                 }
                 if ( request.state === Types.State.Canceled ) {
                     return promiEvent.reject(Error('request cannot be canceled'));
@@ -1388,7 +1388,7 @@ export default class RequestERC20Service {
             }
 
             if (_signedRequest.expectedAmounts.filter((amount: any) => amount.isNeg()).length !== 0) {
-                return reject(Error('_expectedAmounts must be positives integer'));
+                return reject(Error('_expectedAmounts must be positive integers'));
             }
 
             const contract = this.web3Single.getContractInstance(_signedRequest.currencyContract);

--- a/packages/requestNetwork.js/src/servicesContracts/requestEthereum-service.ts
+++ b/packages/requestNetwork.js/src/servicesContracts/requestEthereum-service.ts
@@ -146,7 +146,7 @@ export default class RequestEthereumService {
             }
 
             if (_expectedAmounts.filter((amount) => amount.isNeg()).length !== 0) {
-                return promiEvent.reject(Error('_expectedAmounts must be positives integer'));
+                return promiEvent.reject(Error('_expectedAmounts must be positive integers'));
             }
 
             if (!this.web3Single.isAddressNoChecksum(_payer)) {
@@ -270,13 +270,13 @@ export default class RequestEthereumService {
                 return promiEvent.reject(Error('_payeesIdAddress must be valid eth addresses'));
             }
             if (_expectedAmounts.filter((amount) => amount.isNeg()).length !== 0) {
-                return promiEvent.reject(Error('_expectedAmounts must be positives integer'));
+                return promiEvent.reject(Error('_expectedAmounts must be positive integers'));
             }
             if (amountsToPayParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                return promiEvent.reject(Error('_amountsToPay must be positives integer'));
+                return promiEvent.reject(Error('_amountsToPay must be positive integers'));
             }
             if (additionalsParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                return promiEvent.reject(Error('_additionals must be positives integer'));
+                return promiEvent.reject(Error('_additionals must be positive integers'));
             }
             if (_extension) {
                 return promiEvent.reject(Error('extensions are disabled for now'));
@@ -385,7 +385,7 @@ export default class RequestEthereumService {
             }
 
             if (_expectedAmounts.filter((amount) => amount.isNeg()).length !== 0) {
-                return promiEvent.reject(Error('_expectedAmounts must be positives integer'));
+                return promiEvent.reject(Error('_expectedAmounts must be positive integers'));
             }
             if ( !this.web3Single.areSameAddressesNoChecksum(account, _payeesIdAddress[0]) ) {
                 return promiEvent.reject(Error('account broadcaster must be the main payee'));
@@ -474,10 +474,10 @@ export default class RequestEthereumService {
                 return promiEvent.reject(Error('_additionals cannot be bigger than _payeesIdAddress'));
             }
             if (amountsToPayParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                return promiEvent.reject(Error('_amountsToPay must be positives integer'));
+                return promiEvent.reject(Error('_amountsToPay must be positive integers'));
             }
             if (additionalsParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                return promiEvent.reject(Error('_additionals must be positives integer'));
+                return promiEvent.reject(Error('_additionals must be positive integers'));
             }
             if (this.web3Single.areSameAddressesNoChecksum(account, _signedRequest.payeesIdAddress[0]) ) {
                 return promiEvent.reject(Error('_from must be different than the main payee'));
@@ -715,10 +715,10 @@ export default class RequestEthereumService {
                     return promiEvent.reject(Error('_additionals cannot be bigger than _payeesIdAddress'));
                 }
                 if (amountsToPayParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                    return promiEvent.reject(Error('_amountsToPay must be positives integer'));
+                    return promiEvent.reject(Error('_amountsToPay must be positive integers'));
                 }
                 if (additionalsParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                    return promiEvent.reject(Error('_additionals must be positives integer'));
+                    return promiEvent.reject(Error('_additionals must be positive integers'));
                 }
                 if ( request.state === Types.State.Canceled ) {
                     return promiEvent.reject(Error('request cannot be canceled'));
@@ -883,7 +883,7 @@ export default class RequestEthereumService {
                     return promiEvent.reject(Error('_subtracts cannot be bigger than _payeesIdAddress'));
                 }
                 if (subtractsParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                    return promiEvent.reject(Error('subtracts must be positives integer'));
+                    return promiEvent.reject(Error('subtracts must be positive integers'));
                 }
                 if ( request.state === Types.State.Canceled ) {
                     return promiEvent.reject(Error('request must be accepted or created'));
@@ -982,7 +982,7 @@ export default class RequestEthereumService {
                     return promiEvent.reject(Error('_additionals cannot be bigger than _payeesIdAddress'));
                 }
                 if (additionalsParsed.filter((amount) => amount.isNeg()).length !== 0) {
-                    return promiEvent.reject(Error('additionals must be positives integer'));
+                    return promiEvent.reject(Error('additionals must be positive integers'));
                 }
                 if ( request.state === Types.State.Canceled ) {
                     return promiEvent.reject(Error('request must be accepted or created'));
@@ -1137,7 +1137,7 @@ export default class RequestEthereumService {
         }
 
         if (_signedRequest.expectedAmounts.filter((amount: any) => amount.isNeg()).length !== 0) {
-            return '_expectedAmounts must be positives integer';
+            return '_expectedAmounts must be positive integers';
         }
         if (!this.web3Single.areSameAddressesNoChecksum(this.addressRequestEthereumLast, _signedRequest.currencyContract)) {
             return 'currencyContract must be the last currencyContract of requestEthereum';

--- a/packages/requestNetwork.js/src/servicesContracts/requestEthereum-service.ts
+++ b/packages/requestNetwork.js/src/servicesContracts/requestEthereum-service.ts
@@ -464,7 +464,7 @@ export default class RequestEthereumService {
         this.web3Single.getDefaultAccountCallback(async (err, defaultAccount) => {
             if (!_options.from && err) return promiEvent.reject(err);
             const account = _options.from || defaultAccount;
-            const error = this.isSignedRequestHasError(_signedRequest, account);
+            const error = this.validateSignedRequest(_signedRequest, account);
             if (error !== '') return promiEvent.reject(Error(error));
 
             if (_amountsToPay && _signedRequest.payeesIdAddress.length < _amountsToPay.length) {
@@ -1110,7 +1110,7 @@ export default class RequestEthereumService {
      * @param   _payer             Payer of the request
      * @return  return a string with the error, or ''
      */
-    public isSignedRequestHasError(_signedRequest: any, _payer: string): string {
+    public validateSignedRequest(_signedRequest: any, _payer: string): string {
         _signedRequest.expectedAmounts = _signedRequest.expectedAmounts.map((amount: any) => new BN(amount));
 
         if (_signedRequest.payeesPaymentAddress) {

--- a/packages/requestNetwork.js/test/unit/bitcoinNodesValidationServices/additionalsAction.ts
+++ b/packages/requestNetwork.js/test/unit/bitcoinNodesValidationServices/additionalsAction.ts
@@ -154,7 +154,7 @@ describe('bitcoin NodesValidation additional', () => {
                                 {from: payer});
             expect(false, 'exception not thrown').to.be.true;
         } catch (e) {
-            utils.expectEqualsException(e, Error('additionals must be positives integer'), 'exception not right');
+            utils.expectEqualsException(e, Error('additionals must be positive integers'), 'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/bitcoinNodesValidationServices/broadcastSignedRequestAsPayer.ts
+++ b/packages/requestNetwork.js/test/unit/bitcoinNodesValidationServices/broadcastSignedRequestAsPayer.ts
@@ -189,7 +189,7 @@ describe('bitcoin NodesValidation broadcastSignedRequestAsPayer', () => {
                     {from: payer})
             expect(false, 'exception not thrown').to.be.true; 
         } catch (e) {
-            utils.expectEqualsException(e, Error('_additionals must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_additionals must be positive integers'),'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/bitcoinNodesValidationServices/createRequestAsPayee.ts
+++ b/packages/requestNetwork.js/test/unit/bitcoinNodesValidationServices/createRequestAsPayee.ts
@@ -228,7 +228,7 @@ describe('bitcoinNodesValidation createRequestAsPayeeAction', () => {
                     [payeeRefund])
             expect(false, 'exception not thrown').to.be.true;
         } catch (e) {
-            utils.expectEqualsException(e, Error('_expectedAmounts must be positives integer'), 'exception not right');
+            utils.expectEqualsException(e, Error('_expectedAmounts must be positive integers'), 'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/bitcoinNodesValidationServices/createRequestAsPayee.ts
+++ b/packages/requestNetwork.js/test/unit/bitcoinNodesValidationServices/createRequestAsPayee.ts
@@ -105,7 +105,7 @@ describe('bitcoinNodesValidation createRequestAsPayeeAction', () => {
                     payer,
                     [payeePayment,payee2Payment,payee3Payment],
                     [payeeRefund,payee2Refund,payee3Refund],
-                    '{"reason":"weed purchased"}',
+                    '{"reason":"purchased two large pizzas"}',
                     undefined,
                     undefined,
                     {from: payee})
@@ -127,7 +127,7 @@ describe('bitcoinNodesValidation createRequestAsPayeeAction', () => {
         expect(result.request.state, 'state is wrong').to.equal(0);
         expect(result.request.currencyContract.address.toLowerCase(), 'currencyContract is wrong').to.equal(addressRequestBitcoinNodesValidation.toLowerCase());
 
-        utils.expectEqualsObject(result.request.data.data,{"reason": "weed purchased"}, 'data.data is wrong')
+        utils.expectEqualsObject(result.request.data.data,{"reason": "purchased two large pizzas"}, 'data.data is wrong')
         expect(result.request.data, 'data.hash is wrong').to.have.property('hash');
         expect(result.transaction, 'result.transaction.hash is wrong').to.have.property('hash');
 

--- a/packages/requestNetwork.js/test/unit/bitcoinNodesValidationServices/signRequestAsPayee.ts
+++ b/packages/requestNetwork.js/test/unit/bitcoinNodesValidationServices/signRequestAsPayee.ts
@@ -124,7 +124,7 @@ describe('bitcoinNodesValidation signRequestAsPayee', () => {
 
             expect(false, 'exception not thrown').to.be.true;
         } catch (e) {
-            utils.expectEqualsException(e, Error('_expectedAmounts must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_expectedAmounts must be positive integers'),'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/bitcoinNodesValidationServices/subtractsAction.ts
+++ b/packages/requestNetwork.js/test/unit/bitcoinNodesValidationServices/subtractsAction.ts
@@ -155,7 +155,7 @@ describe('bitcoin NodesValidation subtract', () => {
                                 {from: payee});
             expect(false, 'exception not thrown').to.be.true;
         } catch (e) {
-            utils.expectEqualsException(e, Error('subtracts must be positives integer'), 'exception not right');
+            utils.expectEqualsException(e, Error('subtracts must be positive integers'), 'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/erc20Services/additionalsAction.ts
+++ b/packages/requestNetwork.js/test/unit/erc20Services/additionalsAction.ts
@@ -149,7 +149,7 @@ describe('erc20 additionals Action', () => {
                                 {from: payer});
             expect(false, 'exception not thrown').to.be.true;
         } catch (e) {
-            utils.expectEqualsException(e, Error('additionals must be positives integer'), 'exception not right');
+            utils.expectEqualsException(e, Error('additionals must be positive integers'), 'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/erc20Services/broadcastSignedRequestAsPayer.ts
+++ b/packages/requestNetwork.js/test/unit/erc20Services/broadcastSignedRequestAsPayer.ts
@@ -55,12 +55,12 @@ describe('erc20 broadcastSignedRequestAsPayer', () => {
 
         signedRequest = { 
             currencyContract: '0xf25186b5081ff5ce73482ad761db0eb0d25abfbf',
-            data: 'QmbFpULNpMJEj9LfvhH4hSTfTse5YrS2JvhbHW6bDCNpwS',
+            data: 'QmZLVR5UwkiGLi9nxwTShYJjHbEEYNfBfCkLAy9bLuVrwh',
             expectedAmounts: [ '1000', '200', '30' ],
             expirationDate: 7952342400000,
             extension: undefined,
             extensionParams: undefined,
-            hash: '0xe03268113d12c1a728ba6bc5631649d041d905e2a4dd19b8e5789a22b7800c5e',
+            hash: '0xb9b5fa782449db13db6d625431b7645f3bd7cf6e0e25eefd66f6b09e48581761',
             payeesIdAddress:
                 [ '0x821aea9a577a9b44299b9c15c88cf3087f3b5544',
                  '0x0d1d4e623d10f9fba5db95830f7d3839406c6af2',
@@ -69,7 +69,7 @@ describe('erc20 broadcastSignedRequestAsPayer', () => {
                 [ '0x6330a553fc93768f612722bb8c2ec78ac90b3bbc',
                  undefined,
                  '0x5aeda56215b167893e80b4fe645ba6d5bab767de' ],
-            signature: '0x3d3e6110c4d6f851e444aee6740446dec0bad1fd22cda8d892565188a3fe6d3e6739efb7a6b3c6fef201e60b36300cb3200d162259422a0eda1da1e2fe96c98001' };
+            signature: '0x36353d89ff5cd87f0b0704aed0632b60111d6cc4e76a02255ae1b34f4c6b9e4079933c176d35e6a0d35201cf64f0a187a0b1320589116dfb1162cb5aad84057e1b' };
     });
 
     it.skip('broadcast request as payer no payment no additionals', async function () {

--- a/packages/requestNetwork.js/test/unit/erc20Services/broadcastSignedRequestAsPayer.ts
+++ b/packages/requestNetwork.js/test/unit/erc20Services/broadcastSignedRequestAsPayer.ts
@@ -90,7 +90,7 @@ describe('erc20 broadcastSignedRequestAsPayer', () => {
         expect(result.request.state, 'state is wrong').to.equal(1);
         expect(result.request.currencyContract.address.toLowerCase(), 'currencyContract is wrong').to.equal(addressRequestERC20);
 
-        utils.expectEqualsObject(result.request.data.data,{"reason": "weed purchased"}, 'data.data is wrong')
+        utils.expectEqualsObject(result.request.data.data,{"reason": "purchased two large pizzas"}, 'data.data is wrong')
         expect(result.request.data, 'data.hash is wrong').to.have.property('hash');
         expect(result.transaction, 'result.transaction.hash is wrong').to.have.property('hash');
 
@@ -132,7 +132,7 @@ describe('erc20 broadcastSignedRequestAsPayer', () => {
         expect(result.request.state, 'state is wrong').to.equal(1);
         expect(result.request.currencyContract.address.toLowerCase(), 'currencyContract is wrong').to.equal(addressRequestERC20);
 
-        utils.expectEqualsObject(result.request.data.data,{"reason": "weed purchased"}, 'data.data is wrong')
+        utils.expectEqualsObject(result.request.data.data,{"reason": "purchased two large pizzas"}, 'data.data is wrong')
         expect(result.request.data, 'data.hash is wrong').to.have.property('hash');
         expect(result.transaction, 'result.transaction.hash is wrong').to.have.property('hash');
 

--- a/packages/requestNetwork.js/test/unit/erc20Services/broadcastSignedRequestAsPayer.ts
+++ b/packages/requestNetwork.js/test/unit/erc20Services/broadcastSignedRequestAsPayer.ts
@@ -212,7 +212,7 @@ describe('erc20 broadcastSignedRequestAsPayer', () => {
                     {from: payer})
             expect(false, 'exception not thrown').to.be.true; 
         } catch (e) {
-            utils.expectEqualsException(e, Error('_amountsToPay must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_amountsToPay must be positive integers'),'exception not right');
         }
     });
 
@@ -232,7 +232,7 @@ describe('erc20 broadcastSignedRequestAsPayer', () => {
                     {from: payer})
             expect(false, 'exception not thrown').to.be.true; 
         } catch (e) {
-            utils.expectEqualsException(e, Error('_additionals must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_additionals must be positive integers'),'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/erc20Services/createRequestAsPayee.ts
+++ b/packages/requestNetwork.js/test/unit/erc20Services/createRequestAsPayee.ts
@@ -201,7 +201,7 @@ describe('erc20 createRequestAsPayeeAction', () => {
                     payer);
             expect(false, 'exception not thrown').to.be.true;
         } catch (e) {
-            utils.expectEqualsException(e, Error('_expectedAmounts must be positives integer'), 'exception not right');
+            utils.expectEqualsException(e, Error('_expectedAmounts must be positive integers'), 'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/erc20Services/createRequestAsPayee.ts
+++ b/packages/requestNetwork.js/test/unit/erc20Services/createRequestAsPayee.ts
@@ -97,7 +97,7 @@ describe('erc20 createRequestAsPayeeAction', () => {
                     payer,
                     [payeePaymentAddress, 0, payee3PaymentAddress],
                     payerRefundAddress,
-                    '{"reason":"weed purchased"}',
+                    '{"reason":"purchased two large pizzas"}',
                     '',
                     undefined,
                     {from: payee})
@@ -117,7 +117,7 @@ describe('erc20 createRequestAsPayeeAction', () => {
         expect(result.request.state, 'state is wrong').to.equal(0);
         expect(result.request.currencyContract.address.toLowerCase(), 'currencyContract is wrong').to.equal(addressRequestERC20);
 
-        utils.expectEqualsObject(result.request.data.data,{"reason": "weed purchased"}, 'data.data is wrong')
+        utils.expectEqualsObject(result.request.data.data,{"reason": "purchased two large pizzas"}, 'data.data is wrong')
         expect(result.request.data, 'data.hash is wrong').to.have.property('hash');
         expect(result.transaction, 'result.transaction.hash is wrong').to.have.property('hash');
 

--- a/packages/requestNetwork.js/test/unit/erc20Services/createRequestAsPayer.ts
+++ b/packages/requestNetwork.js/test/unit/erc20Services/createRequestAsPayer.ts
@@ -199,7 +199,7 @@ describe('erc20 createRequestAsPayer', () => {
                     [new WEB3.utils.BN(-1)]);
             expect(false, 'exception not thrown').to.be.true; 
         } catch (e) {
-            utils.expectEqualsException(e, Error('_expectedAmounts must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_expectedAmounts must be positive integers'),'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/erc20Services/createRequestAsPayer.ts
+++ b/packages/requestNetwork.js/test/unit/erc20Services/createRequestAsPayer.ts
@@ -68,7 +68,7 @@ describe('erc20 createRequestAsPayer', () => {
                     payerRefundAddress,
                     [arbitraryAmount, arbitraryAmount2, arbitraryAmount3],
                     [additional, 0, additional3],
-                    '{"reason":"weed purchased"}',
+                    '{"reason":"purchased two large pizzas"}',
                     undefined,
                     undefined,
                     {from: defaultAccount})
@@ -90,7 +90,7 @@ describe('erc20 createRequestAsPayer', () => {
         expect(result.request.state, 'state is wrong').to.equal(1);
         expect(result.request.currencyContract.address.toLowerCase(), 'currencyContract is wrong').to.equal(addressRequestERC20.toLowerCase());
 
-        utils.expectEqualsObject(result.request.data.data,{"reason": "weed purchased"}, 'data.data is wrong')
+        utils.expectEqualsObject(result.request.data.data,{"reason": "purchased two large pizzas"}, 'data.data is wrong')
         expect(result.request.data, 'data.hash is wrong').to.have.property('hash');
         expect(result.transaction, 'result.transaction.hash is wrong').to.have.property('hash');
 

--- a/packages/requestNetwork.js/test/unit/erc20Services/paymentAction.ts
+++ b/packages/requestNetwork.js/test/unit/erc20Services/paymentAction.ts
@@ -187,7 +187,7 @@ describe('erc20 paymentAction', () => {
                                 {from: payer});
             expect(false, 'exception not thrown').to.be.true; 
         } catch (e) {
-            utils.expectEqualsException(e, Error('_additionals must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_additionals must be positive integers'),'exception not right');
         }
     });
 
@@ -204,7 +204,7 @@ describe('erc20 paymentAction', () => {
                                 {from: payer});
             expect(false, 'exception not thrown').to.be.true; 
         } catch (e) {
-            utils.expectEqualsException(e, Error('_amountsToPay must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_amountsToPay must be positive integers'),'exception not right');
         }
         await rn.requestERC20Service.approveTokenForRequest(requestId, 0, {from: payer})
         await testToken.transfer(defaultAccount, arbitraryAmount, {from: payer});

--- a/packages/requestNetwork.js/test/unit/erc20Services/signRequestAsPayee.ts
+++ b/packages/requestNetwork.js/test/unit/erc20Services/signRequestAsPayee.ts
@@ -152,7 +152,7 @@ describe('erc20 signRequestAsPayee', () => {
                     expirationDate);
             expect(false, 'exception not thrown').to.be.true;
         } catch (e) {
-            utils.expectEqualsException(e, Error('_expectedAmounts must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_expectedAmounts must be positive integers'),'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/erc20Services/subtractsAction.ts
+++ b/packages/requestNetwork.js/test/unit/erc20Services/subtractsAction.ts
@@ -152,7 +152,7 @@ describe('erc20 subtracts Action', () => {
                                 {from: payee});
             expect(false, 'exception not thrown').to.be.true;
         } catch (e) {
-            utils.expectEqualsException(e, Error('subtracts must be positives integer'), 'exception not right');
+            utils.expectEqualsException(e, Error('subtracts must be positive integers'), 'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/ethereumServices/additionalsAction.ts
+++ b/packages/requestNetwork.js/test/unit/ethereumServices/additionalsAction.ts
@@ -147,7 +147,7 @@ describe('additionals Action', () => {
                                 {from: payer});
             expect(false, 'exception not thrown').to.be.true;
         } catch (e) {
-            utils.expectEqualsException(e, Error('additionals must be positives integer'), 'exception not right');
+            utils.expectEqualsException(e, Error('additionals must be positive integers'), 'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/ethereumServices/broadcastSignedRequestAsPayer.ts
+++ b/packages/requestNetwork.js/test/unit/ethereumServices/broadcastSignedRequestAsPayer.ts
@@ -208,7 +208,7 @@ describe('broadcastSignedRequestAsPayer', () => {
                     {from: payer})
             expect(false, 'exception not thrown').to.be.true; 
         } catch (e) {
-            utils.expectEqualsException(e, Error('_amountsToPay must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_amountsToPay must be positive integers'),'exception not right');
         }
     });
 
@@ -229,7 +229,7 @@ describe('broadcastSignedRequestAsPayer', () => {
                     {from: payer})
             expect(false, 'exception not thrown').to.be.true; 
         } catch (e) {
-            utils.expectEqualsException(e, Error('_additionals must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_additionals must be positive integers'),'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/ethereumServices/broadcastSignedRequestAsPayer.ts
+++ b/packages/requestNetwork.js/test/unit/ethereumServices/broadcastSignedRequestAsPayer.ts
@@ -47,12 +47,12 @@ describe('broadcastSignedRequestAsPayer', () => {
 
         signedRequest = { 
                 currencyContract: '0xf12b5dd4ead5f743c6baa640b0216200e89b60da',
-                data: 'QmbFpULNpMJEj9LfvhH4hSTfTse5YrS2JvhbHW6bDCNpwS',
+                data: 'QmZLVR5UwkiGLi9nxwTShYJjHbEEYNfBfCkLAy9bLuVrwh',
                 expectedAmounts: [ arbitraryAmount, arbitraryAmount2, arbitraryAmount3 ],
                 expirationDate: 7952313600,
                 extension: undefined,
                 extensionParams: undefined,
-                hash: '0x563f2ca8056ca13d7d4c98e927599f85589225d897057ee1724cb3558708efa8',
+                hash: '0x5eef85ad314d6604ff95a9aecdb5339c5cd8dd3b2237716dac8cf20dc0fd7174',
                 payeesIdAddress:
                     [ payee,
                      payee2,
@@ -61,7 +61,7 @@ describe('broadcastSignedRequestAsPayer', () => {
                     [ payeePaymentAddress,
                       undefined,
                       payee3PaymentAddress ],
-                signature: '0xcb24e672dd3c47f3599cf8be445072189af8a74c8cebb545b06e119985694fd9149af79b16cd48f2ec51ddfa3d54864bb46f1c3efe76f9b43445ad4fdde0317701' }
+                signature: '0xb622372207416d5d377888d3756d5a866a03825f44a692eef2a064b2659a062d3c0ff3aafce4cba4ef37df92cee5f9e8e4bfdbd3fcad74aa2994ebe8c2bd24171c' }
     });
 
     it('broadcast request as payer no payment no additionals', async () => {

--- a/packages/requestNetwork.js/test/unit/ethereumServices/broadcastSignedRequestAsPayer.ts
+++ b/packages/requestNetwork.js/test/unit/ethereumServices/broadcastSignedRequestAsPayer.ts
@@ -82,7 +82,7 @@ describe('broadcastSignedRequestAsPayer', () => {
         expect(result.request.state, 'state is wrong').to.equal(1);
         expect(result.request.currencyContract.address.toLowerCase(), 'currencyContract is wrong').to.equal(addressRequestEthereum);
 
-        utils.expectEqualsObject(result.request.data.data,{"reason": "weed purchased"}, 'data.data is wrong')
+        utils.expectEqualsObject(result.request.data.data,{"reason": "purchased two large pizzas"}, 'data.data is wrong')
         expect(result.request.data, 'data.hash is wrong').to.have.property('hash');
         expect(result.transaction, 'result.transaction.hash is wrong').to.have.property('hash');
 
@@ -123,7 +123,7 @@ describe('broadcastSignedRequestAsPayer', () => {
         expect(result.request.state, 'state is wrong').to.equal(1);
         expect(result.request.currencyContract.address.toLowerCase(), 'currencyContract is wrong').to.equal(addressRequestEthereum);
 
-        utils.expectEqualsObject(result.request.data.data,{"reason": "weed purchased"}, 'data.data is wrong')
+        utils.expectEqualsObject(result.request.data.data,{"reason": "purchased two large pizzas"}, 'data.data is wrong')
         expect(result.request.data, 'data.hash is wrong').to.have.property('hash');
         expect(result.transaction, 'result.transaction.hash is wrong').to.have.property('hash');
 

--- a/packages/requestNetwork.js/test/unit/ethereumServices/createRequestAsPayee.ts
+++ b/packages/requestNetwork.js/test/unit/ethereumServices/createRequestAsPayee.ts
@@ -186,7 +186,7 @@ describe('createRequestAsPayee', () => {
                     payer);
             expect(false, 'exception not thrown').to.be.true;
         } catch (e) {
-            utils.expectEqualsException(e, Error('_expectedAmounts must be positives integer'), 'exception not right');
+            utils.expectEqualsException(e, Error('_expectedAmounts must be positive integers'), 'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/ethereumServices/createRequestAsPayee.ts
+++ b/packages/requestNetwork.js/test/unit/ethereumServices/createRequestAsPayee.ts
@@ -90,7 +90,7 @@ describe('createRequestAsPayee', () => {
                     payer,
                     [payeePaymentAddress, 0, payee3PaymentAddress],
                     payerRefundAddress,
-                    '{"reason":"weed purchased"}',
+                    '{"reason":"purchased two large pizzas"}',
                     undefined,
                     undefined,
                     {from: payee})
@@ -110,7 +110,7 @@ describe('createRequestAsPayee', () => {
         expect(result.request.state, 'state is wrong').to.equal(0);
         expect(result.request.currencyContract.address.toLowerCase(), 'currencyContract is wrong').to.equal(addressRequestEthereum);
 
-        utils.expectEqualsObject(result.request.data.data,{"reason": "weed purchased"}, 'data.data is wrong')
+        utils.expectEqualsObject(result.request.data.data,{"reason": "purchased two large pizzas"}, 'data.data is wrong')
         expect(result.request.data, 'data.hash is wrong').to.have.property('hash');
         expect(result.transaction, 'result.transaction.hash is wrong').to.have.property('hash');
 

--- a/packages/requestNetwork.js/test/unit/ethereumServices/createRequestAsPayer.ts
+++ b/packages/requestNetwork.js/test/unit/ethereumServices/createRequestAsPayer.ts
@@ -54,7 +54,7 @@ describe('createRequestAsPayer', () => {
                     payerRefundAddress,
                     [arbitraryAmount, arbitraryAmount2, arbitraryAmount3],
                     [additional, 0, additional3],
-                    '{"reason":"weed purchased"}',
+                    '{"reason":"purchased two large pizzas"}',
                     undefined,
                     undefined,
                     {from: payer})
@@ -75,7 +75,7 @@ describe('createRequestAsPayer', () => {
         expect(result.request.state, 'state is wrong').to.equal(1);
         expect(result.request.currencyContract.address.toLowerCase(), 'currencyContract is wrong').to.equal(addressRequestEthereum);
 
-        utils.expectEqualsObject(result.request.data.data,{"reason": "weed purchased"}, 'data.data is wrong')
+        utils.expectEqualsObject(result.request.data.data,{"reason": "purchased two large pizzas"}, 'data.data is wrong')
         expect(result.request.data, 'data.hash is wrong').to.have.property('hash');
         expect(result.transaction, 'result.transaction.hash is wrong').to.have.property('hash');
 

--- a/packages/requestNetwork.js/test/unit/ethereumServices/createRequestAsPayer.ts
+++ b/packages/requestNetwork.js/test/unit/ethereumServices/createRequestAsPayer.ts
@@ -164,7 +164,7 @@ describe('createRequestAsPayer', () => {
                     [new WEB3.utils.BN(-1)]);
             expect(false, 'exception not thrown').to.be.true; 
         } catch (e) {
-            utils.expectEqualsException(e, Error('_expectedAmounts must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_expectedAmounts must be positive integers'),'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/ethereumServices/paymentAction.ts
+++ b/packages/requestNetwork.js/test/unit/ethereumServices/paymentAction.ts
@@ -158,7 +158,7 @@ describe('paymentAction', () => {
                                 {from: payer});
             expect(false, 'exception not thrown').to.be.true; 
         } catch (e) {
-            utils.expectEqualsException(e, Error('_additionals must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_additionals must be positive integers'),'exception not right');
         }
     });
 
@@ -171,7 +171,7 @@ describe('paymentAction', () => {
                                 {from: payer});
             expect(false, 'exception not thrown').to.be.true; 
         } catch (e) {
-            utils.expectEqualsException(e, Error('_amountsToPay must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_amountsToPay must be positive integers'),'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/ethereumServices/signRequestAsPayee.ts
+++ b/packages/requestNetwork.js/test/unit/ethereumServices/signRequestAsPayee.ts
@@ -143,7 +143,7 @@ describe('signRequestAsPayee', () => {
                     expirationDate);
             expect(false, 'exception not thrown').to.be.true;
         } catch (e) {
-            utils.expectEqualsException(e, Error('_expectedAmounts must be positives integer'),'exception not right');
+            utils.expectEqualsException(e, Error('_expectedAmounts must be positive integers'),'exception not right');
         }
     });
 

--- a/packages/requestNetwork.js/test/unit/ethereumServices/subtractsAction.ts
+++ b/packages/requestNetwork.js/test/unit/ethereumServices/subtractsAction.ts
@@ -147,7 +147,7 @@ describe('subtracts Action', () => {
                                 {from: payee});
             expect(false, 'exception not thrown').to.be.true;
         } catch (e) {
-            utils.expectEqualsException(e, Error('subtracts must be positives integer'), 'exception not right');
+            utils.expectEqualsException(e, Error('subtracts must be positive integers'), 'exception not right');
         }
     });
 


### PR DESCRIPTION
This PR contains some minor changes to improve readability of code/comments.

- replaced "positives integer" with "positive integers".

- renamed "isSignedRequestHasError" to "validateSignedRequest". The previous function name was unclear and grammatically awkward. What does the function do? It validates a signed Request - so let's call it `validateSignedRequest`.

- changed the reason used in test suite Request data to "purchased two large pizzas". Any serious organisation using Request will do their own code audit, and some might be put off by the previous reason. I also put the new data on IPFS, and updated the hashes/signatures for the relevant tests.

I also added a CircleCI config to validate my changes did not break any tests. You might want to exclude this as it duplicates the tests you are performing in Travis (but IMO Circle > Travis so I used it for my own testing).