### PR TITLE
test: fix getCurrentTimestampInSecond() test to not fail randomly

### DIFF
--- a/packages/utils/test/utils.test.ts
+++ b/packages/utils/test/utils.test.ts
@@ -87,19 +87,16 @@ describe('Utils', () => {
   });
 
   it('getCurrentTimestampInSecond()', () => {
-    // Setup
-    const mockDate = 1576045893373;
-    // save it for later
-    const realDate = Date;
-    // replace the now() by a mock
-    global.Date.now = () => mockDate;
+    sinon.useFakeTimers(Date.now());
+
+    const time = Math.floor(Date.now() / 1000);
 
     expect(Utils.getCurrentTimestampInSecond(), 'getCurrentTimestampInSecond() error').to.be.equal(
-      1576045893,
+      time,
     );
 
-    // Cleanup: back to the real global Date
-    global.Date = realDate;
+    // Cleanup
+    sinon.restore();
   });
 
   describe('unique', () => {

--- a/packages/utils/test/utils.test.ts
+++ b/packages/utils/test/utils.test.ts
@@ -87,10 +87,19 @@ describe('Utils', () => {
   });
 
   it('getCurrentTimestampInSecond()', () => {
-    const time = Math.floor(Date.now() / 1000);
+    // Setup
+    const mockDate = 1576045893373;
+    // save it for later
+    const realDate = Date;
+    // replace the now() by a mock
+    global.Date.now = () => mockDate;
+
     expect(Utils.getCurrentTimestampInSecond(), 'getCurrentTimestampInSecond() error').to.be.equal(
-      time,
+      1576045893,
     );
+
+    // Cleanup: back to the real global Date
+    global.Date = realDate;
   });
 
   describe('unique', () => {

--- a/packages/utils/test/utils.test.ts
+++ b/packages/utils/test/utils.test.ts
@@ -90,7 +90,6 @@ describe('Utils', () => {
     sinon.useFakeTimers(Date.now());
 
     const time = Math.floor(Date.now() / 1000);
-
     expect(Utils.getCurrentTimestampInSecond(), 'getCurrentTimestampInSecond() error').to.be.equal(
       time,
     );


### PR DESCRIPTION
## Description of the changes

fix getCurrentTimestampInSecond() test to not fail randomly

## Link to Jira

https://requestnetwork.atlassian.net/browse/PROT-1057
