### PR TITLE
fix(docs): fix missing buffer

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   title: 'Request Docs',
   tagline: 'Technical documentation',
@@ -6,7 +8,7 @@ module.exports = {
   favicon: 'img/cropped-favicon-32x32.png',
   organizationName: 'requestNetwork',
   projectName: 'requestNetwork/packages/docs',
-  plugins: ['axios'],
+  plugins: [path.resolve(__dirname, 'webpack-config')],
   onBrokenLinks: 'log',
   themeConfig: {
     colorMode: {

--- a/packages/docs/src/components/redoc.js
+++ b/packages/docs/src/components/redoc.js
@@ -1,8 +1,0 @@
-// This component is a hack for Redoc to work with Gatsby
-// We import the missing dependencies for redoc directly on this file
-import { RedocStandalone } from 'redoc';
-import mobx from 'mobx';
-import styled from 'styled-components';
-import * as promise from 'core-js/es/promise';
-
-export default RedocStandalone;

--- a/packages/docs/src/pages/portal/index.js
+++ b/packages/docs/src/pages/portal/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Layout from '@theme/Layout';
-import RedocStandalone from '../../components/redoc';
+import { RedocStandalone } from 'redoc';
 import styles from './styles.module.css';
 
 class docApi extends React.Component {

--- a/packages/docs/webpack-config/index.js
+++ b/packages/docs/webpack-config/index.js
@@ -1,0 +1,14 @@
+const webpack = require('webpack');
+
+module.exports = function (context, options) {
+  return {
+    name: 'webpack-config',
+    configureWebpack(config, isServer, utils) {
+      return {
+       plugins: [new webpack.ProvidePlugin({
+          Buffer: ['buffer', 'Buffer'],
+        })]
+      }
+    }
+  }
+};


### PR DESCRIPTION
## Description of the changes
Some dependencies from ReDoc were having issues with the build (missing Buffer). 
More info [here](https://github.com/isaacs/core-util-is/issues/27) and [here](). There is an issue open [here](https://github.com/isaacs/core-util-is/issues/29).
