### PR TITLE
Extend CircleCI integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,15 +60,15 @@ jobs:
       - attach_workspace:
           at: *working_directory
       - run:
-          name: 'Install lerna'
-          command: 'sudo npm install -g lerna'
+          name: 'Install lerna and solium'
+          command: 'sudo npm install -g lerna solium@1.1.8'
       - run:
-          name: 'Deploy test contract'
-          command: 'lerna run --scope @requestnetwork/request-network.js testdeploy'
+          name: 'Check contract linting'
+          command: 'lerna run --scope request-network-smart-contracts lint'
       - run:
           name: 'Test requestNetwork contract'
-          command: 'lerna run --scope request-network-smart-contracts test --stream'
-  docs-library:
+          command: 'lerna run --scope request-network-smart-contracts test'
+  build-docs-library:
     docker:
       - *node_image
     working_directory: *working_directory
@@ -76,12 +76,16 @@ jobs:
       - attach_workspace:
           at: *working_directory
       - run:
-          name: 'Install lerna'
+          name: 'Install lerna and compodoc'
           command: 'sudo npm install -g lerna @compodoc/compodoc'
       - run:
           name: 'Create library documentation'
-          command: 'lerna run --scope @requestnetwork/request-network.js docs --stream'
-  docs-contract:
+          command: 'lerna run --scope @requestnetwork/request-network.js docs'
+      - persist_to_workspace:
+          root: *working_directory
+          paths:
+            - packages/requestNetwork.js/docs
+  build-docs-contract:
     docker:
       - *node_image
     working_directory: *working_directory
@@ -93,24 +97,53 @@ jobs:
           command: 'sudo npm install -g lerna'
       - run:
           name: 'Create contract documentation'
-          command: 'lerna run --scope request-network-smart-contracts docs:build --stream'
+          command: 'lerna run --scope request-network-smart-contracts docs:build'
+      - persist_to_workspace:
+          root: *working_directory
+          paths:
+            - packages/requestNetworkSmartContracts/docs
+  deploy-docs:
+    docker:
+      - image: circleci/python:2.7-jessie
+    working_directory: *working_directory
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: 'Install awscli'
+          command: 'sudo pip install awscli'
+      - run:
+          name: Deploy library documentation to S3
+          command: 'aws s3 sync packages/requestNetwork.js/docs s3://docs-js-lib.request.network --delete'
+      - run:
+          name: Deploy contracts documentation to S3
+          command: 'aws s3 sync packages/requestNetworkSmartContracts/docs s3://docs-smart-contracts.request.network --delete'
+
 
 workflows:
   version: 2
   build-and-test:
     jobs:
       - build
+      # Test
       - test-library:
           requires:
             - build
       - test-contract:
           requires:
             - build
-      - docs-library:
+      # Build documentation
+      - build-docs-library:
           requires:
-            - build
             - test-library
-      - docs-contract:
+      - build-docs-contract:
           requires:
-            - build
             - test-contract
+      # Deploy documentation
+      - deploy-docs:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build-docs-library
+            - build-docs-contract

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,116 @@
 version: 2
+
+references:
+  working_directory: &working_directory
+    ~/repo
+  attach_workspace: &attach_workspace
+  node_image: &node_image
+    image: circleci/node:8
+  ipfs_image: &ipfs_image
+    image: ipfs/go-ipfs
+  ganache_image: &ganache_image
+    image: trufflesuite/ganache-cli
+    command:
+      - "-l"
+      - "90000000"
+      - "-m"
+      - "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
+
 jobs:
   build:
     docker:
-      - image: circleci/node:8.11.3-stretch
-      - image: ipfs/go-ipfs:v0.4.16
-      - image: trufflesuite/ganache-cli:v6.1.6
-        command: [
-          "-l", "90000000",
-          "-m", "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"]
-    environment:
-      NODE_ENV: test
+      - *node_image
+    working_directory: *working_directory
     steps:
       - checkout
-      - restore_cache:
-          key: v1-node-modules-cache-{{ checksum "package.json" }}-{{ checksum "packages/requestNetwork.js/package.json" }}
       - run:
-          name: Install depedencies
-          command: |
-            npm install .
-            cd packages/requestNetwork.js/ && npm install . && cd -
-      - save_cache:
-          key: v1-node-modules-cache-{{ checksum "package.json" }}-{{ checksum "packages/requestNetwork.js/package.json" }}
-          paths:
-            - "node_modules"
-            - "packages/requestNetwork.js/node_modules"
+          name: 'Install lerna'
+          command: 'sudo npm install -g lerna'
       - run:
-          name: Deploy test contracts and run Request unit tests
-          command: |
-            ./node_modules/lerna/bin/lerna.js run --scope @requestnetwork/request-network.js testdeploy
-            ./node_modules/lerna/bin/lerna.js run --scope @requestnetwork/request-network.js test --stream
+          name: 'Bootstrap'
+          command: 'lerna bootstrap --concurrency=1'
+      - persist_to_workspace:
+          root: *working_directory
+          paths: .
+  test-library:
+    docker:
+      - *node_image
+      - *ipfs_image
+      - *ganache_image
+    working_directory: *working_directory
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: 'Install lerna'
+          command: 'sudo npm install -g lerna'
+      - run:
+          name: 'Deploy test contract'
+          command: 'lerna run --scope @requestnetwork/request-network.js testdeploy'
+      - run:
+          name: 'Test requestNetwork.js library'
+          command: 'lerna run --scope @requestnetwork/request-network.js test --stream'
+  test-contract:
+    docker:
+      - *node_image
+      - *ipfs_image
+      - *ganache_image
+    working_directory: *working_directory
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: 'Install lerna'
+          command: 'sudo npm install -g lerna'
+      - run:
+          name: 'Deploy test contract'
+          command: 'lerna run --scope @requestnetwork/request-network.js testdeploy'
+      - run:
+          name: 'Test requestNetwork contract'
+          command: 'lerna run --scope request-network-smart-contracts test --stream'
+  docs-library:
+    docker:
+      - *node_image
+    working_directory: *working_directory
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: 'Install lerna'
+          command: 'sudo npm install -g lerna @compodoc/compodoc'
+      - run:
+          name: 'Create library documentation'
+          command: 'lerna run --scope @requestnetwork/request-network.js docs --stream'
+  docs-contract:
+    docker:
+      - *node_image
+    working_directory: *working_directory
+    steps:
+      - attach_workspace:
+          at: *working_directory
+      - run:
+          name: 'Install lerna'
+          command: 'sudo npm install -g lerna'
+      - run:
+          name: 'Create contract documentation'
+          command: 'lerna run --scope request-network-smart-contracts docs:build --stream'
+
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - build
+      - test-library:
+          requires:
+            - build
+      - test-contract:
+          requires:
+            - build
+      - docs-library:
+          requires:
+            - build
+            - test-library
+      - docs-contract:
+          requires:
+            - build
+            - test-contract


### PR DESCRIPTION
This PR extends the CircleCI pipeline in separate jobs to:

1. bootstrap the monorepo
2. run the library and contract tests
3. generate the documentation if the tests are successful

The CircleCI jobs and workflow in action can be seen here: https://circleci.com/gh/lrnt/requestNetwork

![image](https://user-images.githubusercontent.com/1248066/46730011-382e2680-cc87-11e8-9795-9ff69b71d0da.png)

There are some things that could be improved/added in the future:

- [ ] Use a Docker image with Node which comes preinstalled with Lerna to speedup each job
- [X] Upload the documentation to S3 like what is currently happening with Travis
- [ ] Add a build status badge to README.md

