### PR TITLE
feat: add currency support to Celo network and CUSD

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
           "btc",
           "bitcoin",
           "cbc",
+          "celo",
           "chai",
           "checksum",
           "cipheriv",

--- a/packages/request-client.js/src/api/currency/erc20/celo.ts
+++ b/packages/request-client.js/src/api/currency/erc20/celo.ts
@@ -1,0 +1,24 @@
+import { RequestLogicTypes } from '@requestnetwork/types';
+
+// List of the supported celo network tokens
+export const supportedCeloERC20 = new Map([
+  // cUSD token (https://explorer.celo.org/address/0x765de816845861e75a25fca122bb6898b8b1282a/transactions)
+  [
+    'CUSD',
+    {
+      network: 'celo',
+      type: RequestLogicTypes.CURRENCY.ERC20,
+      value: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
+    },
+  ],
+]);
+
+// Additional details about the supported rinkeby ERC20 tokens.
+export const supportedCeloERC20Details = {
+  // Request Central Bank token, used for testing on rinkeby.
+  CUSD: {
+    address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
+    decimals: 18,
+    name: 'Celo Dollar',
+  },
+};

--- a/packages/request-client.js/src/api/currency/erc20/networks.ts
+++ b/packages/request-client.js/src/api/currency/erc20/networks.ts
@@ -1,0 +1,39 @@
+import { RequestLogicTypes } from '@requestnetwork/types';
+import { supportedRinkebyERC20, supportedRinkebyERC20Details } from './rinkeby';
+import { supportedCeloERC20, supportedCeloERC20Details } from './celo';
+
+/**
+ * ERC20 Symbol details type
+ */
+export interface ERC20SymbolDetails {
+  address: string;
+  decimals: number;
+  name: string;
+}
+
+interface ISupportedNetworksMap {
+  [network: string]: Map<
+    string,
+    {
+      network: string;
+      type: RequestLogicTypes.CURRENCY;
+      value: string;
+    }
+  >;
+}
+
+interface ISupportedNetworksDetails {
+  [network: string]: {
+    [symbol: string]: ERC20SymbolDetails;
+  };
+}
+
+export const supportedNetworks: ISupportedNetworksMap = {
+  celo: supportedCeloERC20,
+  rinkeby: supportedRinkebyERC20,
+};
+
+export const supportedNetworksDetails: ISupportedNetworksDetails = {
+  celo: supportedCeloERC20Details,
+  rinkeby: supportedRinkebyERC20Details,
+};

--- a/packages/request-client.js/src/api/currency/erc20/rinkeby.ts
+++ b/packages/request-client.js/src/api/currency/erc20/rinkeby.ts
@@ -1,0 +1,42 @@
+import { RequestLogicTypes } from '@requestnetwork/types';
+
+// List of the supported rinkeby ERC20 tokens
+export const supportedRinkebyERC20 = new Map([
+  // Request Central Bank token, used for testing on rinkeby.
+  [
+    'CTBK',
+    {
+      network: 'rinkeby',
+      type: RequestLogicTypes.CURRENCY.ERC20,
+      value: '0x995d6a8c21f24be1dd04e105dd0d83758343e258',
+    },
+  ],
+
+  // Faucet Token on rinkeby network. Easy to use on tests.
+  [
+    'FAU',
+    {
+      network: 'rinkeby',
+      type: RequestLogicTypes.CURRENCY.ERC20,
+      value: '0xFab46E002BbF0b4509813474841E0716E6730136',
+    },
+  ],
+]);
+
+// Additional details about the supported rinkeby ERC20 tokens.
+export const supportedRinkebyERC20Details = {
+  // Request Central Bank token, used for testing on rinkeby.
+  CTBK: {
+    // Faucet URL: https://central.request.network
+    address: '0x995d6a8c21f24be1dd04e105dd0d83758343e258',
+    decimals: 18,
+    name: 'Central Bank Token',
+  },
+  // Faucet Token on rinkeby network.
+  FAU: {
+    // Faucet URL: https://erc20faucet.com/
+    address: '0xFab46E002BbF0b4509813474841E0716E6730136',
+    decimals: 18,
+    name: 'Faucet Token',
+  },
+};

--- a/packages/request-client.js/test/api/currency.test.ts
+++ b/packages/request-client.js/test/api/currency.test.ts
@@ -34,6 +34,15 @@ describe('api/currency', () => {
       });
     });
 
+    it('returns Celo CUSD', () => {
+      expect(getAllSupportedCurrencies().ERC20.find(({ symbol }) => symbol === 'CUSD-celo')).toEqual({
+        address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
+        decimals: 18,
+        name: 'Celo Dollar',
+        symbol: 'CUSD-celo',
+      });
+    });
+
     it('returns CTBK', () => {
       expect(
         getAllSupportedCurrencies().ERC20.find(({ symbol }) => symbol === 'CTBK-rinkeby')
@@ -86,6 +95,14 @@ describe('api/currency', () => {
           value: '0x9FBDa871d559710256a2502A2517b794B482Db40', // local ERC20 contract
         })).toThrow();
     });
+
+    it('returns the correct number of decimals for a a celo ERC20', () => {
+      expect(getDecimalsForCurrency({
+        network: 'celo',
+        type: RequestLogicTypes.CURRENCY.ERC20,
+        value: '0x765DE816845861e75A25fCA122bb6898B8B1282a', // Celo Dollar
+      })).toEqual(18);
+    });
   });
 
   describe('stringToCurrency', () => {
@@ -116,6 +133,14 @@ describe('api/currency', () => {
         network: 'mainnet',
         type: RequestLogicTypes.CURRENCY.ERC20,
         value: '0x8f8221aFbB33998d8584A2B05749bA73c37a938a',
+      });
+    });
+
+    it('return the correct currency for CUSD-celo string', () => {
+      expect(stringToCurrency('CUSD-celo')).toEqual({
+        network: 'celo',
+        type: RequestLogicTypes.CURRENCY.ERC20,
+        value: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
       });
     });
 
@@ -211,6 +236,14 @@ describe('api/currency', () => {
       })).toEqual('REQ');
     });
 
+    it('return the "CUSD-celo" string for Celo CUSD currency', () => {
+      expect(currencyToString({
+        network: 'celo',
+        type: RequestLogicTypes.CURRENCY.ERC20,
+        value: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
+      })).toEqual('CUSD-celo');
+    });
+
     it('return the "CTBK-rinkeby" string for CTBK currency', () => {
       expect(currencyToString({
         network: 'rinkeby',
@@ -244,6 +277,14 @@ describe('api/currency', () => {
         network: 'mainnet',
         type: RequestLogicTypes.CURRENCY.ERC20,
         value: '0x1111111111111111111111111111111111111111',
+      })).toEqual('unknown');
+    });
+
+    it('return unknown for Celo CUSD on mainnet', () => {
+      expect(currencyToString({
+        network: 'mainnet',
+        type: RequestLogicTypes.CURRENCY.ERC20,
+        value: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
       })).toEqual('unknown');
     });
   });

--- a/packages/request-client.js/test/api/currency/erc20.test.ts
+++ b/packages/request-client.js/test/api/currency/erc20.test.ts
@@ -69,7 +69,7 @@ describe('api/currency/erc20', () => {
           type: RequestLogicTypes.CURRENCY.ERC20,
           value: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
         }),
-      );
+      ).toEqual('CUSD');
     });
   });
 });

--- a/packages/request-client.js/test/api/currency/erc20.test.ts
+++ b/packages/request-client.js/test/api/currency/erc20.test.ts
@@ -1,6 +1,6 @@
 import { RequestLogicTypes } from '@requestnetwork/types';
 import {
-  getErc20FromSymbol,
+  getMainnetErc20FromSymbol,
   getErc20Symbol,
   getMainnetErc20FromAddress,
   validERC20Address,
@@ -21,9 +21,9 @@ describe('api/currency/erc20', () => {
     });
   });
 
-  describe('getErc20FromSymbol', () => {
+  describe('getMainnetErc20FromSymbol', () => {
     it('get TokenDescription object from SAI string', async () => {
-      expect(getErc20FromSymbol('SAI')).toEqual({
+      expect(getMainnetErc20FromSymbol('SAI')).toEqual({
         address: '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359',
         decimals: 18,
         erc20: true,
@@ -61,6 +61,15 @@ describe('api/currency/erc20', () => {
         type: RequestLogicTypes.CURRENCY.ERC20,
         value: '0x995d6a8c21f24be1dd04e105dd0d83758343e258',
       })).toEqual('CTBK');
+    });
+    it('get the symbol for CUSD currency (Celo network)', () => {
+      expect(
+        getErc20Symbol({
+          network: 'celo',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
+        }),
+      );
     });
   });
 });

--- a/packages/request-client.js/test/index-encryption.html
+++ b/packages/request-client.js/test/index-encryption.html
@@ -125,6 +125,7 @@
           topics,
         } = getMockData();
 
+        console.log(web3);
         // Initialize the signature provider
         const signatureProvider = new Web3SignatureProvider.Web3SignatureProvider(web3);
 

--- a/packages/request-client.js/test/index-encryption.html
+++ b/packages/request-client.js/test/index-encryption.html
@@ -125,7 +125,6 @@
           topics,
         } = getMockData();
 
-        console.log(web3);
         // Initialize the signature provider
         const signatureProvider = new Web3SignatureProvider.Web3SignatureProvider(web3);
 


### PR DESCRIPTION
## Description of the changes

- Add support to Celo network to ERC20 currencies.
- Add cUSD to ERC20 currencies.
- Make ERC20 networks support generic and extensible.

This PR does not add Celo network support to ERC20 payment networks, only the currency (currently only usable with declarative requests).
