### PR TITLE
fix: erc20 approval

### DIFF
--- a/packages/payment-processor/src/payment/erc20.ts
+++ b/packages/payment-processor/src/payment/erc20.ts
@@ -114,7 +114,7 @@ export async function approveErc20IfNeeded(
   provider: Provider = getNetworkProvider(request),
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction | void> {
-  if (!hasErc20Approval(request, account, provider)) {
+  if (!await hasErc20Approval(request, account, provider)) {
     return approveErc20(request, getSigner(provider), overrides);
   }
 }


### PR DESCRIPTION
## Description of the changes

Ended up being a simple fix but hard to debug. The hasErc20Approval is async but we don't `await` for the result which meant prompts for approvals were never getting triggered

