### PR TITLE
specs: prevent cancelled payments

### DIFF
--- a/packages/advanced-logic/specs/payment-network-any-declarative-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-any-declarative-0.1.0.md
@@ -1,21 +1,13 @@
 # Payment Network - Any currency - Declarative
 
-You can be interested in this document if:
-
-- you want to create your own implementation of the Request protocol
-- you are curious enough to dive and see what is under the hood of the Request protocol
-
-Prerequisite: Having read the advanced logic specification (see [here](/packages/advanced-logic/specs)).
+Prerequisite: Having read the payment network specifications (see [here](./payment-networks-0.1.0.md)).
 
 ## Description
 
 This extension allows to declare payments and the refunds in any currency.
 The payments and refunds are documented by the payer and the payee of the request.
 
-This extension do not ensure payment detection, only a consensus is made between the payer and the payee.
-
-As a payment network, this extension allows to deduce a payment `balance` for the request. (see
-[Interpretation](#Interpretation))
+This extension does not ensure payment detection, only a consensus is made between the payer and the payee.
 
 ## Properties
 
@@ -26,12 +18,21 @@ As a payment network, this extension allows to deduce a payment `balance` for th
 | **version**                      | String | constant value: "0.1.0"                        | **Mandatory** |
 | **events**                       | Array  | List of the actions performed by the extension | **Mandatory** |
 | **values**                       | Object |                                                |               |
-| **values.sentPaymentAmount**     | Amount | Amount of payment declared sent                | **Mandatory** |
-| **values.sentRefundAmount**      | Amount | Amount of refund declared sent                 | **Mandatory** |
-| **values.receivedPaymentAmount** | Amount | Amount of payment declared received            | **Mandatory** |
-| **values.receivedRefundAmount**  | Amount | Amount of refund declared received             | **Mandatory** |
+| **values.sentPaymentAmount**     | Amount | Total amount of payments declared sent                | **Mandatory** |
+| **values.sentRefundAmount**      | Amount | Total amount of refunds declared sent                 | **Mandatory** |
+| **values.receivedPaymentAmount** | Amount | Total amount of payments declared received            | **Mandatory** |
+| **values.receivedRefundAmount**  | Amount | Total amount of refunds declared received             | **Mandatory** |
 | **values.paymentInstruction**    | String | Instruction to make payments                   | Optional      |
 | **values.refundInstruction**     | String | Instruction to make refunds                    | Optional      |
+
+## Interpretation
+
+Payments are described by `receivedPaymentAmount`.
+Refunds are described by `receivedRefundAmount`.
+
+`sentPaymentAmount` and `sentRefundAmount` should be used as informative data or for arbitration of dispute.
+
+However, this interpretation can vary regarding the level of trust between the payer and the payee.
 
 ---
 
@@ -339,14 +340,3 @@ The 'addPaymentInstruction' event:
 | **name**                          | 'addPaymentInstruction'              |
 | **parameters**                    |                                      |
 | **parameters.paymentInstruction** | `paymentInstruction` from parameters |
-
----
-
-## Interpretation
-
-The `balance` starts from `0`.
-Only the amount given in `receivedPaymentAmount` should increase the `balance`.
-Only the amount given in `receivedRefundAmount` should reduce the `balance`.
-`sentPaymentAmount` and `sentRefundAmount` should be used as informative data or for arbitration of dispute.
-
-However, this interpretation can vary regarding the level of trust between the payer and the payee.

--- a/packages/advanced-logic/specs/payment-network-btc-address-based-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-btc-address-based-0.1.0.md
@@ -1,19 +1,11 @@
 # Payment Network - Bitcoin - Address based
 
-You can be interested in this document if:
-
-- you want to create your own implementation of the Request protocol
-- you are curious enough to dive and see what is under the hood of the Request protocol
-
-Prerequisite: Having read the advanced logic specification (see [here](./advanced-logic-specs-0.1.0.md)).
+Prerequisite: Having read the payment network specifications (see [here](./payment-networks-0.1.0.md)).
 
 ## Description
 
 This extension allows the payments and the refunds to be made on the Bitcoin blockchain.
 One address for the payment and one for the refund must be created and used exclusively for **one and only one** request.
-
-As a payment network, this extension allows to deduce a payment `balance` for the request. (see
-[Interpretation](#Interpretation))
 
 ## Properties
 
@@ -28,6 +20,12 @@ As a payment network, this extension allows to deduce a payment `balance` for th
 | **values.refundAddress**  | String | Bitcoin address for the refund                 | Optional      |
 
 Note: to use the bitcoin testnet just replace the id by "pn-testnet-bitcoin-address-based"
+
+## Interpretation
+
+Any bitcoin transaction reaching the address `addPaymentAddress` is considered as payment.
+Any bitcoin transaction reaching the address `addRefundAddress` is considered as a refund.
+
 
 ---
 
@@ -169,11 +167,3 @@ The 'addRefundAddress' event:
 | **name**                     | 'addRefundAddress'              |
 | **parameters**               |                                 |
 | **parameters.refundAddress** | `refundAddress` from parameters |
-
----
-
-## Interpretation
-
-The `balance` starts from `0`.
-Any bitcoin transaction reaching the address `addPaymentAddress` is considered as payment. The `balance` is increased by the amount of the transaction.
-Any bitcoin transaction reaching the address `addRefundAddress` is considered as a refund. The `balance` is reduced by the amount of the transaction.

--- a/packages/advanced-logic/specs/payment-network-erc20-address-based-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-erc20-address-based-0.1.0.md
@@ -1,19 +1,11 @@
 # Payment Network - ERC-20 - Address based
 
-You may be interested in this document if:
-
-- you want to create your own implementation of the Request protocol
-- you are curious enough to dive and see what is under the hood of the Request protocol
-
-Prerequisite: Having read the advanced logic specification (see [here](./advanced-logic-specs-0.1.0.md)).
+Prerequisite: Having read the payment network specifications (see [here](./payment-networks-0.1.0.md)).
 
 ## Description
 
 This extension allows the payments and the refunds to be made on ERC-20 tokens on the Ethereum blockchain.
 One new address for the payment and one for the refund must be created and used exclusively for **one and only one** request.
-
-As a payment network, this extension allows to deduce a payment `balance` for the request. (see
-[Interpretation](#Interpretation))
 
 ## Properties
 
@@ -28,6 +20,11 @@ As a payment network, this extension allows to deduce a payment `balance` for th
 | **values.refundAddress**  | String | Ethereum address for the refund                | Optional      |
 
 Note: to use the Rinkeby testnet just replace the id by "pn-rinkeby-erc20-address-based"
+
+## Interpretation
+
+Any transaction from the request `currency` ERC-20 contract destined to the `addPaymentAddress` is considered as a payment.
+Any ERC-20 transaction reaching the address `addRefundAddress` is considered as a refund. 
 
 ---
 
@@ -170,10 +167,3 @@ The 'addRefundAddress' event:
 | **parameters**               |                                 |
 | **parameters.refundAddress** | `refundAddress` from parameters |
 
----
-
-## Interpretation
-
-The `balance` starts from `0`.
-Any transaction from the request `currency` ERC-20 contract destined to the `addPaymentAddress` is considered as a payment. The `balance` is increased by the sum of the amounts of the transactions.
-Any ERC-20 transaction reaching the address `addRefundAddress` is considered as a refund. The `balance` is reduced by the sum of the amounts of the transactions.

--- a/packages/advanced-logic/specs/payment-network-erc20-fee-proxy-contract-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-erc20-fee-proxy-contract-0.1.0.md
@@ -1,11 +1,6 @@
 # Payment Network - ERC20 with Fee
 
-You may be interested in this document if:
-
-- you want to create your own implementation of the Request protocol
-- you are curious enough to dive and see what is under the hood of the Request protocol
-
-Prerequisite: Having read the advanced logic specification (see [here](./advanced-logic-specs-0.1.0.md)).
+Prerequisite: Having read the payment network specifications (see [here](./payment-networks-0.1.0.md)).
 
 ## Description
 
@@ -27,9 +22,6 @@ The contract also ensures that the `feeAmount` amount of the ERC20 transfer will
 - `hash()` is a keccak256 hash function
 - `last8Bytes()` take the last 8 bytes
 
-As a payment network, this extension allows to deduce a payment `balance` for the request. (see
-[Interpretation](#Interpretation))
-
 ## Contract
 
 The contract contains one function called `transferFromWithReferenceAndFee` which takes 6 arguments:
@@ -43,6 +35,7 @@ The contract contains one function called `transferFromWithReferenceAndFee` whic
 
 The `TransferWithReferenceAndFee` event is emitted when the tokens are transfered. This event contains the same 6 arguments as the `transferFromWithReferenceAndFee` function.
 
+TODO: don't merge without fixing this TODO
 TODO: [See smart contract source]()
 
 | Network | Contract Address                           |
@@ -67,6 +60,29 @@ TODO: [See smart contract source]()
 | **values.feeAmount**      | String | The fee amount in the request `currency`       | Optional      |
 
 Note: to use the Rinkeby testnet, create a request with `currency.network` as `rinkeby`.
+
+## Interpretation
+
+The fee proxy contract address is determined by the `request.currency.network` (see (table)[#Contract] with proxy contract addresses).
+
+### Payments
+
+Any `TransferWithReferenceAndFee` events emitted from the proxy contract with the following arguments are considered as a payment:
+
+- `tokenAddress` `===` `request.currency.value`
+- `to` `===` `paymentAddress`
+- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + payment address)))`
+
+### Refunds
+
+Any `TransferWithReferenceAndFee` events emitted from the proxy contract with the following arguments are considered as a refund:
+
+- `tokenAddress` `===` `request.currency.value`
+- `to` `===` `refundAddress`
+- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + refund address)))`
+
+
+The fees amount can be be inferred from the `TransferWithReferenceAndFee` events emitted from the proxy contract.
 
 ---
 
@@ -265,24 +281,3 @@ the 'addFee' event:
 | **parameters.feeAddress** | `feeAddress` from parameters    |
 | **parameters.feeAmount**  | `feeAmount` from parameters     |
 
----
-
-## Interpretation
-
-The fee proxy contract address is determined by the `request.currency.network` (see (table)[#Contract] with proxy contract addresses).
-
-Any `TransferWithReferenceAndFee` events emitted from the proxy contract with the following arguments are considered as a payment:
-
-- `tokenAddress` `===` `request.currency.value`
-- `to` `===` `paymentAddress`
-- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + payment address)))`
-
-Any `TransferWithReferenceAndFee` events emitted from the proxy contract with the following arguments are considered as a refund:
-
-- `tokenAddress` `===` `request.currency.value`
-- `to` `===` `refundAddress`
-- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + refund address)))`
-
-The sum of payment amounts minus the sum of refund amounts is considered the balance.
-
-The fees amount can be be infered from the `TransferWithReferenceAndFee` events emitted from the proxy contract.

--- a/packages/advanced-logic/specs/payment-network-erc20-proxy-contract-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-erc20-proxy-contract-0.1.0.md
@@ -1,11 +1,6 @@
 # Payment Network - ERC20 - proxy contract
 
-You may be interested in this document if:
-
-- you want to create your own implementation of the Request protocol
-- you are curious enough to dive and see what is under the hood of the Request protocol
-
-Prerequisite: Having read the advanced logic specification (see [here](./advanced-logic-specs-0.1.0.md)).
+Prerequisite: Having read the payment network specifications (see [here](./payment-networks-0.1.0.md)).
 
 ## Description
 
@@ -20,9 +15,6 @@ This `paymentReference` consists of the last 8 bytes of a salted hash of the req
 - `lowercase()` transforms all characters to lowercase
 - `hash()` is a keccak256 hash function
 - `last8Bytes()` take the last 8 bytes
-
-As a payment network, this extension allows to deduce a payment `balance` for the request. (see
-[Interpretation](#Interpretation))
 
 ## Contract
 
@@ -57,6 +49,24 @@ The `TransferWithReference` event is emitted when the tokens are transfered. Thi
 
 
 Note: to use the Rinkeby testnet, create a request with `currency.network` as `rinkeby`.
+
+## Interpretation
+
+The proxy contract address is determined by the `request.currency.network` (see (table)[#Contract] with proxy contract addresses).
+
+### Payments
+
+Any `TransferWithReference` events emitted from the proxy contract with the following arguments are considered as a payment:
+- `tokenAddress` `===` `request.currency.value`
+- `to` `===` `paymentAddress`
+- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + payment address)))`
+
+### Refunds
+
+Any `TransferWithReference` events emitted from the proxy contract with the following arguments are considered as a refund:
+- `tokenAddress` `===` `request.currency.value`
+- `to` `===` `refundAddress`
+- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + refund address)))`
 
 ---
 
@@ -203,21 +213,3 @@ The 'addRefundAddress' event:
 | **name**                     | 'addRefundAddress'              |
 | **parameters**               |                                 |
 | **parameters.refundAddress** | `refundAddress` from parameters |
-
----
-
-## Interpretation
-
-The proxy contract address is determined by the `request.currency.network` (see (table)[#Contract] with proxy contract addresses).
-
-Any `TransferWithReference` events emitted from the proxy contract with the following arguments are considered as a payment:
-- `tokenAddress` `===` `request.currency.value`
-- `to` `===` `paymentAddress`
-- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + payment address)))`
-
-Any `TransferWithReference` events emitted from the proxy contract with the following arguments are considered as a refund:
-- `tokenAddress` `===` `request.currency.value`
-- `to` `===` `refundAddress`
-- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + refund address)))`
-
-The sum of payment amounts minus the sum of refund amounts is considered the balance.

--- a/packages/request-logic/specs/request-logic-specification.md
+++ b/packages/request-logic/specs/request-logic-specification.md
@@ -362,6 +362,10 @@ This action is valid, if:
 - the Role of the action **signer is the payee**
 - the request state is **NOT** `canceled`
 
+**And if**:
+
+The `balance` is 0. (see [here](../../advanced-logic/specs/payment-networks-0.1.0.md))
+
 ##### Result
 
 Modify the following properties of the request:

--- a/packages/request-logic/specs/request-logic-specification.md
+++ b/packages/request-logic/specs/request-logic-specification.md
@@ -364,7 +364,7 @@ This action is valid, if:
 
 **And if**:
 
-The `balance` is 0. (see [here](../../advanced-logic/specs/payment-networks-0.1.0.md))
+The `balance` is 0 at the time of the cancellation. (see [here](../../advanced-logic/specs/payment-networks-0.1.0.md))
 
 ##### Result
 


### PR DESCRIPTION
## Description of the changes
Specify some constraints to limit situations when a request is paid and cancelled at the same time, and the expected behavior when it happens.