### PR TITLE
chore: improve PN types

### DIFF
--- a/packages/payment-detection/test/payment-network-factory.test.ts
+++ b/packages/payment-detection/test/payment-network-factory.test.ts
@@ -14,7 +14,7 @@ const mockAdvancedLogic: AdvancedLogicTypes.IAdvancedLogic = {
   applyActionToExtensions(): any {
     return;
   },
-  extensions: {},
+  extensions: {} as any,
 };
 
 // Most of the tests are done as integration tests in ../index.test.ts
@@ -44,6 +44,7 @@ describe('api/payment-network/payment-network-factory', () => {
       const paymentNetworkCreationParameters: PaymentTypes.IPaymentNetworkCreateParameters = {
         id: PaymentTypes.PAYMENT_NETWORK_ID.DECLARATIVE,
         parameters: {
+          // @ts-ignore
           paymentAddress: 'bitcoin address here',
         },
       };

--- a/packages/request-client.js/test/data-test.ts
+++ b/packages/request-client.js/test/data-test.ts
@@ -188,7 +188,7 @@ export const actionRequestIdSecondRequest = MultiFormat.serialize(
 export const declarativePaymentNetwork: PaymentTypes.IPaymentNetworkCreateParameters = {
   id: PaymentTypes.PAYMENT_NETWORK_ID.DECLARATIVE,
   parameters: {
-    paymentInformation: {
+    paymentInfo: {
       BIC: 'SABAIE2D',
       IBAN: 'FR89370400440532013000',
     },

--- a/packages/types/src/payment-types.ts
+++ b/packages/types/src/payment-types.ts
@@ -45,10 +45,12 @@ export type IPaymentNetworkCreateParameters =
       };
     };
 
+/** Parameters to create a request with address based payment network */
 export interface IAddressBasedCreationParameters {
   paymentAddress?: string;
   refundAddress?: string;
 }
+
 /** Parameters to create a request with reference based payment network */
 export interface IReferenceBasedCreationParameters extends IAddressBasedCreationParameters {
   salt?: string;

--- a/packages/types/src/payment-types.ts
+++ b/packages/types/src/payment-types.ts
@@ -17,15 +17,40 @@ export interface IPaymentNetworkModuleByType {
 }
 
 /** Interface to create a payment network  */
-export interface IPaymentNetworkCreateParameters {
-  id: PAYMENT_NETWORK_ID;
-  parameters: any;
-}
+export type IPaymentNetworkCreateParameters =
+  | {
+      id: 'pn-eth-input-data' | 'pn-erc20-proxy-contract';
+      parameters: IReferenceBasedCreationParameters;
+    }
+  | {
+      id: 'pn-erc20-fee-proxy-contract';
+      parameters: IFeeReferenceBasedCreationParameters;
+    }
+  | {
+      id: 'pn-any-to-erc20-proxy';
+      parameters: IAnyToErc20CreationParameters;
+    }
+  | {
+      id:
+        | 'pn-bitcoin-address-based'
+        | 'pn-testnet-bitcoin-address-based'
+        | 'pn-erc20-address-based';
+      parameters: IAddressBasedCreationParameters;
+    }
+  | {
+      id: 'pn-any-declarative';
+      parameters: {
+        paymentInfo?: any;
+        refundInfo?: any;
+      };
+    };
 
-/** Parameters to create a request with reference based payment network */
-export interface IReferenceBasedCreationParameters {
+export interface IAddressBasedCreationParameters {
   paymentAddress?: string;
   refundAddress?: string;
+}
+/** Parameters to create a request with reference based payment network */
+export interface IReferenceBasedCreationParameters extends IAddressBasedCreationParameters {
   salt?: string;
 }
 

--- a/packages/usage-examples/src/request-client-js-declarative-request.ts
+++ b/packages/usage-examples/src/request-client-js-declarative-request.ts
@@ -36,7 +36,7 @@ const paymentNetwork: RequestNetwork.Types.Payment.IPaymentNetworkCreateParamete
   id: RequestNetwork.Types.Payment.PAYMENT_NETWORK_ID.DECLARATIVE,
   parameters: {
     // eslint-disable-next-line spellcheck/spell-checker
-    paymentInformation: { IBAN: 'FR89370400440532013000', BIC: 'SABAIE2D' },
+    paymentInfo: { IBAN: 'FR89370400440532013000', BIC: 'SABAIE2D' },
   },
 };
 


### PR DESCRIPTION
Strongly typing the Payment Network types will give type checking and autocompletion. 

The changes of this PR include some issues that were detected thanks to the strong typing