### PR TITLE
Add docker support to setup a local testnet

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+node_modules
+.dockerignore
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:8-alpine
+
+WORKDIR /app
+
+RUN apk update && \
+    apk add git && \
+    npm install -g lerna
+
+COPY ./ /app
+
+RUN lerna bootstrap
+
+ENTRYPOINT "./entrypoint.sh"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.0"
+
+services:
+  request_network:
+    build: .
+    command: "sh"
+    tty: true
+    network_mode: "host"
+    extra_hosts:
+      - "localhost:127.0.0.1"
+
+  ganache:
+    image: trufflesuite/ganache-cli
+    command:
+      - "-l"
+      - "90000000"
+      - "-m"
+      - "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
+    ports:
+      - "8545:8545"
+    network_mode: "host"
+
+  ipfs:
+    image: ipfs/go-ipfs
+    network_mode: "host"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+while ! nc -z 127.0.0.1 8545;
+do
+    echo sleeping;
+    sleep 1;
+done;
+
+npm run --prefix ./packages/requestNetwork.js testdeploy
+
+exec "$@"


### PR DESCRIPTION
This PR helps you to easily setup a local testnet with Request using docker and docker-compose. Docker gives us the advantage of not having to deal with dependency constraints like node versions for example.

The docker-compose configuration contains three services (ipfs, ganache and request network). At this moment the request network service is just a dockerized instance of the library used to deploy a test contract.

# How to use it

The only requirements are docker and docker-compose. Once you have that you can use the following command to bring up your test net:

```
docker-compose up
```

# Improvements

The following items might need improvement in the future:

* Due to some constraints the docker services all run in "host" network mode. It would be better if they run in their own network with some ports exposed.
* The request network service doesn't mount the code in the docker container. This makes testing a bit more difficult since it requires a docker build every time the code changes.
* The request network service does a contract deployment on startup every time.