### PR TITLE
build(deps-dev): bump @types/express from 4.16.1 to 4.17.7

### DIFF
--- a/packages/request-node/package.json
+++ b/packages/request-node/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/cors": "2.8.6",
-    "@types/express": "4.16.1",
+    "@types/express": "4.17.7",
     "@types/supertest": "2.0.7",
     "@types/yargs": "12.0.8",
     "chai": "4.2.0",


### PR DESCRIPTION
## Description of the changes
Bumps @types/express from 4.16.1 to 4.17.7