### PR TITLE
fix: use string for rnf_invoice tax amount

### DIFF
--- a/packages/data-format/README.md
+++ b/packages/data-format/README.md
@@ -25,7 +25,7 @@ if (!result.valid) {
 
 | Name                                                    | Last version | Last version | Description                 |
 | ------------------------------------------------------- | ------------ | ------------ | --------------------------- |
-| [Invoice](/packages/data-format/src/format/rnf_invoice) | rnf_invoice  | 0.0.2        | Format to create an invoice |
+| [Invoice](/packages/data-format/src/format/rnf_invoice) | rnf_invoice  | 0.0.3        | Format to create an invoice |
 
 ## Contributing
 

--- a/packages/data-format/src/format/rnf_invoice/README.md
+++ b/packages/data-format/src/format/rnf_invoice/README.md
@@ -21,7 +21,7 @@ _Information about the format of the json_
 | Name    | Type     | Need      | Comment              |
 | ------- | -------- | --------- | -------------------- |
 | format  | constant | Mandatory | value: "rnf_invoice" |
-| version | constant | Mandatory | value: "0.0.2"       |
+| version | constant | Mandatory | value: "0.0.3"       |
 
 ## sellerInfo
 
@@ -66,7 +66,7 @@ _List of the items of the invoices_
 | quantity       | number    | Mandatory | quantity (minimum 0)                                  |
 | unitPrice      | string    | Mandatory | unit price (integer in currency base unit)            |
 | discount       | string    | Optional  | price of the discount (integer in currency base unit) |
-| taxPercent     | number    | Mandatory | taxation percentage of the item                       |
+| tax            | object    | Mandatory | information about the item taxes                      |
 | currency       | string    | Mandatory | currency code                                         |
 | deliveryDate   | date-time | Optional  | expected delivery date                                |
 | deliveryPeriod | string    | Optional  | period of delivery if the item is a service           |
@@ -81,3 +81,9 @@ _Payment terms_
 | lateFeesPercent | number    | Optional | percentage of fees applied if late payment                         |
 | lateFeesFix     | string    | Optional | fixed fees applied if late payment (integer in currency base unit) |
 | miscellaneous   | object    | Optional | Miscellaneous information                                          |
+
+## tax
+| Name   | Type   | Need      | Comment                                                                      |
+| ------ | -------| --------- | ---------------------------------------------------------------------------- |
+| type   | string | Mandatory | tax type, can be "percentage" or "fixed"                                     |
+| amount | string | Mandatory | tax amount, either a percentage or an amount (integer in currency base unit) |

--- a/packages/data-format/src/format/rnf_invoice/rnf_invoice-0.0.3.json
+++ b/packages/data-format/src/format/rnf_invoice/rnf_invoice-0.0.3.json
@@ -137,11 +137,32 @@
             "required": ["amount", "type"],
             "properties": {
               "amount": {
-                "type": "number"
+                "type": "string"
               },
               "type": {
                 "type": "string",
                 "enum": ["percentage", "fixed"]
+              }
+            },
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "percentage"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "amount": {
+                  "pattern": "^\\d+\\.?\\d+$"
+                }
+              }
+            },
+            "else": {
+              "properties": {
+                "amount": {
+                  "pattern": "^\\d+$"
+                }
               }
             }
           },

--- a/packages/data-format/test/data/example-invalid-0.0.3.json
+++ b/packages/data-format/test/data/example-invalid-0.0.3.json
@@ -50,7 +50,7 @@
         "unitPrice": 0.01,
         "discount": 0.002,
         "tax": {
-            "amount": 16.9,
+            "amount": "16.9",
             "type": "percentage"
         },
         "currency": "XTS",
@@ -62,7 +62,7 @@
         "quantity": 1,
         "unitPrice": 0.001,
         "tax": {
-            "amount": 5.5,
+            "amount": "5.5",
             "type": "percentage"
         },
         "currency": "XTS",

--- a/packages/data-format/test/data/example-valid-0.0.3.json
+++ b/packages/data-format/test/data/example-valid-0.0.3.json
@@ -52,7 +52,7 @@
         "unitPrice": "100",
         "discount": "01",
         "tax": {
-            "amount": 19.9,
+            "amount": "19.9",
             "type": "percentage"
         },
         "currency": "XT",
@@ -64,7 +64,7 @@
         "quantity": 1,
         "unitPrice": "1234",
         "tax": {
-            "amount": 5.5,
+            "amount": "5.5",
             "type": "percentage"
         },
         "currency": "XTSS",


### PR DESCRIPTION
## Description of the changes
Use string instead of number to represent tax amount.
Update documentation.

