### PR TITLE
chore: refactoring of any-to-erc20 from erc20-fee-proxy, with test fixes

### DIFF
--- a/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
@@ -1,33 +1,13 @@
 import { ExtensionTypes, IdentityTypes, RequestLogicTypes } from '@requestnetwork/types';
-import Utils from '@requestnetwork/utils';
-import ReferenceBased from './reference-based';
+import { erc20FeeProxyPaymentNetwork } from './erc20/fee-proxy-contract';
 
 const CURRENT_VERSION = '0.1.0';
-
-const walletAddressValidator = require('wallet-address-validator');
-
-/**
- * Implementation of the payment network to pay in ERC20, including third-party fees payment, based on a reference provided to a proxy contract.
- * With this extension, one request can have three Ethereum addresses (one for payment, one for fees payment, and one for refund)
- * Every ERC20 ethereum transaction that reaches these addresses through the proxy contract and has the correct reference will be interpreted as a payment or a refund.
- * The value to give as input data is the last 8 bytes of a salted hash of the requestId and the address: `last8Bytes(hash(requestId + salt + address))`:
- * The salt should have at least 8 bytes of randomness. A way to generate it is:
- *   `Math.floor(Math.random() * Math.pow(2, 4 * 8)).toString(16) + Math.floor(Math.random() * Math.pow(2, 4 * 8)).toString(16)`
- */
-const conversionErc20FeeProxyContract: ExtensionTypes.PnAnyToErc20.IAnyToERC20 = {
-  applyActionToExtension,
-  createAddFeeAction,
-  createAddPaymentAddressAction,
-  createAddRefundAddressAction,
-  createCreationAction,
-  isValidAddress,
-};
 
 /**
  * These currencies are supported by Chainlink for conversion.
  * Only ERC20 is supported as accepted token by the payment proxy.
  */
-const supportedCurrencies: Record<string,  Record<RequestLogicTypes.CURRENCY, string[]>> = {
+const supportedCurrencies: Record<string, Record<RequestLogicTypes.CURRENCY, string[]>> = {
   private: {
     [RequestLogicTypes.CURRENCY.ISO4217]: ['USD', 'EUR'],
     [RequestLogicTypes.CURRENCY.ERC20]: ['0x9FBDa871d559710256a2502A2517b794B482Db40'],
@@ -48,397 +28,163 @@ const supportedCurrencies: Record<string,  Record<RequestLogicTypes.CURRENCY, st
   },
 };
 
-/**
- * Creates the extensionsData to create the extension ERC20 fee proxy contract payment detection
- *
- * @param creationParameters extensions parameters to create
- *
- * @returns IExtensionCreationAction the extensionsData to be stored in the request
- */
-function createCreationAction(
-  creationParameters: ExtensionTypes.PnAnyToErc20.ICreationParameters,
-): ExtensionTypes.IAction {
-  if (creationParameters.paymentAddress && !isValidAddress(creationParameters.paymentAddress)) {
-    throw Error('paymentAddress is not a valid ethereum address');
+export class anyToErc20ProxyPaymentNetwork extends erc20FeeProxyPaymentNetwork {
+  public constructor() {
+    super();
+    this.currentVersion = CURRENT_VERSION;
+    this.paymentNetworkId = ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY;
   }
 
-  if (creationParameters.refundAddress && !isValidAddress(creationParameters.refundAddress)) {
-    throw Error('refundAddress is not a valid ethereum address');
-  }
-
-  if (creationParameters.feeAddress && !isValidAddress(creationParameters.feeAddress)) {
-    throw Error('feeAddress is not a valid ethereum address');
-  }
-
-  if (creationParameters.feeAmount && !Utils.amount.isValid(creationParameters.feeAmount)) {
-    throw Error('feeAmount is not a valid amount');
-  }
-
-  if (creationParameters.feeAmount && !creationParameters.feeAddress) {
-    throw Error('feeAmount requires feeAddress');
-  }
-  if (creationParameters.feeAddress && !creationParameters.feeAmount) {
-    throw Error('feeAddress requires feeAmount');
-  }
-  if (!creationParameters.acceptedTokens || creationParameters.acceptedTokens.length === 0) {
-    throw Error('acceptedTokens is required');
-  }
-  if (creationParameters.acceptedTokens.some((address) => !isValidAddress(address))) {
-    throw Error('acceptedTokens must contains only valid ethereum addresses');
-  }
-
-  const network = creationParameters.network || 'mainnet';
-  if (!supportedCurrencies[network]) {
-    throw Error('network not supported');
-  }
-  const supportedErc20: string[] = supportedCurrencies[network][RequestLogicTypes.CURRENCY.ERC20];
-  if (creationParameters.acceptedTokens.some((address) => !supportedErc20.includes(address))) {
-    throw Error('acceptedTokens must contain only supported token addresses (ERC20 only)');
-  }
-
-  return ReferenceBased.createCreationAction(
-    ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
-    creationParameters,
-    CURRENT_VERSION,
-  );
-}
-
-/**
- * Creates the extensionsData to add a payment address
- *
- * @param addPaymentAddressParameters extensions parameters to create
- *
- * @returns IAction the extensionsData to be stored in the request
- */
-function createAddPaymentAddressAction(
-  addPaymentAddressParameters: ExtensionTypes.PnReferenceBased.IAddPaymentAddressParameters,
-): ExtensionTypes.IAction {
-  if (
-    addPaymentAddressParameters.paymentAddress &&
-    !isValidAddress(addPaymentAddressParameters.paymentAddress)
-  ) {
-    throw Error('paymentAddress is not a valid ethereum address');
-  }
-
-  return ReferenceBased.createAddPaymentAddressAction(
-    ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
-    addPaymentAddressParameters,
-  );
-}
-
-/**
- * Creates the extensionsData to add a refund address
- *
- * @param addRefundAddressParameters extensions parameters to create
- *
- * @returns IAction the extensionsData to be stored in the request
- */
-function createAddRefundAddressAction(
-  addRefundAddressParameters: ExtensionTypes.PnReferenceBased.IAddRefundAddressParameters,
-): ExtensionTypes.IAction {
-  if (
-    addRefundAddressParameters.refundAddress &&
-    !isValidAddress(addRefundAddressParameters.refundAddress)
-  ) {
-    throw Error('refundAddress is not a valid ethereum address');
-  }
-
-  return ReferenceBased.createAddRefundAddressAction(
-    ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
-    addRefundAddressParameters,
-  );
-}
-
-/**
- * Creates the extensionsData to add a fee address
- *
- * @param addFeeParameters extensions parameters to create
- *
- * @returns IAction the extensionsData to be stored in the request
- */
-function createAddFeeAction(
-  addFeeParameters: ExtensionTypes.PnFeeReferenceBased.IAddFeeParameters,
-): ExtensionTypes.IAction {
-  if (addFeeParameters.feeAddress && !isValidAddress(addFeeParameters.feeAddress)) {
-    throw Error('feeAddress is not a valid ethereum address');
-  }
-
-  if (addFeeParameters.feeAmount && !Utils.amount.isValid(addFeeParameters.feeAmount)) {
-    throw Error('feeAmount is not a valid amount');
-  }
-
-  if (!addFeeParameters.feeAmount && addFeeParameters.feeAddress) {
-    throw Error('feeAmount requires feeAddress');
-  }
-  if (addFeeParameters.feeAmount && !addFeeParameters.feeAddress) {
-    throw Error('feeAddress requires feeAmount');
-  }
-
-  return {
-    action: ExtensionTypes.PnFeeReferenceBased.ACTION.ADD_FEE,
-    id: ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
-    parameters: addFeeParameters,
-  };
-}
-/**
- * Applies the extension action to the request state
- * Is called to interpret the extensions data when applying the transaction
- *
- * @param extensionsState previous state of the extensions
- * @param extensionAction action to apply
- * @param requestState request state read-only
- * @param actionSigner identity of the signer
- *
- * @returns state of the request updated
- */
-function applyActionToExtension(
-  extensionsState: RequestLogicTypes.IExtensionStates,
-  extensionAction: ExtensionTypes.IAction,
-  requestState: RequestLogicTypes.IRequest,
-  actionSigner: IdentityTypes.IIdentity,
-  timestamp: number,
-): RequestLogicTypes.IExtensionStates {
-  checkSupportedCurrency(requestState.currency, extensionAction.parameters.network || 'rinkeby');
-
-  const copiedExtensionState: RequestLogicTypes.IExtensionStates = Utils.deepCopy(extensionsState);
-
-  if (extensionAction.action === ExtensionTypes.PnFeeReferenceBased.ACTION.CREATE) {
-    if (requestState.extensions[extensionAction.id]) {
-      throw Error(`This extension has already been created`);
+  /**
+   * Creates the extensionsData to create the extension Any to ERC20
+   *
+   * @param creationParameters extensions parameters to create
+   *
+   * @returns IExtensionCreationAction the extensionsData to be stored in the request
+   */
+  public createCreationAction(creationParameters: ExtensionTypes.PnAnyToErc20.ICreationParameters) {
+    if (!creationParameters.acceptedTokens || creationParameters.acceptedTokens.length === 0) {
+      throw Error('acceptedTokens is required');
+    }
+    if (
+      creationParameters.acceptedTokens.some((address: string) => !this.isValidAddress(address))
+    ) {
+      throw Error('acceptedTokens must contains only valid ethereum addresses');
     }
 
-    copiedExtensionState[extensionAction.id] = applyCreation(extensionAction, timestamp);
-
-    return copiedExtensionState;
+    const network = creationParameters.network || 'mainnet';
+    if (!supportedCurrencies[network]) {
+      throw Error('network not supported');
+    }
+    const supportedErc20: string[] = supportedCurrencies[network][RequestLogicTypes.CURRENCY.ERC20];
+    if (
+      creationParameters.acceptedTokens.some((address: string) => !supportedErc20.includes(address))
+    ) {
+      throw Error('acceptedTokens must contain only supported token addresses (ERC20 only)');
+    }
+    return super.createCreationAction(creationParameters);
   }
 
-  // if the action is not "create", the state must have been created before
-  if (!requestState.extensions[extensionAction.id]) {
-    throw Error(`The extension should be created before receiving any other action`);
-  }
-
-  if (extensionAction.action === ExtensionTypes.PnFeeReferenceBased.ACTION.ADD_PAYMENT_ADDRESS) {
-    copiedExtensionState[extensionAction.id] = ReferenceBased.applyAddPaymentAddress(
-      isValidAddress,
-      copiedExtensionState[extensionAction.id],
+  /**
+   * Applies the extension action to the request state
+   * Is called to interpret the extensions data when applying the transaction
+   *
+   * @param extensionsState previous state of the extensions
+   * @param extensionAction action to apply
+   * @param requestState request state read-only
+   * @param actionSigner identity of the signer
+   *
+   * @returns state of the request updated
+   */
+  public applyActionToExtension(
+    extensionsState: RequestLogicTypes.IExtensionStates,
+    extensionAction: ExtensionTypes.IAction,
+    requestState: RequestLogicTypes.IRequest,
+    actionSigner: IdentityTypes.IIdentity,
+    timestamp: number,
+  ): RequestLogicTypes.IExtensionStates {
+    return super.applyActionToExtension(
+      extensionsState,
       extensionAction,
       requestState,
       actionSigner,
       timestamp,
     );
-
-    return copiedExtensionState;
   }
 
-  if (extensionAction.action === ExtensionTypes.PnFeeReferenceBased.ACTION.ADD_REFUND_ADDRESS) {
-    copiedExtensionState[extensionAction.id] = ReferenceBased.applyAddRefundAddress(
-      isValidAddress,
-      copiedExtensionState[extensionAction.id],
-      extensionAction,
-      requestState,
-      actionSigner,
-      timestamp,
-    );
+  /**
+   * Applies a creation extension action
+   *
+   * @param extensionAction action to apply
+   * @param timestamp action timestamp
+   *
+   * @returns state of the extension created
+   */
+  protected applyCreation(
+    extensionAction: ExtensionTypes.IAction,
+    timestamp: number,
+  ): ExtensionTypes.IState {
+    if (!extensionAction.parameters.network || extensionAction.parameters.network.length === 0) {
+      throw Error('network is required');
+    }
+    if (
+      !extensionAction.parameters.acceptedTokens ||
+      extensionAction.parameters.acceptedTokens.length === 0
+    ) {
+      throw Error('acceptedTokens is required');
+    }
+    if (
+      extensionAction.parameters.acceptedTokens.some(
+        (address: string) => !this.isValidAddress(address),
+      )
+    ) {
+      throw Error('acceptedTokens must contains only valid ethereum addresses');
+    }
+    const feePNCreationAction = super.applyCreation(extensionAction, timestamp);
 
-    return copiedExtensionState;
-  }
-
-  if (extensionAction.action === ExtensionTypes.PnFeeReferenceBased.ACTION.ADD_FEE) {
-    copiedExtensionState[extensionAction.id] = applyAddFee(
-      copiedExtensionState[extensionAction.id],
-      extensionAction,
-      requestState,
-      actionSigner,
-      timestamp,
-    );
-
-    return copiedExtensionState;
-  }
-
-  throw Error(`Unknown action: ${extensionAction.action}`);
-}
-
-/**
- * Applies a creation extension action
- *
- * @param extensionAction action to apply
- * @param timestamp action timestamp
- *
- * @returns state of the extension created
- */
-function applyCreation(
-  extensionAction: ExtensionTypes.IAction,
-  timestamp: number,
-): ExtensionTypes.IState {
-  if (!extensionAction.version) {
-    throw Error('version is missing');
-  }
-  if (!extensionAction.parameters.paymentAddress) {
-    throw Error('salt is missing');
-  }
-  if (
-    extensionAction.parameters.paymentAddress &&
-    !isValidAddress(extensionAction.parameters.paymentAddress)
-  ) {
-    throw Error('paymentAddress is not a valid address');
-  }
-  if (
-    extensionAction.parameters.refundAddress &&
-    !isValidAddress(extensionAction.parameters.refundAddress)
-  ) {
-    throw Error('refundAddress is not a valid address');
-  }
-  if (
-    extensionAction.parameters.feeAddress &&
-    !isValidAddress(extensionAction.parameters.feeAddress)
-  ) {
-    throw Error('feeAddress is not a valid address');
-  }
-  if (
-    extensionAction.parameters.feeAmount &&
-    !Utils.amount.isValid(extensionAction.parameters.feeAmount)
-  ) {
-    throw Error('feeAmount is not a valid amount');
-  }
-  if (
-    !extensionAction.parameters.acceptedTokens ||
-    extensionAction.parameters.acceptedTokens.length === 0
-  ) {
-    throw Error('acceptedTokens is required');
-  }
-  if (
-    extensionAction.parameters.acceptedTokens.some((address: string) => !isValidAddress(address))
-  ) {
-    throw Error('acceptedTokens must contains only valid ethereum addresses');
-  }
-
-  return {
-    events: [
-      {
-        name: 'create',
-        parameters: {
-          feeAddress: extensionAction.parameters.feeAddress,
-          feeAmount: extensionAction.parameters.feeAmount,
-          paymentAddress: extensionAction.parameters.paymentAddress,
-          refundAddress: extensionAction.parameters.refundAddress,
-          salt: extensionAction.parameters.salt,
-          network: extensionAction.parameters.network,
-          acceptedTokens: extensionAction.parameters.acceptedTokens,
-          maxRateTimespan: extensionAction.parameters.maxRateTimespan,
+    return {
+      ...feePNCreationAction,
+      events: [
+        {
+          name: 'create',
+          parameters: {
+            feeAddress: extensionAction.parameters.feeAddress,
+            feeAmount: extensionAction.parameters.feeAmount,
+            paymentAddress: extensionAction.parameters.paymentAddress,
+            refundAddress: extensionAction.parameters.refundAddress,
+            salt: extensionAction.parameters.salt,
+            network: extensionAction.parameters.network,
+            acceptedTokens: extensionAction.parameters.acceptedTokens,
+            maxRateTimespan: extensionAction.parameters.maxRateTimespan,
+          },
+          timestamp,
         },
-        timestamp,
+      ],
+      values: {
+        ...feePNCreationAction.values,
+        network: extensionAction.parameters.network,
+        acceptedTokens: extensionAction.parameters.acceptedTokens,
+        maxRateTimespan: extensionAction.parameters.maxRateTimespan,
       },
-    ],
-    id: extensionAction.id,
-    type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
-    values: {
-      feeAddress: extensionAction.parameters.feeAddress,
-      feeAmount: extensionAction.parameters.feeAmount,
-      paymentAddress: extensionAction.parameters.paymentAddress,
-      refundAddress: extensionAction.parameters.refundAddress,
-      salt: extensionAction.parameters.salt,
-      network: extensionAction.parameters.network,
-      acceptedTokens: extensionAction.parameters.acceptedTokens,
-      maxRateTimespan: extensionAction.parameters.maxRateTimespan,
-    },
-    version: extensionAction.version,
-  };
-}
-
-/**
- * Applies an add fee address and amount extension action
- *
- * @param extensionState previous state of the extension
- * @param extensionAction action to apply
- * @param requestState request state read-only
- * @param actionSigner identity of the signer
- * @param timestamp action timestamp
- *
- * @returns state of the extension updated
- */
-function applyAddFee(
-  extensionState: ExtensionTypes.IState,
-  extensionAction: ExtensionTypes.IAction,
-  requestState: RequestLogicTypes.IRequest,
-  actionSigner: IdentityTypes.IIdentity,
-  timestamp: number,
-): ExtensionTypes.IState {
-  if (
-    extensionAction.parameters.feeAddress &&
-    !isValidAddress(extensionAction.parameters.feeAddress)
-  ) {
-    throw Error('feeAddress is not a valid address');
-  }
-  if (extensionState.values.feeAddress) {
-    throw Error(`Fee address already given`);
-  }
-  if (
-    extensionAction.parameters.feeAmount &&
-    !Utils.amount.isValid(extensionAction.parameters.feeAmount)
-  ) {
-    throw Error('feeAmount is not a valid amount');
-  }
-  if (extensionState.values.feeAmount) {
-    throw Error(`Fee amount already given`);
-  }
-  if (!requestState.payee) {
-    throw Error(`The request must have a payee`);
-  }
-  if (!Utils.identity.areEqual(actionSigner, requestState.payee)) {
-    throw Error(`The signer must be the payee`);
+    };
   }
 
-  const copiedExtensionState: ExtensionTypes.IState = Utils.deepCopy(extensionState);
+  /**
+   * Validates the payment network of the request currency.
+   *
+   * @param currency
+   */
+  protected validateSupportedCurrency(
+    request: RequestLogicTypes.IRequest,
+    extensionAction: ExtensionTypes.IAction,
+  ): void {
+    const network =
+      extensionAction.parameters.network ||
+      request.extensions[this.paymentNetworkId]?.values.network;
 
-  // update fee address and amount
-  copiedExtensionState.values.feeAddress = extensionAction.parameters.feeAddress;
-  copiedExtensionState.values.feeAmount = extensionAction.parameters.feeAmount;
+    // Nothing can be validated if the network has not been given yet
+    if (!network) {
+      return;
+    }
 
-  // update events
-  copiedExtensionState.events.push({
-    name: ExtensionTypes.PnFeeReferenceBased.ACTION.ADD_FEE,
-    parameters: {
-      feeAddress: extensionAction.parameters.feeAddress,
-      feeAmount: extensionAction.parameters.feeAmount,
-    },
-    timestamp,
-  });
+    if (!supportedCurrencies[network]) {
+      throw new Error(`The network (${network}) is not supported for this payment network.`);
+    }
 
-  return copiedExtensionState;
-}
+    if (!supportedCurrencies[network][request.currency.type]) {
+      throw new Error(
+        `The currency type (${request.currency.type}) of the request is not supported for this payment network.`,
+      );
+    }
 
-/**
- * Check if an ethereum address is valid
- *
- * @param {string} address address to check
- * @returns {boolean} true if address is valid
- */
-function isValidAddress(address: string): boolean {
-  return walletAddressValidator.validate(address, 'ethereum');
-}
-
-/**
- * Throw if a currency is not supported
- *
- * @param currency currency to check
- * @param network network of the payment
- */
-function checkSupportedCurrency(currency: RequestLogicTypes.ICurrency, network: string): void {
-  if (!supportedCurrencies[network]) {
-    throw new Error(`The network (${network}) is not supported for this payment network.`);
-  }
-
-  if (!supportedCurrencies[network][currency.type]) {
-    throw new Error(
-      `The currency type (${currency.type}) of the request is not supported for this payment network.`,
-    );
-  }
-
-  if (!supportedCurrencies[network][currency.type].includes(currency.value)) {
-    throw new Error(
-      `The currency (${currency.value}) of the request is not supported for this payment network.`,
-    );
+    if (!supportedCurrencies[network][request.currency.type].includes(request.currency.value)) {
+      throw new Error(
+        `The currency (${request.currency.value}) of the request is not supported for this payment network.`,
+      );
+    }
   }
 }
+
+const conversionErc20FeeProxyContract: ExtensionTypes.PnAnyToErc20.IAnyToERC20 = new anyToErc20ProxyPaymentNetwork() as ExtensionTypes.PnAnyToErc20.IAnyToERC20;
 
 export default conversionErc20FeeProxyContract;

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
@@ -52,10 +52,14 @@ export class anyToErc20ProxyPaymentNetwork extends erc20FeeProxyPaymentNetwork {
       throw Error('acceptedTokens must contains only valid ethereum addresses');
     }
 
-    const network = creationParameters.network || 'mainnet';
+    const network = creationParameters.network;
+    if (!network) {
+      throw Error('network is required');
+    }
     if (!supportedCurrencies[network]) {
       throw Error('network not supported');
     }
+
     const supportedErc20: string[] = supportedCurrencies[network][RequestLogicTypes.CURRENCY.ERC20];
     if (
       creationParameters.acceptedTokens.some((address: string) => !supportedErc20.includes(address))

--- a/packages/advanced-logic/src/extensions/payment-network/erc20/fee-proxy-contract.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/fee-proxy-contract.ts
@@ -14,7 +14,7 @@ const walletAddressValidator = require('wallet-address-validator');
  * The salt should have at least 8 bytes of randomness. A way to generate it is:
  *   `Math.floor(Math.random() * Math.pow(2, 4 * 8)).toString(16) + Math.floor(Math.random() * Math.pow(2, 4 * 8)).toString(16)`
  */
-const erc20FeeProxyContract: ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased = {
+export const erc20FeeProxyContract: ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased = {
   applyActionToExtension,
   createAddFeeAction,
   createAddPaymentAddressAction,
@@ -371,3 +371,371 @@ function isValidAddress(address: string): boolean {
 }
 
 export default erc20FeeProxyContract;
+
+export class erc20FeeProxyPaymentNetwork {
+  public currentVersion;
+  public paymentNetworkId;
+
+  public constructor() {
+    this.currentVersion = CURRENT_VERSION;
+    this.paymentNetworkId = ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT;
+  }
+
+  /**
+   * Creates the extensionsData to create the extension ERC20 fee proxy contract payment detection
+   *
+   * @param creationParameters extensions parameters to create
+   *
+   * @returns IExtensionCreationAction the extensionsData to be stored in the request
+   */
+  public createCreationAction(
+    creationParameters: ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
+  ): ExtensionTypes.IAction {
+    if (creationParameters.paymentAddress && !isValidAddress(creationParameters.paymentAddress)) {
+      throw Error('paymentAddress is not a valid ethereum address');
+    }
+
+    if (creationParameters.refundAddress && !isValidAddress(creationParameters.refundAddress)) {
+      throw Error('refundAddress is not a valid ethereum address');
+    }
+
+    if (creationParameters.feeAddress && !isValidAddress(creationParameters.feeAddress)) {
+      throw Error('feeAddress is not a valid ethereum address');
+    }
+
+    if (creationParameters.feeAmount && !Utils.amount.isValid(creationParameters.feeAmount)) {
+      throw Error('feeAmount is not a valid amount');
+    }
+
+    if (!creationParameters.feeAmount && creationParameters.feeAddress) {
+      throw Error('feeAmount requires feeAddress');
+    }
+    if (creationParameters.feeAmount && !creationParameters.feeAddress) {
+      throw Error('feeAddress requires feeAmount');
+    }
+
+    return ReferenceBased.createCreationAction(
+      this.paymentNetworkId,
+      creationParameters,
+      this.currentVersion,
+    );
+  }
+
+  /**
+   * Creates the extensionsData to add a payment address
+   *
+   * @param addPaymentAddressParameters extensions parameters to create
+   *
+   * @returns IAction the extensionsData to be stored in the request
+   */
+  public createAddPaymentAddressAction(
+    addPaymentAddressParameters: ExtensionTypes.PnReferenceBased.IAddPaymentAddressParameters,
+  ): ExtensionTypes.IAction {
+    if (
+      addPaymentAddressParameters.paymentAddress &&
+      !isValidAddress(addPaymentAddressParameters.paymentAddress)
+    ) {
+      throw Error('paymentAddress is not a valid ethereum address');
+    }
+
+    return ReferenceBased.createAddPaymentAddressAction(
+      this.paymentNetworkId,
+      addPaymentAddressParameters,
+    );
+  }
+
+  /**
+   * Creates the extensionsData to add a refund address
+   *
+   * @param addRefundAddressParameters extensions parameters to create
+   *
+   * @returns IAction the extensionsData to be stored in the request
+   */
+  public createAddRefundAddressAction(
+    addRefundAddressParameters: ExtensionTypes.PnReferenceBased.IAddRefundAddressParameters,
+  ): ExtensionTypes.IAction {
+    if (
+      addRefundAddressParameters.refundAddress &&
+      !isValidAddress(addRefundAddressParameters.refundAddress)
+    ) {
+      throw Error('refundAddress is not a valid ethereum address');
+    }
+
+    return ReferenceBased.createAddRefundAddressAction(
+      this.paymentNetworkId,
+      addRefundAddressParameters,
+    );
+  }
+
+  /**
+   * Creates the extensionsData to add a fee address
+   *
+   * @param addFeeParameters extensions parameters to create
+   *
+   * @returns IAction the extensionsData to be stored in the request
+   */
+  public createAddFeeAction(
+    addFeeParameters: ExtensionTypes.PnFeeReferenceBased.IAddFeeParameters,
+  ): ExtensionTypes.IAction {
+    if (addFeeParameters.feeAddress && !isValidAddress(addFeeParameters.feeAddress)) {
+      throw Error('feeAddress is not a valid ethereum address');
+    }
+
+    if (addFeeParameters.feeAmount && !Utils.amount.isValid(addFeeParameters.feeAmount)) {
+      throw Error('feeAmount is not a valid amount');
+    }
+
+    if (!addFeeParameters.feeAmount && addFeeParameters.feeAddress) {
+      throw Error('feeAmount requires feeAddress');
+    }
+    if (addFeeParameters.feeAmount && !addFeeParameters.feeAddress) {
+      throw Error('feeAddress requires feeAmount');
+    }
+
+    return {
+      action: ExtensionTypes.PnFeeReferenceBased.ACTION.ADD_FEE,
+      id: this.paymentNetworkId,
+      parameters: addFeeParameters,
+    };
+  }
+
+  /**
+   * Applies the extension action to the request
+   * Is called to interpret the extensions data when applying the transaction
+   *
+   * @param extensionsState previous state of the extensions
+   * @param extensionAction action to apply
+   * @param requestState request state read-only
+   * @param actionSigner identity of the signer
+   *
+   * @returns state of the request updated
+   */
+  public applyActionToExtension(
+    extensionsState: RequestLogicTypes.IExtensionStates,
+    extensionAction: ExtensionTypes.IAction,
+    requestState: RequestLogicTypes.IRequest,
+    actionSigner: IdentityTypes.IIdentity,
+    timestamp: number,
+  ): RequestLogicTypes.IExtensionStates {
+    this.validateSupportedCurrency(requestState, extensionAction);
+
+    const copiedExtensionState: RequestLogicTypes.IExtensionStates = Utils.deepCopy(
+      extensionsState,
+    );
+
+    if (extensionAction.action === ExtensionTypes.PnFeeReferenceBased.ACTION.CREATE) {
+      if (requestState.extensions[extensionAction.id]) {
+        throw Error(`This extension has already been created`);
+      }
+
+      copiedExtensionState[extensionAction.id] = this.applyCreation(extensionAction, timestamp);
+
+      return copiedExtensionState;
+    }
+
+    // if the action is not "create", the state must have been created before
+    if (!requestState.extensions[extensionAction.id]) {
+      throw Error(`The extension should be created before receiving any other action`);
+    }
+
+    if (extensionAction.action === ExtensionTypes.PnFeeReferenceBased.ACTION.ADD_PAYMENT_ADDRESS) {
+      copiedExtensionState[extensionAction.id] = ReferenceBased.applyAddPaymentAddress(
+        isValidAddress,
+        copiedExtensionState[extensionAction.id],
+        extensionAction,
+        requestState,
+        actionSigner,
+        timestamp,
+      );
+
+      return copiedExtensionState;
+    }
+
+    if (extensionAction.action === ExtensionTypes.PnFeeReferenceBased.ACTION.ADD_REFUND_ADDRESS) {
+      copiedExtensionState[extensionAction.id] = ReferenceBased.applyAddRefundAddress(
+        isValidAddress,
+        copiedExtensionState[extensionAction.id],
+        extensionAction,
+        requestState,
+        actionSigner,
+        timestamp,
+      );
+
+      return copiedExtensionState;
+    }
+
+    if (extensionAction.action === ExtensionTypes.PnFeeReferenceBased.ACTION.ADD_FEE) {
+      copiedExtensionState[extensionAction.id] = this.applyAddFee(
+        copiedExtensionState[extensionAction.id],
+        extensionAction,
+        requestState,
+        actionSigner,
+        timestamp,
+      );
+
+      return copiedExtensionState;
+    }
+
+    throw Error(`Unknown action: ${extensionAction.action}`);
+  }
+
+  /**
+   * Check if an address is valid for this payment network
+   *
+   * @param {string} address address to check
+   * @returns {boolean} true if address is valid
+   */
+  public isValidAddress(address: string): boolean {
+    return walletAddressValidator.validate(address, 'ethereum');
+  }
+
+  /**
+   * Applies a creation extension action
+   *
+   * @param extensionAction action to apply
+   * @param timestamp action timestamp
+   *
+   * @returns state of the extension created
+   */
+
+  protected applyCreation(
+    extensionAction: ExtensionTypes.IAction,
+    timestamp: number,
+  ): ExtensionTypes.IState {
+    if (!extensionAction.version) {
+      throw Error('version is missing');
+    }
+    if (!extensionAction.parameters.paymentAddress) {
+      throw Error('salt is missing');
+    }
+    if (
+      extensionAction.parameters.paymentAddress &&
+      !this.isValidAddress(extensionAction.parameters.paymentAddress)
+    ) {
+      throw Error('paymentAddress is not a valid address');
+    }
+    if (
+      extensionAction.parameters.refundAddress &&
+      !this.isValidAddress(extensionAction.parameters.refundAddress)
+    ) {
+      throw Error('refundAddress is not a valid address');
+    }
+    if (
+      extensionAction.parameters.feeAddress &&
+      !this.isValidAddress(extensionAction.parameters.feeAddress)
+    ) {
+      throw Error('feeAddress is not a valid address');
+    }
+    if (
+      extensionAction.parameters.feeAmount &&
+      !Utils.amount.isValid(extensionAction.parameters.feeAmount)
+    ) {
+      throw Error('feeAmount is not a valid amount');
+    }
+    return {
+      events: [
+        {
+          name: 'create',
+          parameters: {
+            feeAddress: extensionAction.parameters.feeAddress,
+            feeAmount: extensionAction.parameters.feeAmount,
+            paymentAddress: extensionAction.parameters.paymentAddress,
+            refundAddress: extensionAction.parameters.refundAddress,
+            salt: extensionAction.parameters.salt,
+          },
+          timestamp,
+        },
+      ],
+      id: extensionAction.id,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress: extensionAction.parameters.feeAddress,
+        feeAmount: extensionAction.parameters.feeAmount,
+        paymentAddress: extensionAction.parameters.paymentAddress,
+        refundAddress: extensionAction.parameters.refundAddress,
+        salt: extensionAction.parameters.salt,
+      },
+      version: extensionAction.version,
+    };
+  }
+
+  /**
+   * Applies an add fee address and amount extension action
+   *
+   * @param extensionState previous state of the extension
+   * @param extensionAction action to apply
+   * @param requestState request state read-only
+   * @param actionSigner identity of the signer
+   * @param timestamp action timestamp
+   *
+   * @returns state of the extension updated
+   */
+  protected applyAddFee(
+    extensionState: ExtensionTypes.IState,
+    extensionAction: ExtensionTypes.IAction,
+    requestState: RequestLogicTypes.IRequest,
+    actionSigner: IdentityTypes.IIdentity,
+    timestamp: number,
+  ): ExtensionTypes.IState {
+    if (
+      extensionAction.parameters.feeAddress &&
+      !this.isValidAddress(extensionAction.parameters.feeAddress)
+    ) {
+      throw Error('feeAddress is not a valid address');
+    }
+    if (extensionState.values.feeAddress) {
+      throw Error(`Fee address already given`);
+    }
+    if (
+      extensionAction.parameters.feeAmount &&
+      !Utils.amount.isValid(extensionAction.parameters.feeAmount)
+    ) {
+      throw Error('feeAmount is not a valid amount');
+    }
+    if (extensionState.values.feeAmount) {
+      throw Error(`Fee amount already given`);
+    }
+    if (!requestState.payee) {
+      throw Error(`The request must have a payee`);
+    }
+    if (!Utils.identity.areEqual(actionSigner, requestState.payee)) {
+      throw Error(`The signer must be the payee`);
+    }
+
+    const copiedExtensionState: ExtensionTypes.IState = Utils.deepCopy(extensionState);
+
+    // update fee address and amount
+    copiedExtensionState.values.feeAddress = extensionAction.parameters.feeAddress;
+    copiedExtensionState.values.feeAmount = extensionAction.parameters.feeAmount;
+
+    // update events
+    copiedExtensionState.events.push({
+      name: ExtensionTypes.PnFeeReferenceBased.ACTION.ADD_FEE,
+      parameters: {
+        feeAddress: extensionAction.parameters.feeAddress,
+        feeAmount: extensionAction.parameters.feeAmount,
+      },
+      timestamp,
+    });
+
+    return copiedExtensionState;
+  }
+
+  protected validateSupportedCurrency(
+    request: RequestLogicTypes.IRequest,
+    extensionAction: ExtensionTypes.IAction,
+  ): void {
+    if (
+      request.currency.type !== RequestLogicTypes.CURRENCY.ERC20 ||
+      (request.currency.network &&
+        extensionAction.parameters.network === request.currency.network &&
+        !supportedNetworks.includes(request.currency.network))
+    ) {
+      throw Error(
+        `This extension can be used only on ERC20 requests and on supported networks ${supportedNetworks.join(
+          ', ',
+        )}`,
+      );
+    }
+  }
+}

--- a/packages/advanced-logic/test/extensions/payment-network/any-to-erc20-proxy.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/any-to-erc20-proxy.test.ts
@@ -132,6 +132,16 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       }).toThrowError('acceptedTokens must contains only valid ethereum addresses');
     });
 
+    it('cannot createCreationAction without network', () => {
+      expect(() => {
+        new anyToErc20ProxyPaymentNetwork().createCreationAction({
+          paymentAddress: '0x0000000000000000000000000000000000000001',
+          salt: 'ea3bc7caf64110ca',
+          acceptedTokens: ['0xFab46E002BbF0b4509813474841E0716E6730136'],
+        });
+      }).toThrowError('network is required');
+    });
+
     it('cannot createCreationAction with network not supported', () => {
       expect(() => {
         new anyToErc20ProxyPaymentNetwork().createCreationAction({

--- a/packages/advanced-logic/test/extensions/payment-network/any-to-erc20-proxy.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/any-to-erc20-proxy.test.ts
@@ -1,7 +1,7 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 
-import anyToErc20Proxy from '../../../src/extensions/payment-network/any-to-erc20-proxy'
+import { anyToErc20ProxyPaymentNetwork } from '../../../src/extensions/payment-network/any-to-erc20-proxy';
 import * as DataConversionERC20FeeAddData from '../../utils/payment-network/erc20/any-to-erc20-proxy-add-data-generator';
 import * as DataConversionERC20FeeCreate from '../../utils/payment-network/erc20/any-to-erc20-proxy-create-data-generator';
 import * as TestData from '../../utils/test-data-generator';
@@ -12,7 +12,7 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     it('can create a create action with all parameters', () => {
       // 'extension data is wrong'
       expect(
-        anyToErc20Proxy.createCreationAction({
+        new anyToErc20ProxyPaymentNetwork().createCreationAction({
           feeAddress: '0x0000000000000000000000000000000000000001',
           feeAmount: '0',
           paymentAddress: '0x0000000000000000000000000000000000000002',
@@ -42,7 +42,7 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     it('can create a create action without fee parameters', () => {
       // 'extension data is wrong'
       expect(
-        anyToErc20Proxy.createCreationAction({
+        new anyToErc20ProxyPaymentNetwork().createCreationAction({
           paymentAddress: '0x0000000000000000000000000000000000000001',
           refundAddress: '0x0000000000000000000000000000000000000002',
           salt: 'ea3bc7caf64110ca',
@@ -64,89 +64,92 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     });
 
     it('cannot createCreationAction with payment address not an ethereum address', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.createCreationAction({
+        new anyToErc20ProxyPaymentNetwork().createCreationAction({
           paymentAddress: 'not an ethereum address',
           refundAddress: '0x0000000000000000000000000000000000000002',
           salt: 'ea3bc7caf64110ca',
+          network: 'private',
+          acceptedTokens: [DataConversionERC20FeeCreate.tokenAddress],
         });
       }).toThrowError('paymentAddress is not a valid ethereum address');
     });
 
     it('cannot createCreationAction with refund address not an ethereum address', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.createCreationAction({
+        new anyToErc20ProxyPaymentNetwork().createCreationAction({
           paymentAddress: '0x0000000000000000000000000000000000000001',
           refundAddress: 'not an ethereum address',
           salt: 'ea3bc7caf64110ca',
+          network: 'private',
+          acceptedTokens: [DataConversionERC20FeeCreate.tokenAddress],
         });
       }).toThrowError('refundAddress is not a valid ethereum address');
     });
 
     it('cannot createCreationAction with fee address not an ethereum address', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.createCreationAction({
+        new anyToErc20ProxyPaymentNetwork().createCreationAction({
           feeAddress: 'not an ethereum address',
           paymentAddress: '0x0000000000000000000000000000000000000001',
           salt: 'ea3bc7caf64110ca',
+          network: 'private',
+          acceptedTokens: [DataConversionERC20FeeCreate.tokenAddress],
         });
       }).toThrowError('feeAddress is not a valid ethereum address');
     });
 
     it('cannot createCreationAction with invalid fee amount', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.createCreationAction({
+        new anyToErc20ProxyPaymentNetwork().createCreationAction({
           feeAmount: '-20000',
           paymentAddress: '0x0000000000000000000000000000000000000001',
           salt: 'ea3bc7caf64110ca',
+          acceptedTokens: ['0xFab46E002BbF0b4509813474841E0716E6730136'],
+          network: 'rinkeby',
         });
       }).toThrowError('feeAmount is not a valid amount');
     });
 
     it('cannot createCreationAction without acceptedTokens', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.createCreationAction({
+        new anyToErc20ProxyPaymentNetwork().createCreationAction({
           paymentAddress: '0x0000000000000000000000000000000000000001',
           salt: 'ea3bc7caf64110ca',
+          network: 'rinkeby',
         });
       }).toThrowError('acceptedTokens is required');
     });
 
     it('cannot createCreationAction with invalid tokens accepted', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.createCreationAction({
+        new anyToErc20ProxyPaymentNetwork().createCreationAction({
           paymentAddress: '0x0000000000000000000000000000000000000001',
           salt: 'ea3bc7caf64110ca',
-          acceptedTokens: ['0x0000000000000000000000000000000000000003', 'invalid address']
+          network: 'rinkeby',
+          acceptedTokens: ['0x0000000000000000000000000000000000000003', 'invalid address'],
         });
       }).toThrowError('acceptedTokens must contains only valid ethereum addresses');
     });
 
     it('cannot createCreationAction with network not supported', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.createCreationAction({
+        new anyToErc20ProxyPaymentNetwork().createCreationAction({
           paymentAddress: '0x0000000000000000000000000000000000000001',
           salt: 'ea3bc7caf64110ca',
           network: 'kovan',
-          acceptedTokens: ['0x0000000000000000000000000000000000000003']
+          acceptedTokens: ['0x0000000000000000000000000000000000000003'],
         });
       }).toThrowError('network not supported');
     });
 
     it('cannot createCreationAction with tokens accepted not supported', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.createCreationAction({
+        new anyToErc20ProxyPaymentNetwork().createCreationAction({
           paymentAddress: '0x0000000000000000000000000000000000000001',
           salt: 'ea3bc7caf64110ca',
-          acceptedTokens: ['0x0000000000000000000000000000000000000003']
+          network: 'rinkeby',
+          acceptedTokens: ['0x0000000000000000000000000000000000000003'],
         });
       }).toThrowError('acceptedTokens must contain only supported token addresses (ERC20 only)');
     });
@@ -157,7 +160,7 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       );
       requestCreatedNoExtension.currency = {
         type: RequestLogicTypes.CURRENCY.ETH,
-        value: 'ETH'
+        value: 'ETH',
       };
 
       const action: ExtensionTypes.IAction = Utils.deepCopy(
@@ -165,18 +168,15 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       );
       action.parameters.network = 'invalid network';
 
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.applyActionToExtension(
+        new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
           TestData.requestCreatedNoExtension.extensions,
           action,
           requestCreatedNoExtension,
           TestData.otherIdRaw.identity,
           TestData.arbitraryTimestamp,
         );
-      }).toThrowError(
-        `The network (invalid network) is not supported for this payment network.`,
-      );
+      }).toThrowError(`The network (invalid network) is not supported for this payment network.`);
     });
 
     it('cannot applyActionToExtensions of creation on a non supported currency', () => {
@@ -185,16 +185,15 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       );
       requestCreatedNoExtension.currency = {
         type: RequestLogicTypes.CURRENCY.ETH,
-        value: 'invalid value'
+        value: 'invalid value',
       };
 
       const action: ExtensionTypes.IAction = Utils.deepCopy(
         DataConversionERC20FeeCreate.actionCreationFull,
       );
 
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.applyActionToExtension(
+        new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
           TestData.requestCreatedNoExtension.extensions,
           action,
           requestCreatedNoExtension,
@@ -205,14 +204,13 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
         `The currency (invalid value) of the request is not supported for this payment network.`,
       );
     });
-
   });
 
   describe('createAddPaymentAddressAction', () => {
     it('can createAddPaymentAddressAction', () => {
       // 'extension data is wrong'
       expect(
-        anyToErc20Proxy.createAddPaymentAddressAction({
+        new anyToErc20ProxyPaymentNetwork().createAddPaymentAddressAction({
           paymentAddress: '0x0000000000000000000000000000000000000001',
         }),
       ).toEqual({
@@ -225,9 +223,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     });
 
     it('cannot createAddPaymentAddressAction with payment address not an ethereum address', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.createAddPaymentAddressAction({
+        new anyToErc20ProxyPaymentNetwork().createAddPaymentAddressAction({
           paymentAddress: 'not an ethereum address',
         });
       }).toThrowError('paymentAddress is not a valid ethereum address');
@@ -238,7 +235,7 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     it('can createAddRefundAddressAction', () => {
       // 'extension data is wrong'
       expect(
-        anyToErc20Proxy.createAddRefundAddressAction({
+        new anyToErc20ProxyPaymentNetwork().createAddRefundAddressAction({
           refundAddress: '0x0000000000000000000000000000000000000002',
         }),
       ).toEqual({
@@ -251,9 +248,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     });
 
     it('cannot createAddRefundAddressAction with payment address not an ethereum address', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.createAddRefundAddressAction({
+        new anyToErc20ProxyPaymentNetwork().createAddRefundAddressAction({
           refundAddress: 'not an ethereum address',
         });
       }).toThrowError('refundAddress is not a valid ethereum address');
@@ -264,7 +260,7 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     it('can createAddFeeAction', () => {
       // 'extension data is wrong'
       expect(
-        anyToErc20Proxy.createAddFeeAction({
+        new anyToErc20ProxyPaymentNetwork().createAddFeeAction({
           feeAddress: '0x0000000000000000000000000000000000000002',
           feeAmount: '2000',
         }),
@@ -279,9 +275,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     });
 
     it('cannot createAddFeeAddressAction with payment address not an ethereum address', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.createAddFeeAction({
+        new anyToErc20ProxyPaymentNetwork().createAddFeeAction({
           feeAddress: 'not an ethereum address',
           feeAmount: '2000',
         });
@@ -289,9 +284,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     });
 
     it('cannot createAddFeeAction with amount non positive integer', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.createAddFeeAction({
+        new anyToErc20ProxyPaymentNetwork().createAddFeeAction({
           feeAddress: '0x0000000000000000000000000000000000000002',
           feeAmount: '-30000',
         });
@@ -304,9 +298,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       it('cannot applyActionToExtensions of unknown action', () => {
         const unknownAction = Utils.deepCopy(DataConversionERC20FeeAddData.actionAddPaymentAddress);
         unknownAction.action = 'unknown action';
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestStateCreatedEmpty.extensions,
             unknownAction,
             DataConversionERC20FeeCreate.requestStateCreatedEmpty,
@@ -319,9 +312,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       it('cannot applyActionToExtensions of unknown id', () => {
         const unknownAction = Utils.deepCopy(DataConversionERC20FeeAddData.actionAddPaymentAddress);
         unknownAction.id = 'unknown id';
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestStateCreatedEmpty.extensions,
             unknownAction,
             DataConversionERC20FeeCreate.requestStateCreatedEmpty,
@@ -336,7 +328,7 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       it('can applyActionToExtensions of creation', () => {
         // 'new extension state wrong'
         expect(
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestStateNoExtensions.extensions,
             DataConversionERC20FeeCreate.actionCreationFull,
             DataConversionERC20FeeCreate.requestStateNoExtensions,
@@ -347,9 +339,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       });
 
       it('cannot applyActionToExtensions of creation with a previous state', () => {
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestFullStateCreated.extensions,
             DataConversionERC20FeeCreate.actionCreationFull,
             DataConversionERC20FeeCreate.requestFullStateCreated,
@@ -367,9 +358,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
           type: RequestLogicTypes.CURRENCY.BTC,
           value: 'BTC',
         };
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             TestData.requestCreatedNoExtension.extensions,
             DataConversionERC20FeeCreate.actionCreationFull,
             requestCreatedNoExtension,
@@ -382,11 +372,13 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       });
 
       it('cannot applyActionToExtensions of creation with payment address not valid', () => {
-        const testnetPaymentAddress = Utils.deepCopy(DataConversionERC20FeeCreate.actionCreationFull);
-        testnetPaymentAddress.parameters.paymentAddress = DataConversionERC20FeeAddData.invalidAddress;
-        // 'must throw'
+        const testnetPaymentAddress = Utils.deepCopy(
+          DataConversionERC20FeeCreate.actionCreationFull,
+        );
+        testnetPaymentAddress.parameters.paymentAddress =
+          DataConversionERC20FeeAddData.invalidAddress;
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestStateNoExtensions.extensions,
             testnetPaymentAddress,
             DataConversionERC20FeeCreate.requestStateNoExtensions,
@@ -397,11 +389,12 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       });
 
       it('cannot applyActionToExtensions of creation with no tokens accepted', () => {
-        const testnetPaymentAddress = Utils.deepCopy(DataConversionERC20FeeCreate.actionCreationFull);
+        const testnetPaymentAddress = Utils.deepCopy(
+          DataConversionERC20FeeCreate.actionCreationFull,
+        );
         testnetPaymentAddress.parameters.acceptedTokens = [];
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestStateNoExtensions.extensions,
             testnetPaymentAddress,
             DataConversionERC20FeeCreate.requestStateNoExtensions,
@@ -412,11 +405,12 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       });
 
       it('cannot applyActionToExtensions of creation with token address not valid', () => {
-        const testnetPaymentAddress = Utils.deepCopy(DataConversionERC20FeeCreate.actionCreationFull);
+        const testnetPaymentAddress = Utils.deepCopy(
+          DataConversionERC20FeeCreate.actionCreationFull,
+        );
         testnetPaymentAddress.parameters.acceptedTokens = ['invalid address'];
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestStateNoExtensions.extensions,
             testnetPaymentAddress,
             DataConversionERC20FeeCreate.requestStateNoExtensions,
@@ -427,11 +421,13 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       });
 
       it('cannot applyActionToExtensions of creation with refund address not valid', () => {
-        const testnetRefundAddress = Utils.deepCopy(DataConversionERC20FeeCreate.actionCreationFull);
-        testnetRefundAddress.parameters.refundAddress = DataConversionERC20FeeAddData.invalidAddress;
-        // 'must throw'
+        const testnetRefundAddress = Utils.deepCopy(
+          DataConversionERC20FeeCreate.actionCreationFull,
+        );
+        testnetRefundAddress.parameters.refundAddress =
+          DataConversionERC20FeeAddData.invalidAddress;
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestStateNoExtensions.extensions,
             testnetRefundAddress,
             DataConversionERC20FeeCreate.requestStateNoExtensions,
@@ -446,7 +442,7 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       it('can applyActionToExtensions of addPaymentAddress', () => {
         // 'new extension state wrong'
         expect(
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestStateCreatedEmpty.extensions,
             DataConversionERC20FeeAddData.actionAddPaymentAddress,
             DataConversionERC20FeeCreate.requestStateCreatedEmpty,
@@ -457,9 +453,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       });
 
       it('cannot applyActionToExtensions of addPaymentAddress without a previous state', () => {
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestStateNoExtensions.extensions,
             DataConversionERC20FeeAddData.actionAddPaymentAddress,
             DataConversionERC20FeeCreate.requestStateNoExtensions,
@@ -472,9 +467,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       it('cannot applyActionToExtensions of addPaymentAddress without a payee', () => {
         const previousState = Utils.deepCopy(DataConversionERC20FeeCreate.requestStateCreatedEmpty);
         previousState.payee = undefined;
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             previousState.extensions,
             DataConversionERC20FeeAddData.actionAddPaymentAddress,
             previousState,
@@ -486,9 +480,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
 
       it('cannot applyActionToExtensions of addPaymentAddress signed by someone else than the payee', () => {
         const previousState = Utils.deepCopy(DataConversionERC20FeeCreate.requestStateCreatedEmpty);
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             previousState.extensions,
             DataConversionERC20FeeAddData.actionAddPaymentAddress,
             previousState,
@@ -499,9 +492,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       });
 
       it('cannot applyActionToExtensions of addPaymentAddress with payment address already given', () => {
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestFullStateCreated.extensions,
             DataConversionERC20FeeAddData.actionAddPaymentAddress,
             DataConversionERC20FeeCreate.requestFullStateCreated,
@@ -512,11 +504,13 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       });
 
       it('cannot applyActionToExtensions of addPaymentAddress with payment address not valid', () => {
-        const testnetPaymentAddress = Utils.deepCopy(DataConversionERC20FeeAddData.actionAddPaymentAddress);
-        testnetPaymentAddress.parameters.paymentAddress = DataConversionERC20FeeAddData.invalidAddress;
-        // 'must throw'
+        const testnetPaymentAddress = Utils.deepCopy(
+          DataConversionERC20FeeAddData.actionAddPaymentAddress,
+        );
+        testnetPaymentAddress.parameters.paymentAddress =
+          DataConversionERC20FeeAddData.invalidAddress;
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestStateCreatedEmpty.extensions,
             testnetPaymentAddress,
             DataConversionERC20FeeCreate.requestStateCreatedEmpty,
@@ -531,7 +525,7 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       it('can applyActionToExtensions of addRefundAddress', () => {
         // 'new extension state wrong'
         expect(
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestStateCreatedEmpty.extensions,
             DataConversionERC20FeeAddData.actionAddRefundAddress,
             DataConversionERC20FeeCreate.requestStateCreatedEmpty,
@@ -542,9 +536,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       });
 
       it('cannot applyActionToExtensions of addRefundAddress without a previous state', () => {
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestStateNoExtensions.extensions,
             DataConversionERC20FeeAddData.actionAddRefundAddress,
             DataConversionERC20FeeCreate.requestStateNoExtensions,
@@ -557,9 +550,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       it('cannot applyActionToExtensions of addRefundAddress without a payer', () => {
         const previousState = Utils.deepCopy(DataConversionERC20FeeCreate.requestStateCreatedEmpty);
         previousState.payer = undefined;
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             previousState.extensions,
             DataConversionERC20FeeAddData.actionAddRefundAddress,
             previousState,
@@ -571,9 +563,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
 
       it('cannot applyActionToExtensions of addRefundAddress signed by someone else than the payer', () => {
         const previousState = Utils.deepCopy(DataConversionERC20FeeCreate.requestStateCreatedEmpty);
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             previousState.extensions,
             DataConversionERC20FeeAddData.actionAddRefundAddress,
             previousState,
@@ -584,9 +575,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       });
 
       it('cannot applyActionToExtensions of addRefundAddress with payment address already given', () => {
-        // 'must throw'
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestFullStateCreated.extensions,
             DataConversionERC20FeeAddData.actionAddRefundAddress,
             DataConversionERC20FeeCreate.requestFullStateCreated,
@@ -597,11 +587,13 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       });
 
       it('cannot applyActionToExtensions of addRefundAddress with refund address not valid', () => {
-        const testnetPaymentAddress = Utils.deepCopy(DataConversionERC20FeeAddData.actionAddRefundAddress);
-        testnetPaymentAddress.parameters.refundAddress = DataConversionERC20FeeAddData.invalidAddress;
-        // 'must throw'
+        const testnetPaymentAddress = Utils.deepCopy(
+          DataConversionERC20FeeAddData.actionAddRefundAddress,
+        );
+        testnetPaymentAddress.parameters.refundAddress =
+          DataConversionERC20FeeAddData.invalidAddress;
         expect(() => {
-          anyToErc20Proxy.applyActionToExtension(
+          new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
             DataConversionERC20FeeCreate.requestStateCreatedEmpty.extensions,
             testnetPaymentAddress,
             DataConversionERC20FeeCreate.requestStateCreatedEmpty,
@@ -617,7 +609,7 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     it('can applyActionToExtensions of addFee', () => {
       // 'new extension state wrong'
       expect(
-        anyToErc20Proxy.applyActionToExtension(
+        new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
           DataConversionERC20FeeCreate.requestStateCreatedEmpty.extensions,
           DataConversionERC20FeeAddData.actionAddFee,
           DataConversionERC20FeeCreate.requestStateCreatedEmpty,
@@ -628,9 +620,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     });
 
     it('cannot applyActionToExtensions of addFee without a previous state', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.applyActionToExtension(
+        new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
           DataConversionERC20FeeCreate.requestStateNoExtensions.extensions,
           DataConversionERC20FeeAddData.actionAddFee,
           DataConversionERC20FeeCreate.requestStateNoExtensions,
@@ -643,9 +634,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     it('cannot applyActionToExtensions of addFee without a payee', () => {
       const previousState = Utils.deepCopy(DataConversionERC20FeeCreate.requestStateCreatedEmpty);
       previousState.payee = undefined;
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.applyActionToExtension(
+        new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
           previousState.extensions,
           DataConversionERC20FeeAddData.actionAddFee,
           previousState,
@@ -657,9 +647,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
 
     it('cannot applyActionToExtensions of addFee signed by someone else than the payee', () => {
       const previousState = Utils.deepCopy(DataConversionERC20FeeCreate.requestStateCreatedEmpty);
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.applyActionToExtension(
+        new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
           previousState.extensions,
           DataConversionERC20FeeAddData.actionAddFee,
           previousState,
@@ -670,9 +659,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     });
 
     it('cannot applyActionToExtensions of addFee with fee data already given', () => {
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.applyActionToExtension(
+        new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
           DataConversionERC20FeeCreate.requestFullStateCreated.extensions,
           DataConversionERC20FeeAddData.actionAddFee,
           DataConversionERC20FeeCreate.requestFullStateCreated,
@@ -685,9 +673,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     it('cannot applyActionToExtensions of addFee with fee address not valid', () => {
       const testnetPaymentAddress = Utils.deepCopy(DataConversionERC20FeeAddData.actionAddFee);
       testnetPaymentAddress.parameters.feeAddress = DataConversionERC20FeeAddData.invalidAddress;
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.applyActionToExtension(
+        new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
           DataConversionERC20FeeCreate.requestStateCreatedEmpty.extensions,
           testnetPaymentAddress,
           DataConversionERC20FeeCreate.requestStateCreatedEmpty,
@@ -700,9 +687,8 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
     it('cannot applyActionToExtensions of addFee with fee amount not valid', () => {
       const testnetPaymentAddress = Utils.deepCopy(DataConversionERC20FeeAddData.actionAddFee);
       testnetPaymentAddress.parameters.feeAmount = DataConversionERC20FeeAddData.invalidAddress;
-      // 'must throw'
       expect(() => {
-        anyToErc20Proxy.applyActionToExtension(
+        new anyToErc20ProxyPaymentNetwork().applyActionToExtension(
           DataConversionERC20FeeCreate.requestStateCreatedEmpty.extensions,
           testnetPaymentAddress,
           DataConversionERC20FeeCreate.requestStateCreatedEmpty,
@@ -712,5 +698,4 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
       }).toThrowError('feeAmount is not a valid amount');
     });
   });
-
 });

--- a/packages/advanced-logic/test/utils/payment-network/erc20/any-to-erc20-proxy-add-data-generator.ts
+++ b/packages/advanced-logic/test/utils/payment-network/erc20/any-to-erc20-proxy-add-data-generator.ts
@@ -13,7 +13,7 @@ export const refundAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
 export const feeAddress = '0xC5fdf4076b8F3A5357c5E395ab970B5B54098Fef';
 export const feeAmount = '2000000000000000000';
 export const invalidAddress = '0x not and address';
-export const tokenAddress = '0x6b175474e89094c44da98b954eedeac495271d0f';
+export const tokenAddress = '0x9FBDa871d559710256a2502A2517b794B482Db40';
 // ---------------------------------------------------------------------
 export const salt = 'ea3bc7caf64110ca';
 // actions
@@ -47,7 +47,10 @@ export const extensionStateWithPaymentAfterCreation = {
     events: [
       {
         name: ExtensionTypes.PnFeeReferenceBased.ACTION.CREATE,
-        parameters: {},
+        parameters: {
+          network: 'private',
+          acceptedTokens: [tokenAddress],
+        },
         timestamp: arbitraryTimestamp,
       },
       {
@@ -61,6 +64,8 @@ export const extensionStateWithPaymentAfterCreation = {
     id: ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
     type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
     values: {
+      network: 'private',
+      acceptedTokens: [tokenAddress],
       paymentAddress,
     },
     version: '0.1.0',
@@ -72,7 +77,10 @@ export const extensionStateWithRefundAfterCreation = {
     events: [
       {
         name: ExtensionTypes.PnFeeReferenceBased.ACTION.CREATE,
-        parameters: {},
+        parameters: {
+          network: 'private',
+          acceptedTokens: [tokenAddress],
+        },
         timestamp: arbitraryTimestamp,
       },
       {
@@ -86,6 +94,8 @@ export const extensionStateWithRefundAfterCreation = {
     id: ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
     type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
     values: {
+      network: 'private',
+      acceptedTokens: [tokenAddress],
       refundAddress,
     },
     version: '0.1.0',
@@ -97,7 +107,10 @@ export const extensionStateWithFeeAfterCreation = {
     events: [
       {
         name: ExtensionTypes.PnFeeReferenceBased.ACTION.CREATE,
-        parameters: {},
+        parameters: {
+          network: 'private',
+          acceptedTokens: [tokenAddress],
+        },
         timestamp: arbitraryTimestamp,
       },
       {
@@ -112,6 +125,8 @@ export const extensionStateWithFeeAfterCreation = {
     id: ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
     type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
     values: {
+      network: 'private',
+      acceptedTokens: [tokenAddress],
       feeAddress,
       feeAmount,
     },

--- a/packages/advanced-logic/test/utils/payment-network/erc20/any-to-erc20-proxy-create-data-generator.ts
+++ b/packages/advanced-logic/test/utils/payment-network/erc20/any-to-erc20-proxy-create-data-generator.ts
@@ -11,7 +11,7 @@ export const refundAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
 export const feeAddress = '0xC5fdf4076b8F3A5357c5E395ab970B5B54098Fef';
 export const feeAmount = '2000000000000000000';
 export const invalidAddress = '0x not and address';
-export const tokenAddress = '0x6b175474e89094c44da98b954eedeac495271d0f';
+export const tokenAddress = '0x9FBDa871d559710256a2502A2517b794B482Db40';
 // ---------------------------------------------------------------------
 export const salt = 'ea3bc7caf64110ca';
 // actions
@@ -24,6 +24,7 @@ export const actionCreationFull = {
     paymentAddress,
     refundAddress,
     salt,
+    network: 'private',
     acceptedTokens: [tokenAddress],
   },
   version: '0.1.0',
@@ -33,6 +34,7 @@ export const actionCreationOnlyPayment = {
   id: ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
   parameters: {
     paymentAddress,
+    network: 'private',
     acceptedTokens: [tokenAddress],
   },
   version: '0.1.0',
@@ -42,6 +44,7 @@ export const actionCreationOnlyRefund = {
   id: ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
   parameters: {
     refundAddress,
+    network: 'private',
     acceptedTokens: [tokenAddress],
   },
   version: '0.1.0',
@@ -52,6 +55,7 @@ export const actionCreationOnlyFee = {
   parameters: {
     feeAddress,
     feeAmount,
+    network: 'private',
     acceptedTokens: [tokenAddress],
   },
   version: '0.1.0',
@@ -76,6 +80,7 @@ export const extensionFullState = {
           paymentAddress,
           refundAddress,
           salt,
+          network: 'private',
           acceptedTokens: [tokenAddress],
         },
         timestamp: arbitraryTimestamp,
@@ -89,6 +94,7 @@ export const extensionFullState = {
       paymentAddress,
       refundAddress,
       salt,
+      network: 'private',
       acceptedTokens: [tokenAddress],
     },
     version: '0.1.0',
@@ -99,13 +105,19 @@ export const extensionStateCreatedEmpty = {
     events: [
       {
         name: 'create',
-        parameters: {},
+        parameters: {
+          network: 'private',
+          acceptedTokens: [tokenAddress],
+        },
         timestamp: arbitraryTimestamp,
       },
     ],
     id: ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
     type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
-    values: {},
+    values: {
+      network: 'private',
+      acceptedTokens: [tokenAddress],
+    },
     version: '0.1.0',
   },
 };


### PR DESCRIPTION
## Description of the changes

* I initially wanted to make a first step towards payment network implementation with inheritance. The scope for this first step is the payment network "any to erc20".
* Some small mistakes in the tests were made more obvious by this change, I fixed them.
* It also made visible that default networks can be a pitfall

Overall, if we trim ~350 lines from `fee-proxy-contract.ts`, that's a +300 / -511 (diff stats) refactoring with ease of reading, testing and maintenability.

## Current status

TLDR: ignore `fee-proxy-contract.ts`
* The file `fee-proxy-contract.ts` contains both the former way and the new one (350 lines are +/- duplicated). It's easy to keep the new one, but let's first validate the change on "any-to-erc20". 
* `yarn lint` fails for missing documentation, that I add if we agree on the principle
