### PR TITLE
build: get rid of duplicate open-zepellin contract dependency

### DIFF
--- a/packages/smart-contracts/package.json
+++ b/packages/smart-contracts/package.json
@@ -45,14 +45,13 @@
     "test": "truffle test --contracts_directory=./src test/contracts/*.js"
   },
   "devDependencies": {
-    "@openzeppelin/contracts": "2.4.0",
+    "@openzeppelin/contracts": "2.5.1",
     "@openzeppelin/test-helpers": "0.5.6",
     "@types/node": "14.6.4",
     "chai-bn": "0.2.1",
     "ethers": "4.0.48",
     "ganache-cli": "6.11.0",
     "lint-staged": "10.3.0",
-    "openzeppelin-solidity": "2.1.2",
     "shx": "0.3.2",
     "truffle": "5.1.44"
   }

--- a/packages/smart-contracts/src/contracts/ERC20Proxy.sol
+++ b/packages/smart-contracts/src/contracts/ERC20Proxy.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 
 /**

--- a/packages/smart-contracts/src/contracts/RequestHashStorage.sol
+++ b/packages/smart-contracts/src/contracts/RequestHashStorage.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import "openzeppelin-solidity/contracts/access/roles/WhitelistedRole.sol";
+import "@openzeppelin/contracts/access/roles/WhitelistedRole.sol";
 
 
 /**

--- a/packages/smart-contracts/src/contracts/StorageFeeCollector.sol
+++ b/packages/smart-contracts/src/contracts/StorageFeeCollector.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/access/roles/WhitelistAdminRole.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/access/roles/WhitelistAdminRole.sol";
 
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3334,10 +3334,10 @@
     fs-extra "^8.1.0"
     try-require "^1.2.1"
 
-"@openzeppelin/contracts@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-2.4.0.tgz#7270f79ed1463370fe6e664d36a779aa4d3ee896"
-  integrity sha512-xeKP59REgow5TPBJh3S9BRIm7DDG+Rz3Nt4ANWGUkjk4305DHpyUD5CyMJ6nd2JMmZuFyx4mjvvlCtSJLRnN6w==
+"@openzeppelin/contracts@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-2.5.1.tgz#c76e3fc57aa224da3718ec351812a4251289db31"
+  integrity sha512-qIy6tLx8rtybEsIOAlrM4J/85s2q2nPkDqj/Rx46VakBZ0LwtFhXIVub96LXHczQX0vaqmAueDqNPXtbSXSaYQ==
 
 "@openzeppelin/test-helpers@0.5.6":
   version "0.5.6"
@@ -15739,11 +15739,6 @@ opener@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
   integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
-
-openzeppelin-solidity@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/openzeppelin-solidity/-/openzeppelin-solidity-2.1.2.tgz#94e2bb92b60e91abb22c6fe27d983d92850fb324"
-  integrity sha512-1ggh+AZFpMAgGfgnVMQ8dwYawjD2QN4xuWkQS4FUbeUz1fnCKJpguUl2cyadyfDYjBq1XJ6MA6VkzYpTZtJMqw==
 
 opn@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
## Description of the changes
`@openzeppelin/contracts` and `openzeppelin-solidity` are the same package.
We were using both on our codebase. This PR removes the older alias `openzeppelin-solidity`.