### PR TITLE
fix: add request custom etherscan key

### DIFF
--- a/packages/payment-detection/src/eth/info-retriever.ts
+++ b/packages/payment-detection/src/eth/info-retriever.ts
@@ -18,7 +18,7 @@ export default class ETHInfoRetriever
     private eventName: PaymentTypes.EVENTS_NAMES,
     private network: string,
     private paymentReference: string,
-    private etherscanApiKey?: string,
+    private etherscanApiKey: string = 'TCVQQU5V39TAS1V6HF61P9K7IJZVEHH1D9',
   ) {}
 
   public async getTransferEvents(): Promise<PaymentTypes.ETHPaymentNetworkEvent[]> {


### PR DESCRIPTION
## Description of the changes
Add custom etherscan key as a quick fix for failing etherscan API calls.

Next step will be allowing the user to set their own etherscan key at the payment network declaration.