### PR TITLE
chore: Enums to Unions

### DIFF
--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -16,12 +16,16 @@ import { ISwapSettings } from './swap-erc20-fee-proxy';
 export const supportedNetworks = [
   ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT,
   ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT,
-  ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA
+  ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA,
 ];
 
 const getPaymentNetwork = (request: ClientTypes.IRequestData): ExtensionTypes.ID | undefined => {
   // tslint:disable-next-line: typedef
-  return Object.values(request.extensions).find(x => x.type === 'payment-network')?.id;
+  const pn = Object.values(request.extensions).find((x) => x.type === 'payment-network');
+  if (pn?.id === ExtensionTypes.ID.CONTENT_DATA) {
+    throw new Error('Extension is not a payment network');
+  }
+  return pn?.id;
 };
 
 /**
@@ -119,7 +123,7 @@ export async function hasSufficientFunds(
     address,
     request.currencyInfo,
     bigNumberify(request.expectedAmount).add(feeAmount),
-    provider
+    provider,
   );
 }
 
@@ -139,8 +143,9 @@ export async function isSolvent(
   provider: Provider,
 ): Promise<boolean> {
   const ethBalance = await provider.getBalance(fromAddress);
-  const needsGas  =  !['Safe Multisig WalletConnect', 'Gnosis Safe Multisig']
-    .includes((provider as any)?.provider?.wc?._peerMeta?.name);
+  const needsGas = !['Safe Multisig WalletConnect', 'Gnosis Safe Multisig'].includes(
+    (provider as any)?.provider?.wc?._peerMeta?.name,
+  );
 
   if (currency.type === 'ETH') {
     return ethBalance.gt(amount);
@@ -149,7 +154,6 @@ export async function isSolvent(
     return (ethBalance.gt(0) || !needsGas) && bigNumberify(balance).gte(amount);
   }
 }
-
 
 /**
  * Returns the balance of a given address in a given currency.
@@ -181,8 +185,10 @@ async function getCurrencyBalance(
  */
 export function canSwapToPay(request: ClientTypes.IRequestData): boolean {
   const paymentNetwork = getPaymentNetwork(request);
-  return (paymentNetwork !== undefined
-    && (paymentNetwork === ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT));
+  return (
+    paymentNetwork !== undefined &&
+    paymentNetwork === ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT
+  );
 }
 
 /**

--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -2,7 +2,7 @@ import { ContractTransaction, Signer } from 'ethers';
 import { Provider, Web3Provider } from 'ethers/providers';
 import { BigNumberish, bigNumberify } from 'ethers/utils';
 
-import { ClientTypes, ExtensionTypes } from '@requestnetwork/types';
+import { ClientTypes, ExtensionTypes, PaymentTypes } from '@requestnetwork/types';
 
 import { getBtcPaymentUrl } from './btc-address-based';
 import { _getErc20PaymentUrl, getAnyErc20Balance } from './erc20';
@@ -13,13 +13,15 @@ import { getNetworkProvider, getProvider, getSigner } from './utils';
 import { ICurrency } from '@requestnetwork/types/dist/request-logic-types';
 import { ISwapSettings } from './swap-erc20-fee-proxy';
 
-export const supportedNetworks = [
+export const supportedNetworks: PaymentTypes.PAYMENT_NETWORK_ID[] = [
   ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT,
   ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT,
   ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA,
 ];
 
-const getPaymentNetwork = (request: ClientTypes.IRequestData): ExtensionTypes.ID | undefined => {
+const getPaymentNetwork = (
+  request: ClientTypes.IRequestData,
+): PaymentTypes.PAYMENT_NETWORK_ID | undefined => {
   // tslint:disable-next-line: typedef
   const pn = Object.values(request.extensions).find((x) => x.type === 'payment-network');
   if (pn?.id === ExtensionTypes.ID.CONTENT_DATA) {

--- a/packages/types/src/data-access-types.ts
+++ b/packages/types/src/data-access-types.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import { EnumToType } from './shared';
 
 /** Data Access Layer */
 export interface IDataAccess {
@@ -23,11 +24,13 @@ export interface IDataAccess {
   _getStatus(detailed?: boolean): any;
 }
 
+export const TransactionState = {
+  PENDING: 'pending',
+  CONFIRMED: 'confirmed',
+} as const;
+
 /** Enum of state possible for an action */
-export enum TransactionState {
-  PENDING = 'pending',
-  CONFIRMED = 'confirmed',
-}
+export type TransactionState = EnumToType<typeof TransactionState>;
 
 /** Restrict the get data research to two timestamp */
 export interface ITimestampBoundaries {

--- a/packages/types/src/data-access-types.ts
+++ b/packages/types/src/data-access-types.ts
@@ -24,6 +24,7 @@ export interface IDataAccess {
   _getStatus(detailed?: boolean): any;
 }
 
+// tslint:disable variable-name
 export const TransactionState = {
   PENDING: 'pending',
   CONFIRMED: 'confirmed',

--- a/packages/types/src/encryption-types.ts
+++ b/packages/types/src/encryption-types.ts
@@ -1,3 +1,5 @@
+import { EnumToType } from './shared';
+
 /** Parameters needed to encrypt */
 export interface IEncryptionParameters {
   // method of the encryption
@@ -22,9 +24,11 @@ export interface IEncryptedData {
   value: string;
 }
 
+export const METHOD = {
+  ECIES: 'ecies',
+  AES256_CBC: 'aes256-cbc',
+  AES256_GCM: 'aes256-gcm',
+} as const;
+
 /** Supported encryption methods */
-export enum METHOD {
-  ECIES = 'ecies',
-  AES256_CBC = 'aes256-cbc',
-  AES256_GCM = 'aes256-gcm',
-}
+export type METHOD = EnumToType<typeof METHOD>;

--- a/packages/types/src/extension-types.ts
+++ b/packages/types/src/extension-types.ts
@@ -6,8 +6,16 @@ import * as PnReferenceBased from './extensions/pn-any-reference-based-types';
 import * as PnAnyToErc20 from './extensions/pn-any-to-er20-types';
 import * as Identity from './identity-types';
 import * as RequestLogic from './request-logic-types';
+import { EnumToType } from './shared';
 
-export { ContentData, PnAnyDeclarative, PnAddressBased, PnFeeReferenceBased, PnReferenceBased, PnAnyToErc20 };
+export {
+  ContentData,
+  PnAnyDeclarative,
+  PnAddressBased,
+  PnFeeReferenceBased,
+  PnReferenceBased,
+  PnAnyToErc20,
+};
 
 /** Extension interface is extended by the extensions implementation */
 export interface IExtension {
@@ -44,21 +52,25 @@ export interface IEvent {
   timestamp: number;
 }
 
+export const ID = {
+  CONTENT_DATA: 'content-data',
+  PAYMENT_NETWORK_BITCOIN_ADDRESS_BASED: 'pn-bitcoin-address-based',
+  PAYMENT_NETWORK_TESTNET_BITCOIN_ADDRESS_BASED: 'pn-testnet-bitcoin-address-based',
+  PAYMENT_NETWORK_ERC20_ADDRESS_BASED: 'pn-erc20-address-based',
+  PAYMENT_NETWORK_ERC20_PROXY_CONTRACT: 'pn-erc20-proxy-contract',
+  PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT: 'pn-erc20-fee-proxy-contract',
+  PAYMENT_NETWORK_ETH_INPUT_DATA: 'pn-eth-input-data',
+  PAYMENT_NETWORK_ANY_DECLARATIVE: 'pn-any-declarative',
+  PAYMENT_NETWORK_ANY_TO_ERC20_PROXY: 'pn-any-to-erc20-proxy',
+} as const;
+
 /** Identification of extensions handled by this implementation */
-export enum ID {
-  CONTENT_DATA = 'content-data',
-  PAYMENT_NETWORK_BITCOIN_ADDRESS_BASED = 'pn-bitcoin-address-based',
-  PAYMENT_NETWORK_TESTNET_BITCOIN_ADDRESS_BASED = 'pn-testnet-bitcoin-address-based',
-  PAYMENT_NETWORK_ERC20_ADDRESS_BASED = 'pn-erc20-address-based',
-  PAYMENT_NETWORK_ERC20_PROXY_CONTRACT = 'pn-erc20-proxy-contract',
-  PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT = 'pn-erc20-fee-proxy-contract',
-  PAYMENT_NETWORK_ETH_INPUT_DATA = 'pn-eth-input-data',
-  PAYMENT_NETWORK_ANY_DECLARATIVE = 'pn-any-declarative',
-  PAYMENT_NETWORK_ANY_TO_ERC20_PROXY = 'pn-any-to-erc20-proxy',
-}
+export type ID = EnumToType<typeof ID>;
+
+export const TYPE = {
+  CONTENT_DATA: 'content-data',
+  PAYMENT_NETWORK: 'payment-network',
+} as const;
 
 /** Type of extensions */
-export enum TYPE {
-  CONTENT_DATA = 'content-data',
-  PAYMENT_NETWORK = 'payment-network',
-}
+export type TYPE = EnumToType<typeof TYPE>;

--- a/packages/types/src/extensions/content-data-types.ts
+++ b/packages/types/src/extensions/content-data-types.ts
@@ -1,4 +1,5 @@
 import * as Extension from '../extension-types';
+import { EnumToType } from '../shared';
 
 /** Manager of the extension */
 export interface IContentData extends Extension.IExtension {
@@ -15,7 +16,9 @@ export interface ICreationParameters {
   content: any;
 }
 
+export const ACTION = {
+  CREATE: 'create',
+} as const;
+
 /** Actions possible */
-export enum ACTION {
-  CREATE = 'create',
-}
+export type ACTION = EnumToType<typeof ACTION>;

--- a/packages/types/src/extensions/pn-any-address-based-types.ts
+++ b/packages/types/src/extensions/pn-any-address-based-types.ts
@@ -1,4 +1,5 @@
 import * as Extension from '../extension-types';
+import { EnumToType } from '../shared';
 
 /** Manager of the extension */
 export interface IAddressBased extends Extension.IExtension {
@@ -34,9 +35,11 @@ export interface IAddRefundAddressParameters {
   refundAddress: string;
 }
 
+export const ACTION = {
+  CREATE: 'create',
+  ADD_PAYMENT_ADDRESS: 'addPaymentAddress',
+  ADD_REFUND_ADDRESS: 'addRefundAddress',
+} as const;
+
 /** Actions possible */
-export enum ACTION {
-  CREATE = 'create',
-  ADD_PAYMENT_ADDRESS = 'addPaymentAddress',
-  ADD_REFUND_ADDRESS = 'addRefundAddress',
-}
+export type ACTION = EnumToType<typeof ACTION>;

--- a/packages/types/src/extensions/pn-any-declarative-types.ts
+++ b/packages/types/src/extensions/pn-any-declarative-types.ts
@@ -1,5 +1,6 @@
 import * as Extension from '../extension-types';
 import * as RequestLogicTypes from '../request-logic-types';
+import { EnumToType } from '../shared';
 
 /** Manager of the extension */
 export interface IAnyDeclarative extends Extension.IExtension {
@@ -50,16 +51,18 @@ export interface IAddRefundInstructionParameters {
   refundInfo: any;
 }
 
+export const ACTION = {
+  CREATE: 'create',
+
+  DECLARE_SENT_PAYMENT: 'declareSentPayment',
+  DECLARE_RECEIVED_PAYMENT: 'declareReceivedPayment',
+
+  DECLARE_SENT_REFUND: 'declareSentRefund',
+  DECLARE_RECEIVED_REFUND: 'declareReceivedRefund',
+
+  ADD_PAYMENT_INSTRUCTION: 'addPaymentInstruction',
+  ADD_REFUND_INSTRUCTION: 'addRefundInstruction',
+} as const;
+
 /** Actions possible */
-export enum ACTION {
-  CREATE = 'create',
-
-  DECLARE_SENT_PAYMENT = 'declareSentPayment',
-  DECLARE_RECEIVED_PAYMENT = 'declareReceivedPayment',
-
-  DECLARE_SENT_REFUND = 'declareSentRefund',
-  DECLARE_RECEIVED_REFUND = 'declareReceivedRefund',
-
-  ADD_PAYMENT_INSTRUCTION = 'addPaymentInstruction',
-  ADD_REFUND_INSTRUCTION = 'addRefundInstruction',
-}
+export type ACTION = EnumToType<typeof ACTION>;

--- a/packages/types/src/extensions/pn-any-fee-reference-based-types.ts
+++ b/packages/types/src/extensions/pn-any-fee-reference-based-types.ts
@@ -1,4 +1,5 @@
 import * as Extension from '../extension-types';
+import { EnumToType } from '../shared';
 
 /** Fee reference-based payment network extension interface */
 export interface IFeeReferenceBased extends Extension.IExtension {
@@ -25,10 +26,12 @@ export interface IAddFeeParameters {
   feeAmount: string;
 }
 
+export const ACTION = {
+  CREATE: 'create',
+  ADD_PAYMENT_ADDRESS: 'addPaymentAddress',
+  ADD_REFUND_ADDRESS: 'addRefundAddress',
+  ADD_FEE: 'addFee',
+} as const;
+
 /** Actions specific to the fee payment networks */
-export enum ACTION {
-  CREATE = 'create',
-  ADD_PAYMENT_ADDRESS = 'addPaymentAddress',
-  ADD_REFUND_ADDRESS = 'addRefundAddress',
-  ADD_FEE = 'addFee',
-}
+export type ACTION = EnumToType<typeof ACTION>;

--- a/packages/types/src/extensions/pn-any-reference-based-types.ts
+++ b/packages/types/src/extensions/pn-any-reference-based-types.ts
@@ -1,4 +1,5 @@
 import * as Extension from '../extension-types';
+import { EnumToType } from '../shared';
 
 /** Manager of the extension */
 export interface IReferenceBased extends Extension.IExtension {
@@ -36,9 +37,11 @@ export interface IAddRefundAddressParameters {
   refundAddress: string;
 }
 
+export const ACTION = {
+  CREATE: 'create',
+  ADD_PAYMENT_ADDRESS: 'addPaymentAddress',
+  ADD_REFUND_ADDRESS: 'addRefundAddress',
+} as const;
+
 /** Actions possible */
-export enum ACTION {
-  CREATE = 'create',
-  ADD_PAYMENT_ADDRESS = 'addPaymentAddress',
-  ADD_REFUND_ADDRESS = 'addRefundAddress',
-}
+export type ACTION = EnumToType<typeof ACTION>;

--- a/packages/types/src/identity-types.ts
+++ b/packages/types/src/identity-types.ts
@@ -1,3 +1,5 @@
+import { EnumToType } from './shared';
+
 /** Identity */
 export interface IIdentity {
   // type of the identification
@@ -12,8 +14,10 @@ export interface ISmartContractIdentity extends IIdentity {
   network?: string;
 }
 
+export const TYPE = {
+  ETHEREUM_ADDRESS: 'ethereumAddress',
+  ETHEREUM_SMART_CONTRACT: 'ethereumSmartContract',
+} as const;
+
 /** Supported identity types */
-export enum TYPE {
-  ETHEREUM_ADDRESS = 'ethereumAddress',
-  ETHEREUM_SMART_CONTRACT = 'ethereumSmartContract',
-}
+export type TYPE = EnumToType<typeof TYPE>;

--- a/packages/types/src/multi-format/hash-types.ts
+++ b/packages/types/src/multi-format/hash-types.ts
@@ -1,3 +1,5 @@
+import { EnumToType } from '../shared';
+
 /** Hash */
 export interface IHash {
   // type of the hash
@@ -6,7 +8,9 @@ export interface IHash {
   value: string;
 }
 
+export const TYPE = {
+  KECCAK256: 'keccak256',
+} as const;
+
 /** Supported hash types */
-export enum TYPE {
-  KECCAK256 = 'keccak256',
-}
+export type TYPE = EnumToType<typeof TYPE>;

--- a/packages/types/src/multi-format/plain-types.ts
+++ b/packages/types/src/multi-format/plain-types.ts
@@ -1,3 +1,5 @@
+import { EnumToType } from '../shared';
+
 /** Plain data */
 export interface IPlainData {
   // type of the plain
@@ -6,7 +8,9 @@ export interface IPlainData {
   value: string;
 }
 
+export const TYPE = {
+  PLAIN_TEXT: 'plain-text',
+} as const;
+
 /** Supported types */
-export enum TYPE {
-  PLAIN_TEXT = 'plain-text',
-}
+export type TYPE = EnumToType<typeof TYPE>;

--- a/packages/types/src/payment-types.ts
+++ b/packages/types/src/payment-types.ts
@@ -1,4 +1,4 @@
-import * as Extension from './extension-types';
+import { EnumToType } from './shared';
 import * as RequestLogic from './request-logic-types';
 
 /** Object interface to list the payment network id and its module by currency */
@@ -88,23 +88,26 @@ export interface IPaymentNetworkEvent<TEventParameters> {
   timestamp?: number;
 }
 
+export const EVENTS_NAMES = {
+  PAYMENT: 'payment',
+  REFUND: 'refund',
+} as const;
 /** payment network event names */
-export enum EVENTS_NAMES {
-  PAYMENT = 'payment',
-  REFUND = 'refund',
-}
+export type EVENTS_NAMES = 'payment' | 'refund';
+
+export const PAYMENT_NETWORK_ID = {
+  BITCOIN_ADDRESS_BASED: 'pn-bitcoin-address-based',
+  TESTNET_BITCOIN_ADDRESS_BASED: 'pn-testnet-bitcoin-address-based',
+  ERC20_ADDRESS_BASED: 'pn-erc20-address-based',
+  ERC20_PROXY_CONTRACT: 'pn-erc20-proxy-contract',
+  ERC20_FEE_PROXY_CONTRACT: 'pn-erc20-fee-proxy-contract',
+  ETH_INPUT_DATA: 'pn-eth-input-data',
+  DECLARATIVE: 'pn-any-declarative',
+  ANY_TO_ERC20_PROXY: 'pn-any-to-erc20-proxy',
+} as const;
 
 /** List of payment networks available (abstract the extensions type) */
-export enum PAYMENT_NETWORK_ID {
-  BITCOIN_ADDRESS_BASED = Extension.ID.PAYMENT_NETWORK_BITCOIN_ADDRESS_BASED,
-  TESTNET_BITCOIN_ADDRESS_BASED = Extension.ID.PAYMENT_NETWORK_TESTNET_BITCOIN_ADDRESS_BASED,
-  ERC20_ADDRESS_BASED = Extension.ID.PAYMENT_NETWORK_ERC20_ADDRESS_BASED,
-  ERC20_PROXY_CONTRACT = Extension.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT,
-  ERC20_FEE_PROXY_CONTRACT = Extension.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT,
-  ETH_INPUT_DATA = Extension.ID.PAYMENT_NETWORK_ETH_INPUT_DATA,
-  DECLARATIVE = Extension.ID.PAYMENT_NETWORK_ANY_DECLARATIVE,
-  ANY_TO_ERC20_PROXY = Extension.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
-}
+export type PAYMENT_NETWORK_ID = EnumToType<typeof PAYMENT_NETWORK_ID>;
 
 /** Generic info retriever interface */
 export interface IPaymentNetworkInfoRetriever<

--- a/packages/types/src/request-logic-types.ts
+++ b/packages/types/src/request-logic-types.ts
@@ -5,6 +5,8 @@ import * as Extension from './extension-types';
 import * as Identity from './identity-types';
 import * as Signature from './signature-types';
 
+import { EnumToType } from './shared';
+
 /** Request Logic layer */
 export interface IRequestLogic {
   createRequest: (
@@ -246,37 +248,45 @@ export interface ICurrency {
   network?: string;
 }
 
+export const ACTION_NAME = {
+  CREATE: 'create',
+  BROADCAST: 'broadcastSignedRequest',
+  ACCEPT: 'accept',
+  CANCEL: 'cancel',
+  REDUCE_EXPECTED_AMOUNT: 'reduceExpectedAmount',
+  INCREASE_EXPECTED_AMOUNT: 'increaseExpectedAmount',
+  ADD_EXTENSIONS_DATA: 'addExtensionsData',
+} as const;
+
 /** Enum of name possible in a action */
-export enum ACTION_NAME {
-  CREATE = 'create',
-  BROADCAST = 'broadcastSignedRequest',
-  ACCEPT = 'accept',
-  CANCEL = 'cancel',
-  REDUCE_EXPECTED_AMOUNT = 'reduceExpectedAmount',
-  INCREASE_EXPECTED_AMOUNT = 'increaseExpectedAmount',
-  ADD_EXTENSIONS_DATA = 'addExtensionsData',
-}
+export type ACTION_NAME = EnumToType<typeof ACTION_NAME>;
+
+export const CURRENCY = {
+  ETH: 'ETH',
+  BTC: 'BTC',
+  ISO4217: 'ISO4217',
+  ERC20: 'ERC20',
+} as const;
 
 /** Supported currencies */
-export enum CURRENCY {
-  ETH = 'ETH',
-  BTC = 'BTC',
-  ISO4217 = 'ISO4217',
-  ERC20 = 'ERC20',
-}
+export type CURRENCY = EnumToType<typeof CURRENCY>;
+
+export const STATE = {
+  // use for upper layer (trick to avoid headache with retyping request in upper layer)
+  PENDING: 'pending',
+  CREATED: 'created',
+  ACCEPTED: 'accepted',
+  CANCELED: 'canceled',
+};
 
 /** States of a request */
-export enum STATE {
-  // use for upper layer (trick to avoid headache with retyping request in upper layer)
-  PENDING = 'pending',
-  CREATED = 'created',
-  ACCEPTED = 'accepted',
-  CANCELED = 'canceled',
-}
+export type STATE = EnumToType<typeof STATE>;
+
+export const ROLE = {
+  PAYEE: 'payee',
+  PAYER: 'payer',
+  THIRD_PARTY: 'third-party',
+};
 
 /** Identity roles */
-export enum ROLE {
-  PAYEE = 'payee',
-  PAYER = 'payer',
-  THIRD_PARTY = 'third-party',
-}
+export type ROLE = EnumToType<typeof ROLE>;

--- a/packages/types/src/shared.ts
+++ b/packages/types/src/shared.ts
@@ -1,0 +1,5 @@
+/**
+ * Utility to keep compatibility with Enum and generate a union type
+ * @see https://rlee.dev/writing/stop-misusing-typescript-string-enums
+ */
+export type EnumToType<T> = T[keyof T];

--- a/packages/types/src/signature-types.ts
+++ b/packages/types/src/signature-types.ts
@@ -1,3 +1,5 @@
+import { EnumToType } from './shared';
+
 /** Parameters needed to sign */
 export interface ISignatureParameters {
   // method of the signature
@@ -14,11 +16,13 @@ export interface ISignature {
   value: string;
 }
 
+export const METHOD = {
+  ECDSA: 'ecdsa',
+  ECDSA_ETHEREUM: 'ecdsa-ethereum',
+} as const;
+
 /** Supported signature methods */
-export enum METHOD {
-  ECDSA = 'ecdsa',
-  ECDSA_ETHEREUM = 'ecdsa-ethereum',
-}
+export type METHOD = EnumToType<typeof METHOD>;
 
 /** Signed data interface */
 export interface ISignedData {

--- a/packages/types/src/transaction-types.ts
+++ b/packages/types/src/transaction-types.ts
@@ -83,6 +83,7 @@ export interface IPersistedTransaction {
   encryptionMethod?: string;
 }
 
+// tslint:disable variable-name
 export const TransactionState = {
   PENDING: 'pending',
   CONFIRMED: 'confirmed',

--- a/packages/types/src/transaction-types.ts
+++ b/packages/types/src/transaction-types.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import * as Encryption from './encryption-types';
+import { EnumToType } from './shared';
 
 /** Transaction Manager interface */
 export interface ITransactionManager {
@@ -82,11 +83,13 @@ export interface IPersistedTransaction {
   encryptionMethod?: string;
 }
 
+export const TransactionState = {
+  PENDING: 'pending',
+  CONFIRMED: 'confirmed',
+} as const;
+
 /** Enum of state possible for an action */
-export enum TransactionState {
-  PENDING = 'pending',
-  CONFIRMED = 'confirmed',
-}
+export type TransactionState = EnumToType<typeof TransactionState>;
 
 /** Transaction confirmed */
 export interface ITimestampedTransaction {


### PR DESCRIPTION
Unions are more powerful than enums in TS.
To avoid breaking changes, we keep the export of the former enums as variables.

Recommended reading (and inspiration): https://rlee.dev/writing/stop-misusing-typescript-string-enums