### PR TITLE
fix: company registration on rnf_invoice

### DIFF
--- a/packages/data-format/src/format/rnf_invoice/rnf_invoice-0.0.2.json
+++ b/packages/data-format/src/format/rnf_invoice/rnf_invoice-0.0.2.json
@@ -97,6 +97,9 @@
         "taxRegistration": {
           "type": "string"
         },
+        "companyRegistration": {
+          "type": "string"
+        },
         "miscellaneous": {
           "type": "object"
         }

--- a/packages/data-format/test/data/example-valid-0.0.2.json
+++ b/packages/data-format/test/data/example-valid-0.0.2.json
@@ -21,6 +21,7 @@
       "street-address": "38 avenue de l'Opera",
       "country-name": "France"
     },
+    "companyRegistration": "187 579 453",
     "miscellaneous": {
       "aliases": ["Ultime Fauchelevent", "Urbain Fabre", "Prisoner 24601", "Prisoner 9430"]
     }
@@ -37,6 +38,7 @@
       "postal-code": "98052",
       "street-address": "20341 Whitworth Institute 405 N. Whitworth"
     },
+    "companyRegistration": "147515605",
     "miscellaneous": {
       "Occupation": ["Prison guard", "Police inspector", "Detective"]
     }


### PR DESCRIPTION
## Description of the changes

Add company registration to buyerInfo in rnf-invoice.
This is a bug, since this data was already on specs. Also, it's an optional extra field, so we don't need to create a new version

