### PR TITLE
fix: intercept error and log the missed transaction

### DIFF
--- a/packages/request-node/src/request/persistTransaction.ts
+++ b/packages/request-node/src/request/persistTransaction.ts
@@ -72,6 +72,22 @@ export default class PersistTransaction {
           );
         });
 
+        // when the transaction fails, log an error
+        dataAccessResponse.on('error', async e => {
+          const logData = [
+            'transactionHash',
+            transactionHash.value,
+            'channelId',
+            clientRequest.body.channelId,
+            'topics',
+            clientRequest.body.topics,
+            'transactionData',
+            clientRequest.body.transactionData,
+          ].join('\n');
+
+          logger.error(`persistTransaction error: ${e}. \n${logData}`);
+        });
+
         // Log the request time
         const requestEndTime = Date.now();
         logger.debug(`persistTransaction latency: ${requestEndTime - requestStartTime}ms`, [


### PR DESCRIPTION
## Description of the changes
Catches the error on the node persist transaction, so it doesn't throw.
Also logs the errored transaction, helping us recover it from the logs in case it's lost.


## Link to Jira

https://requestnetwork.atlassian.net/browse/PROT-1211
