### PR TITLE
fix: fix old version id mismatch issue

### DIFF
--- a/packages/request-logic/src/actions/create.ts
+++ b/packages/request-logic/src/actions/create.ts
@@ -100,11 +100,6 @@ function createRequest(
     );
   }
 
-  // If we're creating an older version of a request, we convert the string currency type to the new ICurrency one
-  if (Semver.lt(action.data.version, '2.0.1')) {
-    action.data.parameters.currency = legacyEnumToICurrencyConvert(action.data.parameters.currency);
-  }
-
   const signer: IdentityTypes.IIdentity = Action.getSignerIdentityFromAction(action);
 
   // Copy to not modify the action itself
@@ -113,6 +108,11 @@ function createRequest(
   request.requestId = Action.getRequestId(action);
   request.version = Action.getVersionFromAction(action);
   request.events = [generateEvent(action, timestamp, signer)];
+
+  // If we're creating an older version of a request, we convert the string currency type to the new ICurrency one
+  if (Semver.lt(action.data.version, '2.0.2')) {
+    request.currency = legacyEnumToICurrencyConvert(action.data.parameters.currency);
+  }
 
   const signerRole = Action.getRoleInAction(signer, action);
   if (signerRole === RequestLogicTypes.ROLE.PAYEE) {

--- a/packages/request-logic/test/unit/action.test.ts
+++ b/packages/request-logic/test/unit/action.test.ts
@@ -11,7 +11,7 @@ import {
 import Utils from '@requestnetwork/utils';
 
 import Action from '../../src/action';
-
+import CreateAction from '../../src/actions/create';
 import Version from '../../src/version';
 const CURRENT_VERSION = Version.currentVersion;
 
@@ -139,5 +139,30 @@ describe('Action', () => {
     expect(Action.getVersionFromAction(signedAction), 'getVersionFromAction() error').to.be.equal(
       CURRENT_VERSION,
     );
+  });
+});
+
+describe('actions retrocompatibility', () => {
+  it('old format requestId match', async () => {
+    const actionData = {
+      name: RequestLogicTypes.ACTION_NAME.CREATE,
+      parameters: {
+        currency: 'ETH',
+        expectedAmount: '123400000000000000',
+        payee: TestData.payeeRaw.identity,
+        timestamp: 1,
+      },
+      version: '2.0.1',
+    };
+
+    const action = await Action.createAction(
+      actionData,
+      TestData.payeeRaw.identity,
+      TestData.fakeSignatureProvider,
+    );
+
+    const request = CreateAction.createRequest(action, 2);
+
+    expect(Action.getRequestId(action)).equals(request.requestId);
   });
 });


### PR DESCRIPTION
## Description of the changes
Fixes retrocompatibility issue with requests older than 2.0.2. )
The request Id was being calculated after version changes, which resulted in a different id. 