### PR TITLE
feat: unify ERC20 payment processing API

### DIFF
--- a/packages/payment-processor/src/index.ts
+++ b/packages/payment-processor/src/index.ts
@@ -1,5 +1,6 @@
 export * from './payment';
 export * from './payment/btc-address-based';
+export * from './payment/erc20';
 export * from './payment/erc20-proxy';
 export * from './payment/erc20-fee-proxy';
 export * from './payment/eth-input-data';

--- a/packages/payment-processor/src/payment/erc20.ts
+++ b/packages/payment-processor/src/payment/erc20.ts
@@ -168,5 +168,5 @@ function getProxyAddress(request: ClientTypes.IRequestData): string {
   if (id === ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_ADDRESS_BASED) {
     throw new Error(`ERC20 address based payment network doesn't need approval`);
   }
-  throw new Error('Not an ERC20 request');
+  throw new Error(`Unsupported payment network: ${id}`);
 }

--- a/packages/payment-processor/src/payment/erc20.ts
+++ b/packages/payment-processor/src/payment/erc20.ts
@@ -1,0 +1,172 @@
+import { ContractTransaction, Signer } from 'ethers';
+import { Provider, Web3Provider } from 'ethers/providers';
+import { BigNumber, bigNumberify, BigNumberish } from 'ethers/utils';
+
+import { erc20ProxyArtifact } from '@requestnetwork/smart-contracts';
+import { erc20FeeProxyArtifact } from '@requestnetwork/smart-contracts';
+import { ClientTypes, ExtensionTypes, PaymentTypes } from '@requestnetwork/types';
+
+import { ERC20Contract } from '../contracts/Erc20Contract';
+import { _getErc20FeeProxyPaymentUrl, payErc20FeeProxyRequest } from './erc20-fee-proxy';
+import { _getErc20ProxyPaymentUrl, payErc20ProxyRequest } from './erc20-proxy';
+
+import { ITransactionOverrides } from './transaction-overrides';
+import {
+  getNetworkProvider,
+  getPaymentNetworkExtension,
+  getProvider,
+  getSigner,
+  validateRequest,
+} from './utils';
+
+/**
+ * Processes a transaction to pay an ERC20 Request.
+ * @param request
+ * @param signerOrProvider the Web3 provider, or signer. Defaults to window.ethereum.
+ * @param amount optionally, the amount to pay. Defaults to remaining amount of the request.
+ * @param feeAmount optionally, the fee amount to pay. Only applicable to ERC20 Fee Payment network. Defaults to the fee amount.
+ * @param overrides optionally, override default transaction values, like gas.
+ */
+export async function payErc20Request(
+  request: ClientTypes.IRequestData,
+  signerOrProvider?: Web3Provider | Signer,
+  amount?: BigNumberish,
+  feeAmount?: BigNumberish,
+  overrides?: ITransactionOverrides,
+): Promise<ContractTransaction> {
+  const id = getPaymentNetworkExtension(request)?.id;
+  if (id === ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT) {
+    return payErc20ProxyRequest(request, signerOrProvider, amount, overrides);
+  }
+  if (id === ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT) {
+    return payErc20FeeProxyRequest(request, signerOrProvider, amount, feeAmount, overrides);
+  }
+  throw new Error('Not a supported ERC20 proxy payment network request');
+}
+
+/**
+ * Checks if a given account has the necessary allowance to pay an ERC20 request.
+ * @param request request to pay
+ * @param account account that will be used to pay the request
+ * @param provider the web3 provider. Defaults to Etherscan.
+ */
+export async function hasErc20Approval(
+  request: ClientTypes.IRequestData,
+  account: string,
+  provider: Provider = getNetworkProvider(request),
+): Promise<boolean> {
+  const erc20Contract = ERC20Contract.connect(request.currencyInfo.value, provider);
+  const allowance = await erc20Contract.allowance(account, getProxyAddress(request));
+  return allowance.gt(request.expectedAmount);
+}
+
+/**
+ * Processes the approval transaction of the targeted ERC20.
+ * @param request request to pay
+ * @param provider the web3 provider. Defaults to Etherscan.
+ * @param overrides optionally, override default transaction values, like gas.
+ * @param paymentNetworkId the payment network id
+ * @param proxyContractAddress the address of the proxy contract to set the approval.
+ */
+export async function approveErc20(
+  request: ClientTypes.IRequestData,
+  signerOrProvider: Web3Provider | Signer = getProvider(),
+  overrides?: ITransactionOverrides,
+): Promise<ContractTransaction> {
+  const encodedTx = encodeApproveErc20(request, signerOrProvider);
+  const signer = getSigner(signerOrProvider);
+  const tokenAddress = request.currencyInfo.value;
+  const tx = await signer.sendTransaction({
+    data: encodedTx,
+    to: tokenAddress,
+    value: 0,
+    ...overrides,
+  });
+  return tx;
+}
+
+/**
+ * Encodes the approval call, can be used with a Multisig contract.
+ * @param request the request to pay
+ * @param signerOrProvider the Web3 provider, or signer. Defaults to window.ethereum.
+ * @param proxyContractAddress the address of the proxy contract to set the approval.
+ */
+export function encodeApproveErc20(
+  request: ClientTypes.IRequestData,
+  signerOrProvider: Web3Provider | Signer = getProvider(),
+): string {
+  const paymentNetworkId = (getPaymentNetworkExtension(request)
+    ?.id as unknown) as PaymentTypes.PAYMENT_NETWORK_ID;
+  if (!paymentNetworkId) {
+    throw new Error('No payment network Id');
+  }
+  validateRequest(request, paymentNetworkId);
+  const signer = getSigner(signerOrProvider);
+
+  const proxyAddress = getProxyAddress(request);
+  const tokenAddress = request.currencyInfo.value;
+  const erc20interface = ERC20Contract.connect(tokenAddress, signer).interface;
+  const encodedApproveCall = erc20interface.functions.approve.encode([
+    proxyAddress,
+    bigNumberify(2)
+      // tslint:disable-next-line: no-magic-numbers
+      .pow(256)
+      .sub(1),
+  ]);
+  return encodedApproveCall;
+}
+
+/**
+ * Gets ERC20 balance of an address, based on the request currency information
+ * @param request the request that contains currency information
+ * @param address the address to check
+ * @param provider the web3 provider. Defaults to Etherscan
+ */
+export async function getErc20Balance(
+  request: ClientTypes.IRequestData,
+  address: string,
+  provider: Provider = getNetworkProvider(request),
+): Promise<BigNumber> {
+  const erc20Contract = ERC20Contract.connect(request.currencyInfo.value, provider);
+  return erc20Contract.balanceOf(address);
+}
+
+/**
+ * Return the EIP-681 format URL with the transaction to pay an ERC20
+ * Warning: this EIP isn't widely used, be sure to test compatibility yourself.
+ *
+ * @param request
+ * @param amount optionally, the amount to pay. Defaults to remaining amount of the request.
+ */
+export function _getErc20PaymentUrl(
+  request: ClientTypes.IRequestData,
+  amount?: BigNumberish,
+): string {
+  const id = getPaymentNetworkExtension(request)?.id;
+  if (id === ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT) {
+    return _getErc20ProxyPaymentUrl(request, amount);
+  }
+  if (id === ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT) {
+    return _getErc20FeeProxyPaymentUrl(request, amount);
+  }
+  throw new Error('Not a supported ERC20 proxy payment network request');
+}
+
+/**
+ * Get the request payment network proxy address
+ * @param request
+ * @returns the payment network proxy address
+ */
+function getProxyAddress(request: ClientTypes.IRequestData): string {
+  const id = getPaymentNetworkExtension(request)?.id;
+  if (id === ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT) {
+    return erc20ProxyArtifact.getAddress(request.currencyInfo.network!);
+  }
+  if (id === ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT) {
+    return erc20FeeProxyArtifact.getAddress(request.currencyInfo.network!);
+  }
+  if (id === ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_ADDRESS_BASED) {
+    throw new Error(`ERC20 address based payment network doesn't need approval`);
+  }
+  throw new Error('Not an ERC20 request');
+}

--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -5,8 +5,8 @@ import { bigNumberify, BigNumberish } from 'ethers/utils';
 import { ClientTypes, ExtensionTypes } from '@requestnetwork/types';
 
 import { getBtcPaymentUrl } from './btc-address-based';
-import { _getErc20FeePaymentUrl, payErc20FeeProxyRequest } from './erc20-fee-proxy';
-import { _getErc20PaymentUrl, getErc20Balance, payErc20ProxyRequest } from './erc20-proxy';
+import { _getErc20PaymentUrl, getErc20Balance } from './erc20';
+import { payErc20Request } from './erc20';
 import { _getEthPaymentUrl, payEthInputDataRequest } from './eth-input-data';
 import { ITransactionOverrides } from './transaction-overrides';
 import { getNetworkProvider, getProvider, getSigner } from './utils';
@@ -45,11 +45,10 @@ export async function payRequest(
   const paymentNetwork = getPaymentNetwork(request);
   switch (paymentNetwork) {
     case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT:
-      return payErc20ProxyRequest(request, signer, amount, overrides);
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT:
+      return payErc20Request(request, signer, amount, undefined, overrides);
     case ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA:
       return payEthInputDataRequest(request, signer, amount, overrides);
-    case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT:
-      return payErc20FeeProxyRequest(request, signer, amount, undefined, overrides);
     default:
       throw new UnsupportedNetworkError(paymentNetwork);
   }
@@ -121,14 +120,13 @@ export function _getPaymentUrl(request: ClientTypes.IRequestData, amount?: BigNu
   const paymentNetwork = getPaymentNetwork(request);
   switch (paymentNetwork) {
     case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT:
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT:
       return _getErc20PaymentUrl(request, amount);
     case ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA:
       return _getEthPaymentUrl(request, amount);
     case ExtensionTypes.ID.PAYMENT_NETWORK_BITCOIN_ADDRESS_BASED:
     case ExtensionTypes.ID.PAYMENT_NETWORK_TESTNET_BITCOIN_ADDRESS_BASED:
       return getBtcPaymentUrl(request, amount);
-    case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT:
-      return _getErc20FeePaymentUrl(request, amount);
     default:
       throw new UnsupportedNetworkError(paymentNetwork);
   }

--- a/packages/payment-processor/test/payment/erc20-fee-proxy.test.ts
+++ b/packages/payment-processor/test/payment/erc20-fee-proxy.test.ts
@@ -16,13 +16,11 @@ import {
 } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 
+import { approveErc20, getErc20Balance } from '../../src/payment/erc20';
 import {
-  _getErc20FeePaymentUrl,
-  approveErc20FeeProxy,
-  hasErc20FeeProxyApproval,
+  _getErc20FeeProxyPaymentUrl,
   payErc20FeeProxyRequest,
 } from '../../src/payment/erc20-fee-proxy';
-import { getErc20Balance } from '../../src/payment/erc20-proxy';
 import { getRequestPaymentValues } from '../../src/payment/utils';
 
 // tslint:disable: no-magic-numbers
@@ -97,35 +95,6 @@ describe('erc20-fee-proxy', () => {
     });
   });
 
-  describe('hasErc20FeeProxyApproval & approveErc20FeeProxy', () => {
-    it('should consider override parameters', async () => {
-      const spy = sandbox.on(wallet, 'sendTransaction', () => 0);
-      await approveErc20FeeProxy(validRequest, wallet, {
-        gasPrice: '20000000000',
-      });
-      expect(spy).to.have.been.called.with({
-        data:
-          '0x095ea7b300000000000000000000000075c35c980c0d37ef46df04d31a140b65503c0eedffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
-        gasPrice: '20000000000',
-        to: '0x9FBDa871d559710256a2502A2517b794B482Db40',
-        value: 0,
-      });
-      sandbox.restore();
-    });
-    it('can check and approve', async () => {
-      // use another address so it doesn't mess with other tests.
-      const otherWallet = new Wallet(
-        '0x8d5366123cb560bb606379f90a0bfd4769eecc0557f1b362dcae9012b548b1e5',
-      ).connect(provider);
-      let hasApproval = await hasErc20FeeProxyApproval(validRequest, otherWallet.address, provider);
-      // Warning: this test can run only once!
-      expect(hasApproval, 'already has approval').to.be.false;
-      await approveErc20FeeProxy(validRequest, otherWallet);
-      hasApproval = await hasErc20FeeProxyApproval(validRequest, otherWallet.address, provider);
-      expect(hasApproval, 'approval did not succeed').to.be.true;
-    });
-  });
-
   describe('payErc20FeeProxyRequest', () => {
     it('should throw an error if the request is not erc20', async () => {
       const request = Utils.deepCopy(validRequest) as ClientTypes.IRequestData;
@@ -178,7 +147,7 @@ describe('erc20-fee-proxy', () => {
 
     it('should pay an ERC20 request with fees', async () => {
       // first approve the contract
-      const approvalTx = await approveErc20FeeProxy(validRequest, wallet);
+      const approvalTx = await approveErc20(validRequest, wallet);
       await approvalTx.wait(1);
 
       // get the balance to compare after payment
@@ -212,7 +181,7 @@ describe('erc20-fee-proxy', () => {
 
   describe('getErc20FeePaymentUrl', () => {
     it('can get an ERC20 url', () => {
-      expect(_getErc20FeePaymentUrl(validRequest)).to.eq(
+      expect(_getErc20FeeProxyPaymentUrl(validRequest)).to.eq(
         'ethereum:0x75c35C980C0d37ef46DF04d31A140b65503c0eEd/transferFromWithReferenceAndFee?address=0x9FBDa871d559710256a2502A2517b794B482Db40&address=0xf17f52151EbEF6C7334FAD080c5704D77216b732&uint256=100&bytes=86dfbccad783599a&uint256=2&address=0xC5fdf4076b8F3A5357c5E395ab970B5B54098Fef',
       );
     });

--- a/packages/payment-processor/test/payment/erc20-proxy.test.ts
+++ b/packages/payment-processor/test/payment/erc20-proxy.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable spellcheck/spell-checker */
 import 'mocha';
 
 import * as chai from 'chai';
@@ -14,14 +15,8 @@ import {
   RequestLogicTypes,
 } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
-
-import {
-  _getErc20PaymentUrl,
-  approveErc20,
-  getErc20Balance,
-  hasErc20Approval,
-  payErc20ProxyRequest,
-} from '../../src/payment/erc20-proxy';
+import { approveErc20, getErc20Balance } from '../../src/payment/erc20';
+import { _getErc20ProxyPaymentUrl, payErc20ProxyRequest } from '../../src/payment/erc20-proxy';
 import { getRequestPaymentValues } from '../../src/payment/utils';
 
 // tslint:disable: no-unused-expression
@@ -86,42 +81,6 @@ describe('getRequestPaymentValues', () => {
     const values = getRequestPaymentValues(validRequest);
     expect(values.paymentAddress).to.eq(paymentAddress);
     expect(values.paymentReference).to.eq('86dfbccad783599a');
-  });
-});
-
-describe('getErc20Balance', () => {
-  it('should read the balance', async () => {
-    const balance = await getErc20Balance(validRequest, wallet.address, provider);
-    chai.assert.isTrue(balance.gte('100'));
-  });
-});
-
-describe('hasErc20Approval & approveErc20', () => {
-  it('should consider override parameters', async () => {
-    const spy = sandbox.on(wallet, 'sendTransaction', () => 0);
-    await approveErc20(validRequest, wallet, {
-      gasPrice: '20000000000',
-    });
-    expect(spy).to.have.been.called.with({
-      data:
-        '0x095ea7b30000000000000000000000002c2b9c9a4a25e24b174f26114e8926a9f2128fe4ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
-      gasPrice: '20000000000',
-      to: '0x9FBDa871d559710256a2502A2517b794B482Db40',
-      value: 0,
-    });
-    sandbox.restore();
-  });
-  it('can check and approve', async () => {
-    // use another address so it doesn't mess with other tests.
-    const otherWallet = new Wallet(
-      '0x8d5366123cb560bb606379f90a0bfd4769eecc0557f1b362dcae9012b548b1e5',
-    ).connect(provider);
-    let hasApproval = await hasErc20Approval(validRequest, otherWallet.address, provider);
-    // Warning: this test can run only once!
-    expect(hasApproval, 'already has approval').to.be.false;
-    await approveErc20(validRequest, otherWallet);
-    hasApproval = await hasErc20Approval(validRequest, otherWallet.address, provider);
-    expect(hasApproval, 'approval did not succeed').to.be.true;
   });
 });
 
@@ -205,7 +164,7 @@ describe('payErc20ProxyRequest', () => {
 
 describe('getErc20PaymentUrl', () => {
   it('can get an ERC20 url', () => {
-    expect(_getErc20PaymentUrl(validRequest)).to.eq(
+    expect(_getErc20ProxyPaymentUrl(validRequest)).to.eq(
       'ethereum:0x2c2b9c9a4a25e24b174f26114e8926a9f2128fe4/transferFromWithReference?address=0x9FBDa871d559710256a2502A2517b794B482Db40&address=0xf17f52151EbEF6C7334FAD080c5704D77216b732&uint256=100&bytes=86dfbccad783599a',
     );
   });

--- a/packages/payment-processor/test/payment/erc20.test.ts
+++ b/packages/payment-processor/test/payment/erc20.test.ts
@@ -1,0 +1,208 @@
+/* eslint-disable spellcheck/spell-checker */
+import 'mocha';
+
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as spies from 'chai-spies';
+
+import {
+  ClientTypes,
+  ExtensionTypes,
+  IdentityTypes,
+  PaymentTypes,
+  RequestLogicTypes,
+} from '@requestnetwork/types';
+import { Wallet } from 'ethers';
+import { JsonRpcProvider } from 'ethers/providers';
+import {
+  _getErc20PaymentUrl,
+  approveErc20,
+  getErc20Balance,
+  hasErc20Approval,
+} from '../../src/payment/erc20';
+
+// tslint:disable: no-unused-expression
+
+const expect = chai.expect;
+chai.use(chaiAsPromised);
+chai.use(spies);
+const sandbox = chai.spy.sandbox();
+
+const erc20ContractAddress = '0x9FBDa871d559710256a2502A2517b794B482Db40';
+const paymentAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
+const feeAddress = '0xC5fdf4076b8F3A5357c5E395ab970B5B54098Fef';
+const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
+const provider = new JsonRpcProvider('http://localhost:8545');
+const wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
+
+const erc20FeeProxyRequest: ClientTypes.IRequestData = {
+  balance: {
+    balance: '0',
+    events: [],
+  },
+  contentData: {},
+  creator: {
+    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
+    value: wallet.address,
+  },
+  currency: 'DAI',
+  currencyInfo: {
+    network: 'private',
+    type: RequestLogicTypes.CURRENCY.ERC20,
+    value: erc20ContractAddress,
+  },
+
+  events: [],
+  expectedAmount: '100',
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress,
+        feeAmount: '2',
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '1.0',
+    },
+  },
+  extensionsData: [],
+  meta: {
+    transactionManagerMeta: {},
+  },
+  pending: null,
+  requestId: 'abcd',
+  state: RequestLogicTypes.STATE.CREATED,
+  timestamp: 0,
+  version: '1.0',
+};
+
+const erc20ProxyRequest: ClientTypes.IRequestData = {
+  balance: {
+    balance: '0',
+    events: [],
+  },
+  contentData: {},
+  creator: {
+    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
+    value: wallet.address,
+  },
+  currency: 'DAI',
+  currencyInfo: {
+    network: 'private',
+    type: RequestLogicTypes.CURRENCY.ERC20,
+    value: erc20ContractAddress,
+  },
+
+  events: [],
+  expectedAmount: '100',
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ERC20_PROXY_CONTRACT]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '1.0',
+    },
+  },
+  extensionsData: [],
+  meta: {
+    transactionManagerMeta: {},
+  },
+  pending: null,
+  requestId: 'abcd',
+  state: RequestLogicTypes.STATE.CREATED,
+  timestamp: 0,
+  version: '1.0',
+};
+
+describe('hasErc20approval & approveErc20', () => {
+  describe('ERC20 fee proxy payment network', () => {
+    it('should consider override parameters', async () => {
+      const spy = sandbox.on(wallet, 'sendTransaction', () => 0);
+      await approveErc20(erc20FeeProxyRequest, wallet, {
+        gasPrice: '20000000000',
+      });
+      expect(spy).to.have.been.called.with({
+        data:
+          '0x095ea7b300000000000000000000000075c35c980c0d37ef46df04d31a140b65503c0eedffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+        gasPrice: '20000000000',
+        to: '0x9FBDa871d559710256a2502A2517b794B482Db40',
+        value: 0,
+      });
+      sandbox.restore();
+    });
+    it('can check and approve', async () => {
+      // use another address so it doesn't mess with other tests.
+      const otherWallet = new Wallet(
+        '0x8d5366123cb560bb606379f90a0bfd4769eecc0557f1b362dcae9012b548b1e5',
+      ).connect(provider);
+      let hasApproval = await hasErc20Approval(erc20FeeProxyRequest, otherWallet.address, provider);
+      // Warning: this test can run only once!
+      expect(hasApproval, 'already has approval').to.be.false;
+      await approveErc20(erc20FeeProxyRequest, otherWallet);
+      hasApproval = await hasErc20Approval(erc20FeeProxyRequest, otherWallet.address, provider);
+      expect(hasApproval, 'approval did not succeed').to.be.true;
+    });
+  });
+
+  describe('ERC20 fee proxy payment network', () => {
+    it('should consider override parameters', async () => {
+      const spy = sandbox.on(wallet, 'sendTransaction', () => 0);
+      await approveErc20(erc20ProxyRequest, wallet, {
+        gasPrice: '20000000000',
+      });
+      expect(spy).to.have.been.called.with({
+        data:
+          '0x095ea7b30000000000000000000000002c2b9c9a4a25e24b174f26114e8926a9f2128fe4ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+        gasPrice: '20000000000',
+        to: '0x9FBDa871d559710256a2502A2517b794B482Db40',
+        value: 0,
+      });
+      sandbox.restore();
+    });
+    it('can check and approve', async () => {
+      // use another address so it doesn't mess with other tests.
+      const otherWallet = new Wallet(
+        '0x8d5366123cb560bb606379f90a0bfd4769eecc0557f1b362dcae9012b548b1e5',
+      ).connect(provider);
+      let hasApproval = await hasErc20Approval(erc20ProxyRequest, otherWallet.address, provider);
+      // Warning: this test can run only once!
+      expect(hasApproval, 'already has approval').to.be.false;
+      await approveErc20(erc20ProxyRequest, otherWallet);
+      hasApproval = await hasErc20Approval(erc20ProxyRequest, otherWallet.address, provider);
+      expect(hasApproval, 'approval did not succeed').to.be.true;
+    });
+  });
+});
+
+describe('getErc20Balance', () => {
+  it('should read the balance for ERC20 Fee Proxy payment network', async () => {
+    const balance = await getErc20Balance(erc20FeeProxyRequest, wallet.address, provider);
+    chai.assert.isTrue(balance.gte('100'));
+  });
+
+  it('should read the balance for ERC20 Proxy payment network', async () => {
+    const balance = await getErc20Balance(erc20ProxyRequest, wallet.address, provider);
+    chai.assert.isTrue(balance.gte('100'));
+  });
+});
+
+describe('getErc20PaymentUrl', () => {
+  it('can get an ERC20 url for ERC20 Fee Proxy payment network', () => {
+    expect(_getErc20PaymentUrl(erc20FeeProxyRequest)).to.eq(
+      'ethereum:0x75c35C980C0d37ef46DF04d31A140b65503c0eEd/transferFromWithReferenceAndFee?address=0x9FBDa871d559710256a2502A2517b794B482Db40&address=0xf17f52151EbEF6C7334FAD080c5704D77216b732&uint256=100&bytes=86dfbccad783599a&uint256=2&address=0xC5fdf4076b8F3A5357c5E395ab970B5B54098Fef',
+    );
+  });
+
+  it('can get an ERC20 url for ERC20 Proxy payment network', () => {
+    expect(_getErc20PaymentUrl(erc20ProxyRequest)).to.eq(
+      'ethereum:0x2c2b9c9a4a25e24b174f26114e8926a9f2128fe4/transferFromWithReference?address=0x9FBDa871d559710256a2502A2517b794B482Db40&address=0xf17f52151EbEF6C7334FAD080c5704D77216b732&uint256=100&bytes=86dfbccad783599a',
+    );
+  });
+});

--- a/packages/payment-processor/test/payment/index.test.ts
+++ b/packages/payment-processor/test/payment/index.test.ts
@@ -9,7 +9,7 @@ import { ExtensionTypes, PaymentTypes, RequestLogicTypes } from '@requestnetwork
 
 import { _getPaymentUrl, hasSufficientFunds, payRequest } from '../../src/payment';
 import * as btcModule from '../../src/payment/btc-address-based';
-import * as erc20Module from '../../src/payment/erc20-proxy';
+import * as erc20Module from '../../src/payment/erc20';
 import * as ethModule from '../../src/payment/eth-input-data';
 
 // tslint:disable: no-unused-expression
@@ -75,7 +75,7 @@ describe('payRequest', () => {
   });
 
   it('should call the ERC20 payment method', async () => {
-    const spy = stub(erc20Module, 'payErc20ProxyRequest');
+    const spy = stub(erc20Module, 'payErc20Request');
     const request: any = {
       extensions: {
         [PaymentTypes.PAYMENT_NETWORK_ID.ERC20_PROXY_CONTRACT]: {


### PR DESCRIPTION
## Description of the changes
The separate APIs for ERC20 proxy and ERC20 fees proxy are unnecessary and confusing.
On this PR we merge both APIs into one.