### PR TITLE
fix: ipfs manager read() decode from base64 before checking the size 

### DIFF
--- a/packages/ethereum-storage/src/ipfs-manager.ts
+++ b/packages/ethereum-storage/src/ipfs-manager.ts
@@ -222,11 +222,12 @@ export default class IpfsManager {
             // Chunk of response data
             res.on('data', (chunk: string) => {
               data += chunk;
-              if (data.length > maxSize) {
+              // decode the base64 to compute the actual size of the data
+              if (Buffer.from(data, 'base64').length > maxSize) {
                 getRequest.abort();
                 res.destroy();
                 return reject(
-                  new Error(`File size (${data.length}) exceeds maximum file size of ${maxSize}`),
+                  new Error(`File size (${data.length}) exceeds the declared file size (${maxSize})`),
                 );
               }
             });
@@ -244,7 +245,7 @@ export default class IpfsManager {
               if (jsonData.Type === 'error') {
                 return reject(new Error(`Ipfs object get failed: ${jsonData.Message}`));
               }
-              const ipfsDataBuffer =Buffer.from(jsonData.Data,'base64')
+              const ipfsDataBuffer = Buffer.from(jsonData.Data, 'base64');
               const content = this.getContentFromMarshaledData(ipfsDataBuffer);
               const ipfsSize = ipfsDataBuffer.length;
               const ipfsLinks = jsonData.Links;

--- a/packages/ethereum-storage/test/ipfs-manager.test.ts
+++ b/packages/ethereum-storage/test/ipfs-manager.test.ts
@@ -154,6 +154,7 @@ describe('Ipfs manager', () => {
     // Hook the get function of the protocol module to allow us to send customized event
     const requestHook = (request: string, _resCallback: any): EventEmitter => {
       // We filter the response of the request to prevent the promise to resolve
+      // tslint:disable-next-line:no-empty
       hookedRequest = http.get(request, (_res) => {});
       return hookedRequest;
     };
@@ -205,6 +206,7 @@ describe('Ipfs manager', () => {
 
     // Hook the get function of the protocol module to allow us to send customized event
     const requestHook = (request: string, _resCallback: any): EventEmitter => {
+      // tslint:disable-next-line:no-empty
       hookedRequest = http.get(request, (_res) => {});
       return hookedRequest;
     };

--- a/packages/ethereum-storage/test/ipfs-manager.test.ts
+++ b/packages/ethereum-storage/test/ipfs-manager.test.ts
@@ -93,7 +93,7 @@ describe('Ipfs manager', () => {
 
   it('allows to read files from ipfs', async () => {
     await ipfsManager.add(content);
-    let contentReturned = await ipfsManager.read(hash, 82);
+    let contentReturned = await ipfsManager.read(hash, 36);
     expect(content).toBe(contentReturned.content);
 
     await ipfsManager.add(content2);
@@ -106,7 +106,7 @@ describe('Ipfs manager', () => {
 
     const maxSize = 10;
     await expect(ipfsManager.read(hash, maxSize)).rejects.toThrowError(
-      `File size (63) exceeds maximum file size of ${maxSize}`,
+      `File size (63) exceeds the declared file size (${maxSize})`,
     );
   });
 


### PR DESCRIPTION
## Description of the changes

During the "chunk size test", we decode from base64 before checking the size of the file downloaded.
