### PR TITLE
fix: use force push to fix lerna broken nightly updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,8 +535,30 @@ jobs:
           name: 'Authenticate with registry'
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
       - run:
+          name: 'Get updated packages'
+          command: >- 
+            export FORCE_PUBLISH=$(
+              node -p "
+                const a = JSON.parse(process.argv[1]), b = JSON.parse(process.argv[2]); 
+                a.filter(({name}) => b.some(({name: othername})=> name === othername)).map(({name}) => name).join(',');
+              " 
+              "$($(yarn bin)/lerna list --since "HEAD^" --include-dependencies --json)" 
+              "$($(yarn bin)/lerna changed --json)"
+            )
+      - run:
           name: 'publish'
-          command: '$(yarn bin)/lerna publish --conventional-commits --conventional-prerelease --exact --canary --no-git-tag-version --no-push --preid next --dist-tag next --yes'
+          command: >-
+            $(yarn bin)/lerna publish 
+              --conventional-commits 
+              --conventional-prerelease 
+              --exact 
+              --canary 
+              --no-git-tag-version 
+              --no-push 
+              --preid next 
+              --dist-tag next 
+              --force-publish=$FORCE_PUBLISH 
+              --yes
 
 workflows:
   version: 2


### PR DESCRIPTION
## Description of the changes

Tries to fix lerna canary release (for nightlies) by force-publishing all the changed packages since last release (and not only the ones changed at the last commit).
Based on this thread: https://github.com/lerna/lerna/issues/2060#issuecomment-619403848

This is a hack and should be addressed in the future, probably by migrating to a better tool (like Nx, Rush, multi-semantic-release) or using our own publishing script (simple if we want to use fixed versions for all packages).