### PR TITLE
fix: swap methods for partial ERC20 approvals

### DIFF
--- a/packages/smart-contracts/src/contracts/ERC20SwapToPay.sol
+++ b/packages/smart-contracts/src/contracts/ERC20SwapToPay.sol
@@ -37,7 +37,7 @@ contract ERC20SwapToPay is Ownable {
   function approvePaymentProxyToSpend(address _erc20Address) public {
     IERC20 erc20 = IERC20(_erc20Address);
     uint256 max = 2**256 - 1;
-    erc20.approve(address(paymentProxy), max);
+    erc20.safeApprove(address(paymentProxy), max);
   }
 
  /**
@@ -47,7 +47,7 @@ contract ERC20SwapToPay is Ownable {
   function approveRouterToSpend(address _erc20Address) public {
     IERC20 erc20 = IERC20(_erc20Address);
     uint256 max = 2**256 - 1;
-    erc20.approve(address(swapRouter), max);
+    erc20.safeApprove(address(swapRouter), max);
   }
 
   /**

--- a/packages/smart-contracts/src/contracts/lib/SafeERC20.sol
+++ b/packages/smart-contracts/src/contracts/lib/SafeERC20.sol
@@ -48,4 +48,48 @@ library SafeERC20 {
     /* solium-enable security/no-inline-assembly */
     return result;
   }
+
+  
+  
+  /**
+    * @dev Deprecated. This function has issues similar to the ones found in
+    * {IERC20-approve}, and its usage is discouraged.
+    *
+    * Whenever possible, use {safeIncreaseAllowance} and
+    * {safeDecreaseAllowance} instead.
+    */
+  function safeApprove(IERC20 _token, address _spender, uint256 _amount) internal returns (bool result) {
+    address tokenAddress = address(_token);
+    /* solium-disable security/no-inline-assembly */
+    // check if the address is a contract
+    assembly {
+      if iszero(extcodesize(tokenAddress)) { revert(0, 0) }
+    }
+    
+    // solium-disable-next-line security/no-low-level-calls
+    (bool success, ) = tokenAddress.call(abi.encodeWithSignature(
+      "approve(address,uint256)",
+      _spender,
+      _amount
+    ));
+
+    assembly {
+        switch returndatasize()
+        case 0 { // not a standard erc20
+            result := 1
+        }
+        case 32 { // standard erc20
+            returndatacopy(0, 0, 32)
+            result := mload(0)
+        }
+        default { // anything else, should revert for safety
+            revert(0, 0)
+        }
+    }
+
+    require(success, "approve() has been reverted");
+
+    /* solium-enable security/no-inline-assembly */
+    return result;
+  }
 }


### PR DESCRIPTION
## Description of the changes

* Handle ERC20 tokens that do not implement approve() with a bool return as the standard suggests