### PR TITLE
chore: migrate to ethers v5

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -44,7 +44,7 @@
     "bn.js": "5.1.3",
     "classnames": "2.2.6",
     "core-js": "3.6.5",
-    "ethers": "4.0.48",
+    "ethers": "5.0.32",
     "mobx": "6.0.4",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/packages/ethereum-storage/src/ethereum-utils.ts
+++ b/packages/ethereum-storage/src/ethereum-utils.ts
@@ -1,7 +1,7 @@
 import { StorageTypes } from '@requestnetwork/types';
 import * as config from './config';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 /**
  * Collection of utils functions related to Ethereum
@@ -31,9 +31,9 @@ export default {
    * @param gasPrice Value of the gas price
    * @returns True if the gas price can be used
    */
-  isGasPriceSafe(gasPrice: typeof bigNumber): boolean {
+  isGasPriceSafe(gasPrice: BigNumber): boolean {
     return (
-      gasPrice.gt(new bigNumber(0)) && gasPrice.lt(new bigNumber(config.getSafeGasPriceLimit()))
+      gasPrice.gt(new BigNumber(0)) && gasPrice.lt(new BigNumber(config.getSafeGasPriceLimit()))
     );
   },
 };

--- a/packages/ethereum-storage/src/gas-price-definer.ts
+++ b/packages/ethereum-storage/src/gas-price-definer.ts
@@ -7,7 +7,7 @@ import EthGasStationProvider from './gas-price-providers/ethgasstation-provider'
 import { LogTypes, StorageTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 /**
  * Determines the gas price to use depending on the used network
@@ -49,14 +49,14 @@ export default class GasPriceDefiner {
       networkName ===
       EthereumUtils.getEthereumNetworkNameFromId(StorageTypes.EthereumNetwork.MAINNET)
     ) {
-      const gasPriceArray: Array<typeof bigNumber> = await this.pollProviders(type);
+      const gasPriceArray: Array<BigNumber> = await this.pollProviders(type);
 
       if (gasPriceArray.length > 0) {
         // Get the highest gas price from the providers
         return gasPriceArray
           .reduce(
-            (currentMax, gasPrice: typeof bigNumber) => bigNumber.max(currentMax, gasPrice),
-            new bigNumber(0),
+            (currentMax, gasPrice: BigNumber) => BigNumber.max(currentMax, gasPrice),
+            new BigNumber(0),
           )
           .toString();
       } else {
@@ -76,14 +76,16 @@ export default class GasPriceDefiner {
    * @param type Gas price type (fast, standard or safe low)
    * @returns Array containing each gas price
    */
-  public async pollProviders(type: StorageTypes.GasPriceType): Promise<Array<typeof bigNumber>> {
-    const gasPriceArray: Array<typeof bigNumber> = [];
+  public async pollProviders(type: StorageTypes.GasPriceType): Promise<Array<BigNumber>> {
+    const gasPriceArray: Array<BigNumber> = [];
 
     for (const gasPriceProvider of this.gasPriceProviderList) {
       try {
         // Get the gas price from the provider
         const providerGasPrice = await gasPriceProvider.getGasPrice(type);
-        gasPriceArray.push(providerGasPrice);
+        if (providerGasPrice) {
+          gasPriceArray.push(providerGasPrice);
+        }
       } catch (err) {
         // If the function throws, it means the gas price provider is not available or the value sent is not valid
         this.logger.warn(err, ['ethereum', 'gas']);

--- a/packages/ethereum-storage/src/gas-price-providers/etherchain-provider.ts
+++ b/packages/ethereum-storage/src/gas-price-providers/etherchain-provider.ts
@@ -7,7 +7,7 @@ import fetch from 'node-fetch';
 
 /* eslint-disable spellcheck/spell-checker */
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 // Maximum number of api requests to retry when an error is encountered (ECONNRESET, EPIPE, ENOTFOUND)
 const ETHERCHAIN_REQUEST_MAX_RETRY: number = 3;
@@ -31,7 +31,7 @@ export default class EtherchainProvider implements StorageTypes.IGasPriceProvide
    * Fetch library to send http requests
    * This value is left public for mocking purpose
    */
-  public fetch: typeof fetch = fetch;
+  public fetch = fetch;
 
   /**
    * Gets gas price from etherchain.org API
@@ -39,7 +39,7 @@ export default class EtherchainProvider implements StorageTypes.IGasPriceProvide
    * @param type Type of the gas price (fast, standard or safe low)
    * @returns Requested gas price
    */
-  public async getGasPrice(type: StorageTypes.GasPriceType): Promise<typeof bigNumber | null> {
+  public async getGasPrice(type: StorageTypes.GasPriceType): Promise<BigNumber | null> {
     const res = await Utils.retry(async () => this.fetch(this.providerUrl), {
       maxRetries: ETHERCHAIN_REQUEST_MAX_RETRY,
       retryDelay: ETHERCHAIN_REQUEST_RETRY_DELAY,
@@ -66,7 +66,7 @@ export default class EtherchainProvider implements StorageTypes.IGasPriceProvide
     }
 
     // Retrieve the gas price from the provided gas price type and the format of the API response
-    const apiGasPrice = new bigNumber(
+    const apiGasPrice = new BigNumber(
       parseFloat(
         {
           [StorageTypes.GasPriceType.FAST]: apiResponse.fast,

--- a/packages/ethereum-storage/src/gas-price-providers/etherscan-provider.ts
+++ b/packages/ethereum-storage/src/gas-price-providers/etherscan-provider.ts
@@ -7,7 +7,7 @@ import fetch from 'node-fetch';
 
 /* eslint-disable spellcheck/spell-checker */
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 // Maximum number of api requests to retry when an error is encountered (ECONNRESET, EPIPE, ENOTFOUND)
 const ETHERSCAN_REQUEST_MAX_RETRY: number = 3;
@@ -31,7 +31,7 @@ export default class EtherscanProvider implements StorageTypes.IGasPriceProvider
    * Fetch library to send http requests
    * This value is left public for mocking purpose
    */
-  public fetch: typeof fetch = fetch;
+  public fetch = fetch;
 
   /**
    * Gets gas price from etherscan.io API
@@ -39,7 +39,7 @@ export default class EtherscanProvider implements StorageTypes.IGasPriceProvider
    * @param type Type of the gas price (fast, standard or safe low)
    * @returns Requested gas price
    */
-  public async getGasPrice(type: StorageTypes.GasPriceType): Promise<typeof bigNumber | null> {
+  public async getGasPrice(type: StorageTypes.GasPriceType): Promise<BigNumber | null> {
     const res = await Utils.retry(async () => this.fetch(this.providerUrl), {
       maxRetries: ETHERSCAN_REQUEST_MAX_RETRY,
       retryDelay: ETHERSCAN_REQUEST_RETRY_DELAY,
@@ -73,7 +73,7 @@ export default class EtherscanProvider implements StorageTypes.IGasPriceProvider
     }
 
     // Retrieve the gas price from the provided gas price type and the format of the API response
-    const apiGasPrice = new bigNumber(
+    const apiGasPrice = new BigNumber(
       parseInt(
         {
           [StorageTypes.GasPriceType.FAST]: result.FastGasPrice,

--- a/packages/ethereum-storage/src/gas-price-providers/ethgasstation-provider.ts
+++ b/packages/ethereum-storage/src/gas-price-providers/ethgasstation-provider.ts
@@ -4,9 +4,7 @@ import { StorageTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import fetch from 'node-fetch';
 
-/* eslint-disable spellcheck/spell-checker */
-
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 // Maximum number of api requests to retry when an error is encountered (ECONNRESET, EPIPE, ENOTFOUND)
 const ETHGASSTATION_REQUEST_MAX_RETRY: number = 3;
@@ -30,7 +28,7 @@ export default class EthGasStationProvider implements StorageTypes.IGasPriceProv
    * Fetch library to send http requests
    * This value is left public for mocking purpose
    */
-  public fetch: typeof fetch = fetch;
+  public fetch = fetch;
 
   /**
    * Gets gas price from ethgasstation.org API
@@ -38,7 +36,7 @@ export default class EthGasStationProvider implements StorageTypes.IGasPriceProv
    * @param type Type of the gas price (fast, standard or safe low)
    * @returns Requested gas price
    */
-  public async getGasPrice(type: StorageTypes.GasPriceType): Promise<typeof bigNumber | null> {
+  public async getGasPrice(type: StorageTypes.GasPriceType): Promise<BigNumber | null> {
     const res = await Utils.retry(async () => this.fetch(this.providerUrl), {
       maxRetries: ETHGASSTATION_REQUEST_MAX_RETRY,
       retryDelay: ETHGASSTATION_RETRY_DELAY,
@@ -65,7 +63,7 @@ export default class EthGasStationProvider implements StorageTypes.IGasPriceProv
     }
 
     // Retrieve the gas price from the provided gas price type and the format of the API response
-    const apiGasPrice = new bigNumber(
+    const apiGasPrice = new BigNumber(
       parseFloat(
         {
           [StorageTypes.GasPriceType.FAST]: apiResponse.fast,

--- a/packages/ethereum-storage/test/ethereum-utils.test.ts
+++ b/packages/ethereum-storage/test/ethereum-utils.test.ts
@@ -2,25 +2,25 @@ import { StorageTypes } from '@requestnetwork/types';
 import { getSafeGasPriceLimit } from '../src/config';
 import EthereumUtils from '../src/ethereum-utils';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 /* tslint:disable:no-unused-expression */
 
 describe('Ethereum Utils', () => {
   describe('getEthereumNetworkNameFromId', () => {
     it('allows to get the correct network name', async () => {
-      expect(
-        EthereumUtils.getEthereumNetworkNameFromId(StorageTypes.EthereumNetwork.PRIVATE),
-      ).toBe('private');
-      expect(
-        EthereumUtils.getEthereumNetworkNameFromId(StorageTypes.EthereumNetwork.MAINNET),
-      ).toBe('mainnet');
-      expect(
-        EthereumUtils.getEthereumNetworkNameFromId(StorageTypes.EthereumNetwork.KOVAN),
-      ).toBe('kovan');
-      expect(
-        EthereumUtils.getEthereumNetworkNameFromId(StorageTypes.EthereumNetwork.RINKEBY),
-      ).toBe('rinkeby');
+      expect(EthereumUtils.getEthereumNetworkNameFromId(StorageTypes.EthereumNetwork.PRIVATE)).toBe(
+        'private',
+      );
+      expect(EthereumUtils.getEthereumNetworkNameFromId(StorageTypes.EthereumNetwork.MAINNET)).toBe(
+        'mainnet',
+      );
+      expect(EthereumUtils.getEthereumNetworkNameFromId(StorageTypes.EthereumNetwork.KOVAN)).toBe(
+        'kovan',
+      );
+      expect(EthereumUtils.getEthereumNetworkNameFromId(StorageTypes.EthereumNetwork.RINKEBY)).toBe(
+        'rinkeby',
+      );
     });
 
     it(`should return undefined if the network doesn't exist`, async () => {
@@ -30,14 +30,18 @@ describe('Ethereum Utils', () => {
 
   describe('isGasPriceSafe', () => {
     it('should return true when a safe value is given', async () => {
-      expect(EthereumUtils.isGasPriceSafe(new bigNumber(1))).toBe(true);
-      expect(EthereumUtils.isGasPriceSafe(new bigNumber(1000))).toBe(true);
-      expect(EthereumUtils.isGasPriceSafe(new bigNumber(parseInt(getSafeGasPriceLimit()) - 1))).toBe(true);
+      expect(EthereumUtils.isGasPriceSafe(new BigNumber(1))).toBe(true);
+      expect(EthereumUtils.isGasPriceSafe(new BigNumber(1000))).toBe(true);
+      expect(
+        EthereumUtils.isGasPriceSafe(new BigNumber(parseInt(getSafeGasPriceLimit()) - 1)),
+      ).toBe(true);
     });
 
     it('should return false when an unsafe value is given', async () => {
-      expect(EthereumUtils.isGasPriceSafe(new bigNumber(0))).toBe(false);
-      expect(EthereumUtils.isGasPriceSafe(new bigNumber(parseInt(getSafeGasPriceLimit())))).toBe(false);
+      expect(EthereumUtils.isGasPriceSafe(new BigNumber(0))).toBe(false);
+      expect(EthereumUtils.isGasPriceSafe(new BigNumber(parseInt(getSafeGasPriceLimit())))).toBe(
+        false,
+      );
     });
   });
 });

--- a/packages/ethereum-storage/test/gas-price-definer.test.ts
+++ b/packages/ethereum-storage/test/gas-price-definer.test.ts
@@ -28,7 +28,7 @@ describe('GasPriceDefiner', () => {
     it('returns default gas price from config if no provider is available', async () => {
       gasPriceDefiner.pollProviders = async (
         _type: StorageTypes.GasPriceType,
-      ): Promise<BigNumber> => [];
+      ): Promise<BigNumber[]> => Promise.resolve([]);
       const gasPrice = await gasPriceDefiner.getGasPrice(
         StorageTypes.GasPriceType.STANDARD,
         EthereumUtils.getEthereumNetworkNameFromId(StorageTypes.EthereumNetwork.MAINNET),

--- a/packages/ethereum-storage/test/gas-price-definer.test.ts
+++ b/packages/ethereum-storage/test/gas-price-definer.test.ts
@@ -6,7 +6,7 @@ import EthereumUtils from '../src/ethereum-utils';
 import * as config from '../src/config';
 import GasPriceDefiner from '../src/gas-price-definer';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 let gasPriceDefiner: GasPriceDefiner;
 
@@ -28,7 +28,7 @@ describe('GasPriceDefiner', () => {
     it('returns default gas price from config if no provider is available', async () => {
       gasPriceDefiner.pollProviders = async (
         _type: StorageTypes.GasPriceType,
-      ): Promise<typeof bigNumber> => [];
+      ): Promise<BigNumber> => [];
       const gasPrice = await gasPriceDefiner.getGasPrice(
         StorageTypes.GasPriceType.STANDARD,
         EthereumUtils.getEthereumNetworkNameFromId(StorageTypes.EthereumNetwork.MAINNET),
@@ -40,28 +40,28 @@ describe('GasPriceDefiner', () => {
     it('returns the max of values returned by providers', async () => {
       gasPriceDefiner.gasPriceProviderList = [
         {
-          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<typeof bigNumber> =>
-            new bigNumber(100),
+          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<BigNumber> =>
+            new BigNumber(100),
           providerUrl: '',
         },
         {
-          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<typeof bigNumber> =>
-            new bigNumber(200),
+          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<BigNumber> =>
+            new BigNumber(200),
           providerUrl: '',
         },
         {
-          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<typeof bigNumber> =>
-            new bigNumber(300),
+          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<BigNumber> =>
+            new BigNumber(300),
           providerUrl: '',
         },
         {
-          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<typeof bigNumber> =>
-            new bigNumber(40),
+          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<BigNumber> =>
+            new BigNumber(40),
           providerUrl: '',
         },
         {
-          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<typeof bigNumber> =>
-            new bigNumber(300),
+          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<BigNumber> =>
+            new BigNumber(300),
           providerUrl: '',
         },
       ];
@@ -79,23 +79,23 @@ describe('GasPriceDefiner', () => {
     it('returns an array containing value from each provider', async () => {
       gasPriceDefiner.gasPriceProviderList = [
         {
-          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<typeof bigNumber> =>
-            new bigNumber(100),
+          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<BigNumber> =>
+            new BigNumber(100),
           providerUrl: '',
         },
         {
-          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<typeof bigNumber> =>
-            new bigNumber(500),
+          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<BigNumber> =>
+            new BigNumber(500),
           providerUrl: '',
         },
         {
-          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<typeof bigNumber> =>
-            new bigNumber(200),
+          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<BigNumber> =>
+            new BigNumber(200),
           providerUrl: '',
         },
         {
-          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<typeof bigNumber> =>
-            new bigNumber(300000),
+          getGasPrice: async (_type: StorageTypes.GasPriceType): Promise<BigNumber> =>
+            new BigNumber(300000),
           providerUrl: '',
         },
       ];
@@ -103,10 +103,10 @@ describe('GasPriceDefiner', () => {
       await expect(
         gasPriceDefiner.pollProviders(StorageTypes.GasPriceType.STANDARD),
       ).resolves.toEqual([
-        new bigNumber(100),
-        new bigNumber(500),
-        new bigNumber(200),
-        new bigNumber(300000),
+        new BigNumber(100),
+        new BigNumber(500),
+        new BigNumber(200),
+        new BigNumber(300000),
       ]);
     });
 

--- a/packages/ethereum-storage/test/gas-price-providers/etherchain-provider.test.ts
+++ b/packages/ethereum-storage/test/gas-price-providers/etherchain-provider.test.ts
@@ -6,7 +6,7 @@ import EtherchainProvider from '../../src/gas-price-providers/etherchain-provide
 
 import * as fetchMock from 'fetch-mock';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 let etherchainProvider: EtherchainProvider;
 
@@ -50,14 +50,14 @@ describe('EtherchainProvider', () => {
       // Test with each gas price type
       await expect(
         etherchainProvider.getGasPrice(StorageTypes.GasPriceType.SAFELOW),
-      ).resolves.toEqual(new bigNumber(1000000000));
+      ).resolves.toEqual(new BigNumber(1000000000));
 
       await expect(
         etherchainProvider.getGasPrice(StorageTypes.GasPriceType.STANDARD),
-      ).resolves.toEqual(new bigNumber(3500000000));
+      ).resolves.toEqual(new BigNumber(3500000000));
 
       await expect(etherchainProvider.getGasPrice(StorageTypes.GasPriceType.FAST)).resolves.toEqual(
-        new bigNumber(7000000000),
+        new BigNumber(7000000000),
       );
     });
 

--- a/packages/ethereum-storage/test/gas-price-providers/etherscan-provider.test.ts
+++ b/packages/ethereum-storage/test/gas-price-providers/etherscan-provider.test.ts
@@ -4,7 +4,7 @@ import EtherscanProvider from '../../src/gas-price-providers/etherscan-provider'
 
 import * as fetchMock from 'fetch-mock';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 let etherscanProvider: EtherscanProvider;
 
@@ -71,14 +71,14 @@ describe('EtherscanProvider', () => {
       // Test with each gas price type
       await expect(
         etherscanProvider.getGasPrice(StorageTypes.GasPriceType.SAFELOW),
-      ).resolves.toEqual(new bigNumber(10000000000));
+      ).resolves.toEqual(new BigNumber(10000000000));
 
       await expect(
         etherscanProvider.getGasPrice(StorageTypes.GasPriceType.STANDARD),
-      ).resolves.toEqual(new bigNumber(35000000000));
+      ).resolves.toEqual(new BigNumber(35000000000));
 
       await expect(etherscanProvider.getGasPrice(StorageTypes.GasPriceType.FAST)).resolves.toEqual(
-        new bigNumber(70000000000),
+        new BigNumber(70000000000),
       );
     });
 

--- a/packages/ethereum-storage/test/gas-price-providers/ethgasstation-provider.test.ts
+++ b/packages/ethereum-storage/test/gas-price-providers/ethgasstation-provider.test.ts
@@ -6,7 +6,7 @@ import EthGasStationProvider from '../../src/gas-price-providers/ethgasstation-p
 
 import * as fetchMock from 'fetch-mock';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 let ethGasStationProvider: EthGasStationProvider;
 
@@ -50,15 +50,15 @@ describe('EtherchainProvider', () => {
       // Test with each gas price type
       await expect(
         ethGasStationProvider.getGasPrice(StorageTypes.GasPriceType.SAFELOW),
-      ).resolves.toEqual(new bigNumber(1000000000));
+      ).resolves.toEqual(new BigNumber(1000000000));
 
       await expect(
         ethGasStationProvider.getGasPrice(StorageTypes.GasPriceType.STANDARD),
-      ).resolves.toEqual(new bigNumber(3050000000));
+      ).resolves.toEqual(new BigNumber(3050000000));
 
       await expect(
         ethGasStationProvider.getGasPrice(StorageTypes.GasPriceType.FAST),
-      ).resolves.toEqual(new bigNumber(7000000000));
+      ).resolves.toEqual(new BigNumber(7000000000));
     });
 
     it('throws when API is not available', async () => {

--- a/packages/payment-detection/package.json
+++ b/packages/payment-detection/package.json
@@ -45,7 +45,7 @@
     "@requestnetwork/utils": "0.30.0",
     "axios": "0.21.1",
     "bn.js": "5.1.3",
-    "ethers": "4.0.48",
+    "ethers": "5.0.32",
     "node-fetch": "2.6.1",
     "satoshi-bitcoin": "1.0.4"
   },

--- a/packages/payment-detection/package.json
+++ b/packages/payment-detection/package.json
@@ -44,13 +44,11 @@
     "@requestnetwork/types": "0.30.0",
     "@requestnetwork/utils": "0.30.0",
     "axios": "0.21.1",
-    "bn.js": "5.1.3",
     "ethers": "5.0.32",
     "node-fetch": "2.6.1",
     "satoshi-bitcoin": "1.0.4"
   },
   "devDependencies": {
-    "@types/bn.js": "4.11.6",
     "@types/jest": "26.0.13",
     "@typescript-eslint/parser": "4.1.1",
     "eslint": "7.9.0",

--- a/packages/payment-detection/src/any/any-to-erc20-proxy-contract.ts
+++ b/packages/payment-detection/src/any/any-to-erc20-proxy-contract.ts
@@ -12,7 +12,7 @@ import PaymentNetworkERC20FeeProxyContract, {
 import PaymentReferenceCalculator from '../payment-reference-calculator';
 import ProxyInfoRetriever from './any-to-erc20-proxy-info-retriever';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 // tslint:disable:max-classes-per-file
 /** Exception when network not supported */
@@ -146,7 +146,7 @@ export default class PaymentNetworkAnyToERC20 extends PaymentNetworkERC20FeeProx
     const events = await infoRetriever.getTransferEvents();
 
     const balance = events
-      .reduce((acc, event) => acc.add(new bigNumber(event.amount)), new bigNumber(0))
+      .reduce((acc, event) => acc.add(new BigNumber(event.amount)), new BigNumber(0))
       .toString();
 
     return {

--- a/packages/payment-detection/src/any/any-to-erc20-proxy-contract.ts
+++ b/packages/payment-detection/src/any/any-to-erc20-proxy-contract.ts
@@ -12,7 +12,7 @@ import PaymentNetworkERC20FeeProxyContract, {
 import PaymentReferenceCalculator from '../payment-reference-calculator';
 import ProxyInfoRetriever from './any-to-erc20-proxy-info-retriever';
 
-import * as BigNumber from 'bn.js';
+import { BigNumber } from 'ethers';
 
 // tslint:disable:max-classes-per-file
 /** Exception when network not supported */
@@ -146,7 +146,7 @@ export default class PaymentNetworkAnyToERC20 extends PaymentNetworkERC20FeeProx
     const events = await infoRetriever.getTransferEvents();
 
     const balance = events
-      .reduce((acc, event) => acc.add(new BigNumber(event.amount)), new BigNumber(0))
+      .reduce((acc, event) => acc.add(BigNumber.from(event.amount)), BigNumber.from(0))
       .toString();
 
     return {

--- a/packages/payment-detection/src/any/any-to-erc20-proxy-info-retriever.ts
+++ b/packages/payment-detection/src/any/any-to-erc20-proxy-info-retriever.ts
@@ -1,6 +1,7 @@
 import { getDecimalsForCurrency, getCurrencyHash } from '@requestnetwork/currency';
 import { PaymentTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { ethers } from 'ethers';
+import { getDefaultProvider } from '../provider';
 
 // The conversion proxy smart contract ABI fragment containing TransferWithConversionAndReference event
 const erc20ConversionProxyContractAbiFragment = [
@@ -44,10 +45,7 @@ export default class ProxyERC20InfoRetriever
     private maxRateTimespan: number = 0,
   ) {
     // Creates a local or default provider
-    this.provider =
-      this.network === 'private'
-        ? new ethers.providers.JsonRpcProvider()
-        : ethers.getDefaultProvider(this.network);
+    this.provider = getDefaultProvider(this.network);
 
     // Setup the conversion proxy contract interface
     this.contractConversionProxy = new ethers.Contract(

--- a/packages/payment-detection/src/btc/address-based.ts
+++ b/packages/payment-detection/src/btc/address-based.ts
@@ -2,7 +2,7 @@ import { ExtensionTypes, PaymentTypes, RequestLogicTypes } from '@requestnetwork
 
 import getBalanceErrorObject from '../balance-error';
 import DefaultBitcoinDetectionProvider from './default-bitcoin-detection-provider';
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 /**
  * Handle payment networks with BTC based address extension
@@ -107,8 +107,8 @@ export default class PaymentNetworkBTCAddressBased {
         );
       }
 
-      const balance: string = new bigNumber(new bigNumber(payments.balance || 0))
-        .sub(new bigNumber(refunds.balance || 0))
+      const balance: string = new BigNumber(new BigNumber(payments.balance || 0))
+        .sub(new BigNumber(refunds.balance || 0))
         .toString();
 
       const events: PaymentTypes.BTCPaymentNetworkEvent[] = [

--- a/packages/payment-detection/src/btc/address-based.ts
+++ b/packages/payment-detection/src/btc/address-based.ts
@@ -2,7 +2,7 @@ import { ExtensionTypes, PaymentTypes, RequestLogicTypes } from '@requestnetwork
 
 import getBalanceErrorObject from '../balance-error';
 import DefaultBitcoinDetectionProvider from './default-bitcoin-detection-provider';
-import * as BigNumber from 'bn.js';
+import { BigNumber } from 'ethers';
 
 /**
  * Handle payment networks with BTC based address extension
@@ -107,8 +107,8 @@ export default class PaymentNetworkBTCAddressBased {
         );
       }
 
-      const balance: string = new BigNumber(new BigNumber(payments.balance || 0))
-        .sub(new BigNumber(refunds.balance || 0))
+      const balance: string = BigNumber.from(BigNumber.from(payments.balance || 0))
+        .sub(BigNumber.from(refunds.balance || 0))
         .toString();
 
       const events: PaymentTypes.BTCPaymentNetworkEvent[] = [

--- a/packages/payment-detection/src/btc/default-providers/blockchain-info.ts
+++ b/packages/payment-detection/src/btc/default-providers/blockchain-info.ts
@@ -2,8 +2,7 @@ import { PaymentTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import fetch from 'node-fetch';
 
-import * as BigNumber from 'bn.js';
-
+import { BigNumber } from 'ethers';
 /* eslint-disable spellcheck/spell-checker */
 
 // Maximum number of api requests to retry when an error is encountered (ECONNRESET, EPIPE, ENOTFOUND)
@@ -93,7 +92,7 @@ export default class BlockchainInfo implements PaymentTypes.IBitcoinDetectionPro
     eventName: PaymentTypes.EVENTS_NAMES,
   ): PaymentTypes.BTCBalanceWithEvents {
     const address = addressInfo.address;
-    const balance = new BigNumber(addressInfo.total_received).toString();
+    const balance = BigNumber.from(addressInfo.total_received).toString();
 
     const events: PaymentTypes.BTCPaymentNetworkEvent[] = addressInfo.txs
       // exclude the transactions coming from the same address

--- a/packages/payment-detection/src/btc/default-providers/blockchain-info.ts
+++ b/packages/payment-detection/src/btc/default-providers/blockchain-info.ts
@@ -2,7 +2,7 @@ import { PaymentTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import fetch from 'node-fetch';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 /* eslint-disable spellcheck/spell-checker */
 
@@ -93,7 +93,7 @@ export default class BlockchainInfo implements PaymentTypes.IBitcoinDetectionPro
     eventName: PaymentTypes.EVENTS_NAMES,
   ): PaymentTypes.BTCBalanceWithEvents {
     const address = addressInfo.address;
-    const balance = new bigNumber(addressInfo.total_received).toString();
+    const balance = new BigNumber(addressInfo.total_received).toString();
 
     const events: PaymentTypes.BTCPaymentNetworkEvent[] = addressInfo.txs
       // exclude the transactions coming from the same address

--- a/packages/payment-detection/src/btc/default-providers/blockcypher-com.ts
+++ b/packages/payment-detection/src/btc/default-providers/blockcypher-com.ts
@@ -1,7 +1,7 @@
 import { PaymentTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import fetch from 'node-fetch';
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 /* eslint-disable spellcheck/spell-checker */
 
@@ -61,7 +61,7 @@ export default class BlockcypherCom implements PaymentTypes.IBitcoinDetectionPro
     addressInfo: any,
     eventName: PaymentTypes.EVENTS_NAMES,
   ): PaymentTypes.BTCBalanceWithEvents {
-    const balance = new bigNumber(addressInfo.total_received).toString();
+    const balance = new BigNumber(addressInfo.total_received).toString();
 
     // Retrieves all the transaction hash of the transactions having as input the current address
     const inputTxHashes = addressInfo.txrefs

--- a/packages/payment-detection/src/btc/default-providers/blockcypher-com.ts
+++ b/packages/payment-detection/src/btc/default-providers/blockcypher-com.ts
@@ -1,7 +1,7 @@
 import { PaymentTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import fetch from 'node-fetch';
-import * as BigNumber from 'bn.js';
+import { BigNumber } from 'ethers';
 
 /* eslint-disable spellcheck/spell-checker */
 
@@ -61,7 +61,7 @@ export default class BlockcypherCom implements PaymentTypes.IBitcoinDetectionPro
     addressInfo: any,
     eventName: PaymentTypes.EVENTS_NAMES,
   ): PaymentTypes.BTCBalanceWithEvents {
-    const balance = new BigNumber(addressInfo.total_received).toString();
+    const balance = BigNumber.from(addressInfo.total_received).toString();
 
     // Retrieves all the transaction hash of the transactions having as input the current address
     const inputTxHashes = addressInfo.txrefs

--- a/packages/payment-detection/src/btc/default-providers/blockstream-info.ts
+++ b/packages/payment-detection/src/btc/default-providers/blockstream-info.ts
@@ -1,7 +1,7 @@
 import { PaymentTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import fetch from 'node-fetch';
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 /* eslint-disable spellcheck/spell-checker */
 
@@ -125,8 +125,8 @@ export default class BlockstreamInfo implements PaymentTypes.IBitcoinDetectionPr
 
     const balance: string = events
       .reduce((balanceAccumulator: any, event: PaymentTypes.BTCPaymentNetworkEvent) => {
-        return balanceAccumulator.add(new bigNumber(event.amount));
-      }, new bigNumber('0'))
+        return balanceAccumulator.add(new BigNumber(event.amount));
+      }, new BigNumber('0'))
       .toString();
 
     return { balance, events };

--- a/packages/payment-detection/src/btc/default-providers/blockstream-info.ts
+++ b/packages/payment-detection/src/btc/default-providers/blockstream-info.ts
@@ -1,7 +1,7 @@
 import { PaymentTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import fetch from 'node-fetch';
-import * as BigNumber from 'bn.js';
+import { BigNumber } from 'ethers';
 
 /* eslint-disable spellcheck/spell-checker */
 
@@ -125,8 +125,8 @@ export default class BlockstreamInfo implements PaymentTypes.IBitcoinDetectionPr
 
     const balance: string = events
       .reduce((balanceAccumulator: any, event: PaymentTypes.BTCPaymentNetworkEvent) => {
-        return balanceAccumulator.add(new BigNumber(event.amount));
-      }, new BigNumber('0'))
+        return balanceAccumulator.add(BigNumber.from(event.amount));
+      }, BigNumber.from('0'))
       .toString();
 
     return { balance, events };

--- a/packages/payment-detection/src/btc/default-providers/chain-so.ts
+++ b/packages/payment-detection/src/btc/default-providers/chain-so.ts
@@ -2,7 +2,7 @@ import { PaymentTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import fetch from 'node-fetch';
 const converterBTC = require('satoshi-bitcoin');
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 /* eslint-disable spellcheck/spell-checker */
 
@@ -87,8 +87,8 @@ export default class ChainSo implements PaymentTypes.IBitcoinDetectionProvider {
     // Compute the balance making the sum of all the transactions amount
     const balance: string = events
       .reduce((balanceAccumulator: any, event: PaymentTypes.BTCPaymentNetworkEvent) => {
-        return balanceAccumulator.add(new bigNumber(event.amount));
-      }, new bigNumber('0'))
+        return balanceAccumulator.add(new BigNumber(event.amount));
+      }, new BigNumber('0'))
       .toString();
 
     return { balance, events };

--- a/packages/payment-detection/src/btc/default-providers/chain-so.ts
+++ b/packages/payment-detection/src/btc/default-providers/chain-so.ts
@@ -2,7 +2,7 @@ import { PaymentTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import fetch from 'node-fetch';
 const converterBTC = require('satoshi-bitcoin');
-import * as BigNumber from 'bn.js';
+import { BigNumber } from 'ethers';
 
 /* eslint-disable spellcheck/spell-checker */
 
@@ -87,8 +87,8 @@ export default class ChainSo implements PaymentTypes.IBitcoinDetectionProvider {
     // Compute the balance making the sum of all the transactions amount
     const balance: string = events
       .reduce((balanceAccumulator: any, event: PaymentTypes.BTCPaymentNetworkEvent) => {
-        return balanceAccumulator.add(new BigNumber(event.amount));
-      }, new BigNumber('0'))
+        return balanceAccumulator.add(BigNumber.from(event.amount));
+      }, BigNumber.from('0'))
       .toString();
 
     return { balance, events };

--- a/packages/payment-detection/src/declarative.ts
+++ b/packages/payment-detection/src/declarative.ts
@@ -4,7 +4,7 @@ import {
   PaymentTypes,
   RequestLogicTypes,
 } from '@requestnetwork/types';
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 /**
  * Handle payment networks with declarative requests extension
@@ -134,17 +134,17 @@ export default class PaymentNetworkDeclarative
   public async getBalance(
     request: RequestLogicTypes.IRequest,
   ): Promise<PaymentTypes.DeclarativeBalanceWithEvents> {
-    let balance = new bigNumber(0);
+    let balance = new BigNumber(0);
     const events: PaymentTypes.DeclarativePaymentNetworkEvent[] = [];
 
     // For each extension data related to the declarative payment network,
     // we check if the data is a declared received payment or refund and we modify the balance
     // Received payment increase the balance and received refund decrease the balance
-    request.extensions[PaymentTypes.PAYMENT_NETWORK_ID.DECLARATIVE].events.forEach(data => {
+    request.extensions[PaymentTypes.PAYMENT_NETWORK_ID.DECLARATIVE].events.forEach((data) => {
       const parameters = data.parameters;
       if (data.name === ExtensionTypes.PnAnyDeclarative.ACTION.DECLARE_RECEIVED_PAYMENT) {
         // Declared received payments from payee is added to the balance
-        balance = balance.add(new bigNumber(parameters.amount));
+        balance = balance.add(new BigNumber(parameters.amount));
         events.push({
           amount: parameters.amount,
           name: PaymentTypes.EVENTS_NAMES.PAYMENT,
@@ -157,7 +157,7 @@ export default class PaymentNetworkDeclarative
         parameters.timestamp = data.timestamp;
 
         // The balance is subtracted from declared received refunds from payer
-        balance = balance.sub(new bigNumber(parameters.amount));
+        balance = balance.sub(new BigNumber(parameters.amount));
         events.push({
           amount: parameters.amount,
           name: PaymentTypes.EVENTS_NAMES.REFUND,

--- a/packages/payment-detection/src/declarative.ts
+++ b/packages/payment-detection/src/declarative.ts
@@ -4,7 +4,7 @@ import {
   PaymentTypes,
   RequestLogicTypes,
 } from '@requestnetwork/types';
-import * as BigNumber from 'bn.js';
+import { BigNumber } from 'ethers';
 
 /**
  * Handle payment networks with declarative requests extension
@@ -134,7 +134,7 @@ export default class PaymentNetworkDeclarative
   public async getBalance(
     request: RequestLogicTypes.IRequest,
   ): Promise<PaymentTypes.DeclarativeBalanceWithEvents> {
-    let balance = new BigNumber(0);
+    let balance = BigNumber.from(0);
     const events: PaymentTypes.DeclarativePaymentNetworkEvent[] = [];
 
     // For each extension data related to the declarative payment network,
@@ -144,7 +144,7 @@ export default class PaymentNetworkDeclarative
       const parameters = data.parameters;
       if (data.name === ExtensionTypes.PnAnyDeclarative.ACTION.DECLARE_RECEIVED_PAYMENT) {
         // Declared received payments from payee is added to the balance
-        balance = balance.add(new BigNumber(parameters.amount));
+        balance = balance.add(BigNumber.from(parameters.amount));
         events.push({
           amount: parameters.amount,
           name: PaymentTypes.EVENTS_NAMES.PAYMENT,
@@ -157,7 +157,7 @@ export default class PaymentNetworkDeclarative
         parameters.timestamp = data.timestamp;
 
         // The balance is subtracted from declared received refunds from payer
-        balance = balance.sub(new BigNumber(parameters.amount));
+        balance = balance.sub(BigNumber.from(parameters.amount));
         events.push({
           amount: parameters.amount,
           name: PaymentTypes.EVENTS_NAMES.REFUND,

--- a/packages/payment-detection/src/erc20/address-based-info-retriever.ts
+++ b/packages/payment-detection/src/erc20/address-based-info-retriever.ts
@@ -1,5 +1,6 @@
 import { PaymentTypes } from '@requestnetwork/types';
 import { ethers } from 'ethers';
+import { getDefaultProvider } from '../provider';
 
 // The ERC20 smart contract ABI fragment containing decimals property and Transfer event
 const erc20BalanceOfAbiFragment = [
@@ -66,10 +67,7 @@ export default class ERC20InfoRetriever
    */
   public async getTransferEvents(): Promise<PaymentTypes.ERC20PaymentNetworkEvent[]> {
     // Creates a local or default provider
-    const provider =
-      this.network === 'private'
-        ? new ethers.providers.JsonRpcProvider()
-        : ethers.getDefaultProvider(this.network);
+    const provider = getDefaultProvider(this.network);
 
     // Setup the ERC20 contract interface
     const contract = new ethers.Contract(

--- a/packages/payment-detection/src/erc20/address-based-info-retriever.ts
+++ b/packages/payment-detection/src/erc20/address-based-info-retriever.ts
@@ -87,19 +87,19 @@ export default class ERC20InfoRetriever
     const logs = await provider.getLogs(filter);
 
     // Clean up the Transfer logs data
-    const eventPromises = logs.map(async log => {
+    const eventPromises = logs.map(async (log) => {
       if (!log.blockNumber) {
         throw new Error('Block number not found');
       }
       const block = await provider.getBlock(log.blockNumber);
       const parsedLog = contract.interface.parseLog(log);
       return {
-        amount: parsedLog.values.value.toString(),
+        amount: parsedLog.args.value.toString(),
         name: this.eventName,
         parameters: {
           block: block.number,
-          from: parsedLog.values.from,
-          to: parsedLog.values.to,
+          from: parsedLog.args.from,
+          to: parsedLog.args.to,
           txHash: log.transactionHash,
         },
         timestamp: block.timestamp,

--- a/packages/payment-detection/src/erc20/address-based.ts
+++ b/packages/payment-detection/src/erc20/address-based.ts
@@ -7,7 +7,7 @@ import {
 import getBalanceErrorObject from '../balance-error';
 import Erc20InfoRetriever from './address-based-info-retriever';
 
-import * as BigNumber from 'bn.js';
+import { BigNumber } from 'ethers';
 const supportedNetworks = ['mainnet', 'rinkeby', 'private'];
 
 /**
@@ -116,8 +116,8 @@ export default class PaymentNetworkERC20AddressBased
         );
       }
 
-      const balance: string = new BigNumber(payments.balance || 0)
-        .sub(new BigNumber(refunds.balance || 0))
+      const balance: string = BigNumber.from(payments.balance || 0)
+        .sub(BigNumber.from(refunds.balance || 0))
         .toString();
 
       const events: PaymentTypes.ERC20PaymentNetworkEvent[] = [
@@ -154,7 +154,7 @@ export default class PaymentNetworkERC20AddressBased
     const events = await infoRetriever.getTransferEvents();
 
     const balance = events
-      .reduce((acc, event) => acc.add(new BigNumber(event.amount)), new BigNumber(0))
+      .reduce((acc, event) => acc.add(BigNumber.from(event.amount)), BigNumber.from(0))
       .toString();
 
     return {

--- a/packages/payment-detection/src/erc20/address-based.ts
+++ b/packages/payment-detection/src/erc20/address-based.ts
@@ -7,7 +7,7 @@ import {
 import getBalanceErrorObject from '../balance-error';
 import Erc20InfoRetriever from './address-based-info-retriever';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 const supportedNetworks = ['mainnet', 'rinkeby', 'private'];
 
 /**
@@ -116,8 +116,8 @@ export default class PaymentNetworkERC20AddressBased
         );
       }
 
-      const balance: string = new bigNumber(payments.balance || 0)
-        .sub(new bigNumber(refunds.balance || 0))
+      const balance: string = new BigNumber(payments.balance || 0)
+        .sub(new BigNumber(refunds.balance || 0))
         .toString();
 
       const events: PaymentTypes.ERC20PaymentNetworkEvent[] = [
@@ -154,7 +154,7 @@ export default class PaymentNetworkERC20AddressBased
     const events = await infoRetriever.getTransferEvents();
 
     const balance = events
-      .reduce((acc, event) => acc.add(new bigNumber(event.amount)), new bigNumber(0))
+      .reduce((acc, event) => acc.add(new BigNumber(event.amount)), new BigNumber(0))
       .toString();
 
     return {

--- a/packages/payment-detection/src/erc20/fee-proxy-contract.ts
+++ b/packages/payment-detection/src/erc20/fee-proxy-contract.ts
@@ -10,7 +10,7 @@ import getBalanceErrorObject from '../balance-error';
 import PaymentReferenceCalculator from '../payment-reference-calculator';
 import ProxyInfoRetriever from './proxy-info-retriever';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 // tslint:disable:max-classes-per-file
 /** Exception when network not supported */
@@ -163,8 +163,8 @@ export default class PaymentNetworkERC20FeeProxyContract<
       // a better place to retrieve them from the request object them.
       paymentNetwork.values.feeBalance = fees;
 
-      const balance: string = new bigNumber(payments.balance || 0)
-        .sub(new bigNumber(refunds.balance || 0))
+      const balance: string = new BigNumber(payments.balance || 0)
+        .sub(new BigNumber(refunds.balance || 0))
         .toString();
 
       const events: PaymentTypes.ERC20PaymentNetworkEvent[] = [
@@ -248,7 +248,7 @@ export default class PaymentNetworkERC20FeeProxyContract<
     const events = await infoRetriever.getTransferEvents();
 
     const balance = events
-      .reduce((acc, event) => acc.add(new bigNumber(event.amount)), new bigNumber(0))
+      .reduce((acc, event) => acc.add(new BigNumber(event.amount)), new BigNumber(0))
       .toString();
 
     return {
@@ -289,8 +289,8 @@ export default class PaymentNetworkERC20FeeProxyContract<
         }
 
         feeBalance = {
-          balance: new bigNumber(feeBalance.balance)
-            .add(new bigNumber(event.parameters.feeAmount))
+          balance: new BigNumber(feeBalance.balance)
+            .add(new BigNumber(event.parameters.feeAmount))
             .toString(),
           events: [...feeBalance.events, event],
         };

--- a/packages/payment-detection/src/erc20/fee-proxy-contract.ts
+++ b/packages/payment-detection/src/erc20/fee-proxy-contract.ts
@@ -10,7 +10,7 @@ import getBalanceErrorObject from '../balance-error';
 import PaymentReferenceCalculator from '../payment-reference-calculator';
 import ProxyInfoRetriever from './proxy-info-retriever';
 
-import * as BigNumber from 'bn.js';
+import { BigNumber } from 'ethers';
 
 // tslint:disable:max-classes-per-file
 /** Exception when network not supported */
@@ -163,8 +163,8 @@ export default class PaymentNetworkERC20FeeProxyContract<
       // a better place to retrieve them from the request object them.
       paymentNetwork.values.feeBalance = fees;
 
-      const balance: string = new BigNumber(payments.balance || 0)
-        .sub(new BigNumber(refunds.balance || 0))
+      const balance: string = BigNumber.from(payments.balance || 0)
+        .sub(BigNumber.from(refunds.balance || 0))
         .toString();
 
       const events: PaymentTypes.ERC20PaymentNetworkEvent[] = [
@@ -248,7 +248,7 @@ export default class PaymentNetworkERC20FeeProxyContract<
     const events = await infoRetriever.getTransferEvents();
 
     const balance = events
-      .reduce((acc, event) => acc.add(new BigNumber(event.amount)), new BigNumber(0))
+      .reduce((acc, event) => acc.add(BigNumber.from(event.amount)), BigNumber.from(0))
       .toString();
 
     return {
@@ -289,8 +289,8 @@ export default class PaymentNetworkERC20FeeProxyContract<
         }
 
         feeBalance = {
-          balance: new BigNumber(feeBalance.balance)
-            .add(new BigNumber(event.parameters.feeAmount))
+          balance: BigNumber.from(feeBalance.balance)
+            .add(BigNumber.from(event.parameters.feeAmount))
             .toString(),
           events: [...feeBalance.events, event],
         };

--- a/packages/payment-detection/src/erc20/proxy-contract.ts
+++ b/packages/payment-detection/src/erc20/proxy-contract.ts
@@ -9,7 +9,7 @@ import getBalanceErrorObject from '../balance-error';
 import PaymentReferenceCalculator from '../payment-reference-calculator';
 import ProxyInfoRetriever from './proxy-info-retriever';
 
-import * as BigNumber from 'bn.js';
+import { BigNumber } from 'ethers';
 
 // tslint:disable:max-classes-per-file
 /** Exception when network not supported */
@@ -148,8 +148,8 @@ export default class PaymentNetworkERC20ProxyContract implements PaymentTypes.IP
         );
       }
 
-      const balance: string = new BigNumber(payments.balance || 0)
-        .sub(new BigNumber(refunds.balance || 0))
+      const balance: string = BigNumber.from(payments.balance || 0)
+        .sub(BigNumber.from(refunds.balance || 0))
         .toString();
 
       const events: PaymentTypes.ERC20PaymentNetworkEvent[] = [
@@ -233,7 +233,7 @@ export default class PaymentNetworkERC20ProxyContract implements PaymentTypes.IP
     const events = await infoRetriever.getTransferEvents();
 
     const balance = events
-      .reduce((acc, event) => acc.add(new BigNumber(event.amount)), new BigNumber(0))
+      .reduce((acc, event) => acc.add(BigNumber.from(event.amount)), BigNumber.from(0))
       .toString();
 
     return {

--- a/packages/payment-detection/src/erc20/proxy-contract.ts
+++ b/packages/payment-detection/src/erc20/proxy-contract.ts
@@ -9,7 +9,7 @@ import getBalanceErrorObject from '../balance-error';
 import PaymentReferenceCalculator from '../payment-reference-calculator';
 import ProxyInfoRetriever from './proxy-info-retriever';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 // tslint:disable:max-classes-per-file
 /** Exception when network not supported */
@@ -148,8 +148,8 @@ export default class PaymentNetworkERC20ProxyContract implements PaymentTypes.IP
         );
       }
 
-      const balance: string = new bigNumber(payments.balance || 0)
-        .sub(new bigNumber(refunds.balance || 0))
+      const balance: string = new BigNumber(payments.balance || 0)
+        .sub(new BigNumber(refunds.balance || 0))
         .toString();
 
       const events: PaymentTypes.ERC20PaymentNetworkEvent[] = [
@@ -233,7 +233,7 @@ export default class PaymentNetworkERC20ProxyContract implements PaymentTypes.IP
     const events = await infoRetriever.getTransferEvents();
 
     const balance = events
-      .reduce((acc, event) => acc.add(new bigNumber(event.amount)), new bigNumber(0))
+      .reduce((acc, event) => acc.add(new BigNumber(event.amount)), new BigNumber(0))
       .toString();
 
     return {

--- a/packages/payment-detection/src/erc20/proxy-info-retriever.ts
+++ b/packages/payment-detection/src/erc20/proxy-info-retriever.ts
@@ -85,25 +85,24 @@ export default class ProxyERC20InfoRetriever
     // Parses, filters and creates the events from the logs with the payment reference
     const eventPromises = logs
       // Parses the logs
-      .map(log => {
+      .map((log) => {
         const parsedLog = this.contractProxy.interface.parseLog(log);
         return { parsedLog, log };
       })
       // Keeps only the log with the right token and the right destination address
       .filter(
-        log =>
-          log.parsedLog.values.tokenAddress.toLowerCase() ===
-            this.tokenContractAddress.toLowerCase() &&
-          log.parsedLog.values.to.toLowerCase() === this.toAddress.toLowerCase(),
+        (log) =>
+          log.parsedLog.args[0].toLowerCase() === this.tokenContractAddress.toLowerCase() &&
+          log.parsedLog.args[1].toLowerCase() === this.toAddress.toLowerCase(),
       )
       // Creates the balance events
-      .map(async t => ({
-        amount: t.parsedLog.values.amount.toString(),
+      .map(async (t) => ({
+        amount: t.parsedLog.args[2].toString(),
         name: this.eventName,
         parameters: {
           block: t.log.blockNumber,
-          feeAddress: t.parsedLog.values.feeAddress || undefined,
-          feeAmount: t.parsedLog.values.feeAmount?.toString() || undefined,
+          feeAddress: t.parsedLog.args[5] || undefined,
+          feeAmount: t.parsedLog.args[4]?.toString() || undefined,
           to: this.toAddress,
           txHash: t.log.transactionHash,
         },

--- a/packages/payment-detection/src/erc20/proxy-info-retriever.ts
+++ b/packages/payment-detection/src/erc20/proxy-info-retriever.ts
@@ -1,5 +1,6 @@
 import { PaymentTypes } from '@requestnetwork/types';
-import { ethers, getDefaultProvider } from 'ethers';
+import { ethers } from 'ethers';
+import { getDefaultProvider } from '../provider';
 
 // The ERC20 proxy smart contract ABI fragment containing TransferWithReference event
 const erc20proxyContractAbiFragment = [

--- a/packages/payment-detection/src/erc20/proxy-info-retriever.ts
+++ b/packages/payment-detection/src/erc20/proxy-info-retriever.ts
@@ -1,5 +1,5 @@
 import { PaymentTypes } from '@requestnetwork/types';
-import { ethers } from 'ethers';
+import { ethers, getDefaultProvider } from 'ethers';
 
 // The ERC20 proxy smart contract ABI fragment containing TransferWithReference event
 const erc20proxyContractAbiFragment = [
@@ -34,10 +34,7 @@ export default class ProxyERC20InfoRetriever
     private network: string,
   ) {
     // Creates a local or default provider
-    this.provider =
-      this.network === 'private'
-        ? new ethers.providers.JsonRpcProvider()
-        : ethers.getDefaultProvider(this.network);
+    this.provider = getDefaultProvider(this.network);
 
     // Setup the ERC20 proxy contract interface
     this.contractProxy = new ethers.Contract(

--- a/packages/payment-detection/src/eth/info-retriever.ts
+++ b/packages/payment-detection/src/eth/info-retriever.ts
@@ -33,15 +33,15 @@ export default class ETHInfoRetriever
     const events = history
       // keep only when address is the destination
       .filter(
-        transaction =>
+        (transaction) =>
           transaction.to && transaction.to.toLowerCase() === this.toAddress.toLowerCase(),
       )
       // keep only if data contains the payment reference
       .filter(
-        transaction =>
+        (transaction) =>
           transaction.data.toLowerCase() === '0x' + this.paymentReference.toLowerCase(),
       )
-      .map(transaction => ({
+      .map((transaction) => ({
         amount: transaction.value.toString(),
         name: this.eventName,
         parameters: {

--- a/packages/payment-detection/src/eth/input-data.ts
+++ b/packages/payment-detection/src/eth/input-data.ts
@@ -12,7 +12,7 @@ import PaymentReferenceCalculator from '../payment-reference-calculator';
 import EthInputDataInfoRetriever from './info-retriever';
 import EthProxyInputDataInfoRetriever from './proxy-info-retriever';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 const supportedNetworks = ['mainnet', 'rinkeby', 'private'];
 
 // interface of the object indexing the proxy contract version
@@ -114,9 +114,7 @@ export default class PaymentNetworkETHInputData
 
     if (!paymentNetwork) {
       return getBalanceErrorObject(
-        `The request does not have the extension: ${
-          ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA
-        }`,
+        `The request does not have the extension: ${ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA}`,
         PaymentTypes.BALANCE_ERROR_CODE.WRONG_EXTENSION,
       );
     }
@@ -157,8 +155,8 @@ export default class PaymentNetworkETHInputData
         );
       }
 
-      const balance: string = new bigNumber(payments.balance || 0)
-        .sub(new bigNumber(refunds.balance || 0))
+      const balance: string = new BigNumber(payments.balance || 0)
+        .sub(new BigNumber(refunds.balance || 0))
         .toString();
 
       const events: PaymentTypes.ETHPaymentNetworkEvent[] = [
@@ -233,7 +231,7 @@ export default class PaymentNetworkETHInputData
           (a.timestamp || 0) - (b.timestamp || 0),
       );
     const balance = events
-      .reduce((acc, event) => acc.add(new bigNumber(event.amount)), new bigNumber(0))
+      .reduce((acc, event) => acc.add(new BigNumber(event.amount)), new BigNumber(0))
       .toString();
 
     return {

--- a/packages/payment-detection/src/eth/input-data.ts
+++ b/packages/payment-detection/src/eth/input-data.ts
@@ -12,7 +12,7 @@ import PaymentReferenceCalculator from '../payment-reference-calculator';
 import EthInputDataInfoRetriever from './info-retriever';
 import EthProxyInputDataInfoRetriever from './proxy-info-retriever';
 
-import * as BigNumber from 'bn.js';
+import { BigNumber } from 'ethers';
 const supportedNetworks = ['mainnet', 'rinkeby', 'private'];
 
 // interface of the object indexing the proxy contract version
@@ -155,8 +155,8 @@ export default class PaymentNetworkETHInputData
         );
       }
 
-      const balance: string = new BigNumber(payments.balance || 0)
-        .sub(new BigNumber(refunds.balance || 0))
+      const balance: string = BigNumber.from(payments.balance || 0)
+        .sub(BigNumber.from(refunds.balance || 0))
         .toString();
 
       const events: PaymentTypes.ETHPaymentNetworkEvent[] = [
@@ -231,7 +231,7 @@ export default class PaymentNetworkETHInputData
           (a.timestamp || 0) - (b.timestamp || 0),
       );
     const balance = events
-      .reduce((acc, event) => acc.add(new BigNumber(event.amount)), new BigNumber(0))
+      .reduce((acc, event) => acc.add(BigNumber.from(event.amount)), BigNumber.from(0))
       .toString();
 
     return {

--- a/packages/payment-detection/src/eth/proxy-info-retriever.ts
+++ b/packages/payment-detection/src/eth/proxy-info-retriever.ts
@@ -63,15 +63,15 @@ export default class ProxyEthereumInfoRetriever
     // Parses, filters and creates the events from the logs of the proxy contract
     const eventPromises = logs
       // Parses the logs
-      .map(log => {
+      .map((log) => {
         const parsedLog = this.contractProxy.interface.parseLog(log);
         return { parsedLog, log };
       })
       // Keeps only the log with the right token and the right destination address
-      .filter(log => log.parsedLog.values.to.toLowerCase() === this.toAddress.toLowerCase())
+      .filter((log) => log.parsedLog.args[0].toLowerCase() === this.toAddress.toLowerCase())
       // Creates the balance events
-      .map(async t => ({
-        amount: t.parsedLog.values.amount.toString(),
+      .map(async (t) => ({
+        amount: t.parsedLog.args[1].toString(),
         name: this.eventName,
         parameters: {
           block: t.log.blockNumber,

--- a/packages/payment-detection/src/eth/proxy-info-retriever.ts
+++ b/packages/payment-detection/src/eth/proxy-info-retriever.ts
@@ -1,5 +1,6 @@
 import { PaymentTypes } from '@requestnetwork/types';
 import { ethers } from 'ethers';
+import { getDefaultProvider } from '../provider';
 
 // The Ethereum proxy smart contract ABI fragment containing TransferWithReference event
 const ethProxyContractAbiFragment = [
@@ -31,10 +32,7 @@ export default class ProxyEthereumInfoRetriever
     private network: string,
   ) {
     // Creates a local or default provider
-    this.provider =
-      this.network === 'private'
-        ? new ethers.providers.JsonRpcProvider()
-        : ethers.getDefaultProvider(this.network);
+    this.provider = getDefaultProvider(this.network);
 
     // Setup the Ethereum proxy contract interface
     this.contractProxy = new ethers.Contract(

--- a/packages/payment-detection/src/index.ts
+++ b/packages/payment-detection/src/index.ts
@@ -5,6 +5,7 @@ import * as BtcPaymentNetwork from './btc';
 import DeclarativePaymentNetwork from './declarative';
 import * as Erc20PaymentNetwork from './erc20';
 import * as EthPaymentNetwork from './eth';
+import { initPaymentDetectionProvider, getDefaultProvider } from './provider';
 
 export {
   PaymentNetworkFactory,
@@ -13,4 +14,6 @@ export {
   DeclarativePaymentNetwork,
   Erc20PaymentNetwork,
   EthPaymentNetwork,
+  initPaymentDetectionProvider,
+  getDefaultProvider,
 };

--- a/packages/payment-detection/src/provider.ts
+++ b/packages/payment-detection/src/provider.ts
@@ -1,0 +1,21 @@
+import { ethers } from 'ethers';
+
+let configuration = {
+  // fallback to Ethers v4 default projectId
+  infura: process.env.RN_INFURA_KEY || '7d0d81d0919f4f05b9ab6634be01ee73',
+};
+
+export const initPaymentDetectionProvider = (config: Partial<typeof configuration>) => {
+  configuration = { ...configuration, ...config };
+};
+
+export const getDefaultProvider = (network?: string | ethers.providers.Network | undefined) => {
+  if (network === 'private') {
+    return new ethers.providers.JsonRpcProvider();
+  }
+  if (configuration.infura) {
+    return new ethers.providers.InfuraProvider(network, process.env.RN_INFURA_KEY);
+  }
+
+  return ethers.getDefaultProvider(network);
+};

--- a/packages/payment-detection/test/any/any-to-erc20-proxy-info-retriever.test.ts
+++ b/packages/payment-detection/test/any/any-to-erc20-proxy-info-retriever.test.ts
@@ -7,7 +7,7 @@ import { ethers } from 'ethers';
 const erc20LocalhostContractAddress = '0x38cF23C52Bb4B13F051Aec09580a2dE845a7FA35';
 const conversionProxyContractAddress = '0x2C2B9C9a4a25e24B174f26114e8926a9f2128FE4';
 const erc20FeeProxyContractAddress = '0x75c35C980C0d37ef46DF04d31A140b65503c0eEd';
-const paymentReferenceMock = '0111111111111111111111111111111111111111111111111';
+const paymentReferenceMock = '01111111111111111111111111111111111111111111111111';
 const acceptedTokens = [erc20LocalhostContractAddress];
 const USDCurrency = { type: RequestLogicTypes.CURRENCY.ISO4217, value: 'USD' };
 
@@ -54,6 +54,7 @@ describe('api/any/conversion-proxy-info-retriever', () => {
         ],
         transactionHash: '0x08fa12d6647053fc1ff21179ec1b16d3825144cb3840957f98830b8e416516f1',
         logIndex: 4,
+        removed: false, // TODO ??
       };
 
       proxyConversionLog = {
@@ -69,6 +70,7 @@ describe('api/any/conversion-proxy-info-retriever', () => {
         ],
         transactionHash: '0x08fa12d6647053fc1ff21179ec1b16d3825144cb3840957f98830b8e416516f1',
         logIndex: 5,
+        removed: false, // TODO ??
       };
       infoRetriever = new AnyToErc20ProxyInfoRetriever(
         USDCurrency,

--- a/packages/payment-detection/test/erc20/proxy-info-retriever.test.ts
+++ b/packages/payment-detection/test/erc20/proxy-info-retriever.test.ts
@@ -7,7 +7,7 @@ import { ethers } from 'ethers';
 const erc20LocalhostContractAddress = '0x9FBDa871d559710256a2502A2517b794B482Db40';
 const proxyContractAddress = '0x2C2B9C9a4a25e24B174f26114e8926a9f2128FE4';
 const feeProxyContractAddress = '0x75c35C980C0d37ef46DF04d31A140b65503c0eEd';
-const paymentReferenceMock = '0111111111111111111111111111111111111111111111111';
+const paymentReferenceMock = '01111111111111111111111111111111111111111111111111';
 
 /* tslint:disable:no-unused-expression */
 describe('api/erc20/proxy-info-retriever', () => {

--- a/packages/payment-detection/test/eth/proxy-info-retriever.test.ts
+++ b/packages/payment-detection/test/eth/proxy-info-retriever.test.ts
@@ -4,7 +4,7 @@ import { PaymentTypes } from '@requestnetwork/types';
 import ProxyETHInfoRetriever from '../../src/eth/proxy-info-retriever';
 
 const proxyContractAddress = '0xf204a4ef082f5c04bb89f7d5e6568b796096735a';
-const paymentReferenceMock = '0111111111111111111111111111111111111111111111111';
+const paymentReferenceMock = '01111111111111111111111111111111111111111111111111';
 
 /* tslint:disable:no-unused-expression */
 describe('api/eth/proxy-info-retriever', () => {

--- a/packages/payment-processor/package.json
+++ b/packages/payment-processor/package.json
@@ -43,7 +43,7 @@
     "@requestnetwork/smart-contracts": "0.23.0",
     "@requestnetwork/types": "0.30.0",
     "@requestnetwork/utils": "0.30.0",
-    "ethers": "4.0.48"
+    "ethers": "5.0.32"
   },
   "devDependencies": {
     "@types/jest": "26.0.13",

--- a/packages/payment-processor/src/contracts/Erc20Contract.ts
+++ b/packages/payment-processor/src/contracts/Erc20Contract.ts
@@ -1,7 +1,4 @@
-import { Contract, Signer } from 'ethers';
-import { Provider } from 'ethers/providers';
-import { BigNumber, BigNumberish, Interface } from 'ethers/utils';
-import { ITypedFunctionDescription } from './TypedFunctionDescription';
+import { Contract, Signer, providers } from 'ethers';
 
 const abi = [
   'function balanceOf(address _owner) view returns (uint)',
@@ -9,23 +6,17 @@ const abi = [
   'function approve(address _spender, uint _value)',
 ];
 
-interface IErc20ContractInterface extends Interface {
-  functions: {
-    approve: ITypedFunctionDescription<{
-      encode([_spender, _value]: [string, BigNumberish]): string;
-    }>;
-  };
-}
-
 /**
  * A typescript-documented ERC20 Contract.
  */
 export abstract class ERC20Contract extends Contract {
-  public static connect(address: string, signerOrProvider: Signer | Provider): ERC20Contract {
-    return new Contract(address, abi, signerOrProvider) as ERC20Contract;
+  public static connect(
+    address: string,
+    signerOrProvider: Signer | providers.Provider,
+  ): ERC20Contract {
+    return new Contract(address, abi, signerOrProvider);
   }
 
-  public abstract interface: IErc20ContractInterface;
-  public abstract allowance(_owner: string, _spender: string): Promise<BigNumber>;
-  public abstract balanceOf(_owner: string): Promise<BigNumber>;
+  // public abstract allowance(_owner: string, _spender: string): Promise<BigNumber>;
+  // public abstract balanceOf(_owner: string): Promise<BigNumber>;
 }

--- a/packages/payment-processor/src/contracts/Erc20FeeProxyContract.ts
+++ b/packages/payment-processor/src/contracts/Erc20FeeProxyContract.ts
@@ -1,35 +1,16 @@
-import { Contract, Signer } from 'ethers';
-import { Provider } from 'ethers/providers';
-import { Arrayish, BigNumberish, Interface } from 'ethers/utils';
+import { Contract, providers, Signer } from 'ethers';
 
 import { erc20FeeProxyArtifact } from '@requestnetwork/smart-contracts';
-import { ITypedFunctionDescription } from './TypedFunctionDescription';
 
-interface IErc20FeeProxyContractInterface extends Interface {
-  functions: {
-    transferFromWithReferenceAndFee: ITypedFunctionDescription<{
-      encode([_tokenAddress, _to, _amount, _paymentReference, _feeAmount, _feeAddress]: [
-        string,
-        string,
-        BigNumberish,
-        Arrayish,
-        BigNumberish,
-        string,
-      ]): string;
-    }>;
-  };
-}
 /**
  *  A typescript-documented ERC20 Proxy Contract.
  */
 export abstract class Erc20FeeProxyContract extends Contract {
   public static connect(
     address: string,
-    signerOrProvider: Signer | Provider,
+    signerOrProvider: Signer | providers.Provider,
   ): Erc20FeeProxyContract {
     const abi = erc20FeeProxyArtifact.getContractAbi();
     return new Contract(address, abi, signerOrProvider) as Erc20FeeProxyContract;
   }
-
-  public abstract interface: IErc20FeeProxyContractInterface;
 }

--- a/packages/payment-processor/src/contracts/Erc20ProxyContract.ts
+++ b/packages/payment-processor/src/contracts/Erc20ProxyContract.ts
@@ -1,30 +1,16 @@
-import { Contract, Signer } from 'ethers';
-import { Provider } from 'ethers/providers';
-import { Arrayish, BigNumberish, Interface } from 'ethers/utils';
+import { Contract, providers, Signer } from 'ethers';
 
 import { erc20ProxyArtifact } from '@requestnetwork/smart-contracts';
-import { ITypedFunctionDescription } from './TypedFunctionDescription';
 
-interface IErc20ProxyContractInterface extends Interface {
-  functions: {
-    transferFromWithReference: ITypedFunctionDescription<{
-      encode([_tokenAddress, _to, _amount, _paymentReference]: [
-        string,
-        string,
-        BigNumberish,
-        Arrayish,
-      ]): string;
-    }>;
-  };
-}
 /**
  *  A typescript-documented ERC20 Proxy Contract.
  */
 export abstract class Erc20ProxyContract extends Contract {
-  public static connect(address: string, signerOrProvider: Signer | Provider): Erc20ProxyContract {
+  public static connect(
+    address: string,
+    signerOrProvider: Signer | providers.Provider,
+  ): Erc20ProxyContract {
     const abi = erc20ProxyArtifact.getContractAbi();
     return new Contract(address, abi, signerOrProvider) as Erc20ProxyContract;
   }
-
-  public abstract interface: IErc20ProxyContractInterface;
 }

--- a/packages/payment-processor/src/contracts/Erc20SwapToPayContract.ts
+++ b/packages/payment-processor/src/contracts/Erc20SwapToPayContract.ts
@@ -1,46 +1,16 @@
-import { Contract, Signer } from 'ethers';
-import { Provider } from 'ethers/providers';
-import { BigNumberish, Interface } from 'ethers/utils';
+import { Contract, Signer, providers } from 'ethers';
 
 import { erc20SwapToPayArtifact } from '@requestnetwork/smart-contracts';
-import { ITypedFunctionDescription } from './TypedFunctionDescription';
 
-interface IErc20SwapToPayContractInterface extends Interface {
-  functions: {
-    swapTransferWithReference: ITypedFunctionDescription<{
-      encode([
-        _to,
-        _amount,
-        _amountInMax,
-        _path,
-        _paymentReference,
-        _feeAmount,
-        _feeAddress,
-        _deadline,
-      ]: [
-        string,
-        BigNumberish,
-        BigNumberish,
-        string[],
-        string,
-        BigNumberish,
-        string,
-        number,
-      ]): string;
-    }>;
-  };
-}
 /**
  *  A typescript-documented ERC20 Proxy Contract.
  */
 export abstract class Erc20SwapToPayContract extends Contract {
   public static connect(
     address: string,
-    signerOrProvider: Signer | Provider,
+    signerOrProvider: Signer | providers.Provider,
   ): Erc20SwapToPayContract {
     const abi = erc20SwapToPayArtifact.getContractAbi();
     return new Contract(address, abi, signerOrProvider) as Erc20SwapToPayContract;
   }
-
-  public abstract interface: IErc20SwapToPayContractInterface;
 }

--- a/packages/payment-processor/src/contracts/EthProxyContract.ts
+++ b/packages/payment-processor/src/contracts/EthProxyContract.ts
@@ -1,25 +1,16 @@
-import { Contract, Signer } from 'ethers';
-import { Provider } from 'ethers/providers';
-import { Arrayish, Interface } from 'ethers/utils';
+import { Contract, Signer, providers } from 'ethers';
 
 import { ethereumProxyArtifact } from '@requestnetwork/smart-contracts';
-import { ITypedFunctionDescription } from './TypedFunctionDescription';
 
-interface IEthProxyContractInterface extends Interface {
-  functions: {
-    transferWithReference: ITypedFunctionDescription<{
-      encode([_to, _paymentReference]: [string, Arrayish]): string;
-    }>;
-  };
-}
 /**
  *  A typescript-documented ETH Proxy Contract.
  */
 export abstract class EthProxyContract extends Contract {
-  public static connect(address: string, signerOrProvider: Signer | Provider): EthProxyContract {
+  public static connect(
+    address: string,
+    signerOrProvider: Signer | providers.Provider,
+  ): EthProxyContract {
     const abi = ethereumProxyArtifact.getContractAbi();
     return new Contract(address, abi, signerOrProvider) as EthProxyContract;
   }
-
-  public abstract interface: IEthProxyContractInterface;
 }

--- a/packages/payment-processor/src/contracts/TypedFunctionDescription.ts
+++ b/packages/payment-processor/src/contracts/TypedFunctionDescription.ts
@@ -1,7 +1,0 @@
-import {} from 'ethers';
-import { FunctionFragment } from 'ethers/lib/utils';
-
-/**
- * Typescript-documented FunctionDescription
- */
-export interface ITypedFunctionDescription extends FunctionFragment {}

--- a/packages/payment-processor/src/contracts/TypedFunctionDescription.ts
+++ b/packages/payment-processor/src/contracts/TypedFunctionDescription.ts
@@ -1,9 +1,7 @@
-import { FunctionDescription } from 'ethers/utils';
+import {} from 'ethers';
+import { FunctionFragment } from 'ethers/lib/utils';
 
 /**
  * Typescript-documented FunctionDescription
  */
-export interface ITypedFunctionDescription<T extends Pick<FunctionDescription, 'encode'>>
-  extends FunctionDescription {
-  encode: T['encode'];
-}
+export interface ITypedFunctionDescription extends FunctionFragment {}

--- a/packages/payment-processor/src/payment/btc-address-based.ts
+++ b/packages/payment-processor/src/payment/btc-address-based.ts
@@ -1,5 +1,4 @@
-import { ethers } from 'ethers';
-import { BigNumberish } from 'ethers/utils';
+import { ethers, BigNumberish } from 'ethers';
 
 import { ClientTypes } from '@requestnetwork/types';
 

--- a/packages/payment-processor/src/payment/erc20-fee-proxy.ts
+++ b/packages/payment-processor/src/payment/erc20-fee-proxy.ts
@@ -1,6 +1,4 @@
-import { constants, ContractTransaction, Signer } from 'ethers';
-import { Web3Provider } from 'ethers/providers';
-import { bigNumberify, BigNumberish } from 'ethers/utils';
+import { constants, ContractTransaction, Signer, BigNumberish, providers, BigNumber } from 'ethers';
 
 import { erc20FeeProxyArtifact } from '@requestnetwork/smart-contracts';
 import { ClientTypes, PaymentTypes } from '@requestnetwork/types';
@@ -26,7 +24,7 @@ import {
  */
 export async function payErc20FeeProxyRequest(
   request: ClientTypes.IRequestData,
-  signerOrProvider: Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   amount?: BigNumberish,
   feeAmount?: BigNumberish,
   overrides?: ITransactionOverrides,
@@ -53,7 +51,7 @@ export async function payErc20FeeProxyRequest(
  */
 export function encodePayErc20FeeRequest(
   request: ClientTypes.IRequestData,
-  signerOrProvider: Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   amount?: BigNumberish,
   feeAmountOverride?: BigNumberish,
 ): string {
@@ -65,11 +63,11 @@ export function encodePayErc20FeeRequest(
     request,
   );
   const amountToPay = getAmountToPay(request, amount);
-  const feeToPay = bigNumberify(feeAmountOverride || feeAmount || 0);
+  const feeToPay = BigNumber.from(feeAmountOverride || feeAmount || 0);
   const proxyAddress = erc20FeeProxyArtifact.getAddress(request.currencyInfo.network!);
   const proxyContract = Erc20FeeProxyContract.connect(proxyAddress, signer);
 
-  return proxyContract.interface.functions.transferFromWithReferenceAndFee.encode([
+  return proxyContract.interface.encodeFunctionData('transferFromWithReferenceAndFee', [
     tokenAddress,
     paymentAddress,
     amountToPay,
@@ -98,7 +96,7 @@ export function _getErc20FeeProxyPaymentUrl(
   );
   const contractAddress = erc20FeeProxyArtifact.getAddress(request.currencyInfo.network!);
   const amountToPay = getAmountToPay(request, amount);
-  const feeToPay = feeAmountOverride || bigNumberify(feeAmount || 0);
+  const feeToPay = feeAmountOverride || BigNumber.from(feeAmount || 0);
   const parameters = `transferFromWithReferenceAndFee?address=${request.currencyInfo.value}&address=${paymentAddress}&uint256=${amountToPay}&bytes=${paymentReference}&uint256=${feeToPay}&address=${feeAddress}`;
   return `ethereum:${contractAddress}/${parameters}`;
 }

--- a/packages/payment-processor/src/payment/erc20-proxy.ts
+++ b/packages/payment-processor/src/payment/erc20-proxy.ts
@@ -1,6 +1,4 @@
-import { ContractTransaction, Signer } from 'ethers';
-import { Web3Provider } from 'ethers/providers';
-import { BigNumberish } from 'ethers/utils';
+import { ContractTransaction, Signer, BigNumberish, providers } from 'ethers';
 
 import { erc20ProxyArtifact } from '@requestnetwork/smart-contracts';
 import { ClientTypes, PaymentTypes } from '@requestnetwork/types';
@@ -24,7 +22,7 @@ import {
  */
 export async function payErc20ProxyRequest(
   request: ClientTypes.IRequestData,
-  signerOrProvider: Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   amount?: BigNumberish,
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {
@@ -48,7 +46,7 @@ export async function payErc20ProxyRequest(
  */
 export function encodePayErc20Request(
   request: ClientTypes.IRequestData,
-  signerOrProvider: Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   amount?: BigNumberish,
 ): string {
   validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_PROXY_CONTRACT);
@@ -61,7 +59,7 @@ export function encodePayErc20Request(
   const amountToPay = getAmountToPay(request, amount);
 
   const proxyContract = Erc20ProxyContract.connect(proxyAddress, signer);
-  return proxyContract.interface.functions.transferFromWithReference.encode([
+  return proxyContract.interface.encodeFunctionData('transferFromWithReference', [
     tokenAddress,
     paymentAddress,
     amountToPay,

--- a/packages/payment-processor/src/payment/erc20.ts
+++ b/packages/payment-processor/src/payment/erc20.ts
@@ -1,6 +1,4 @@
-import { ContractTransaction, Signer } from 'ethers';
-import { Provider, Web3Provider } from 'ethers/providers';
-import { bigNumberify, BigNumberish } from 'ethers/utils';
+import { ContractTransaction, Signer, BigNumber, BigNumberish, providers } from 'ethers';
 
 import { erc20ProxyArtifact } from '@requestnetwork/smart-contracts';
 import { erc20FeeProxyArtifact } from '@requestnetwork/smart-contracts';
@@ -31,7 +29,7 @@ import {
  */
 export async function payErc20Request(
   request: ClientTypes.IRequestData,
-  signerOrProvider?: Web3Provider | Signer,
+  signerOrProvider?: providers.Web3Provider | Signer,
   amount?: BigNumberish,
   feeAmount?: BigNumberish,
   overrides?: ITransactionOverrides,
@@ -67,7 +65,7 @@ export async function payErc20Request(
 export async function hasErc20Approval(
   request: ClientTypes.IRequestData,
   account: string,
-  signerOrProvider: Provider | Signer = getNetworkProvider(request),
+  signerOrProvider: providers.Provider | Signer = getNetworkProvider(request),
 ): Promise<boolean> {
   return checkErc20Allowance(
     account,
@@ -89,7 +87,7 @@ export async function hasErc20Approval(
 export async function checkErc20Allowance(
   ownerAddress: string,
   spenderAddress: string,
-  signerOrProvider: Provider | Signer,
+  signerOrProvider: providers.Provider | Signer,
   tokenAddress: string,
   amount: BigNumberish,
 ): Promise<boolean> {
@@ -107,7 +105,7 @@ export async function checkErc20Allowance(
 export async function approveErc20IfNeeded(
   request: ClientTypes.IRequestData,
   account: string,
-  signerOrProvider: Provider | Signer = getNetworkProvider(request),
+  signerOrProvider: providers.Provider | Signer = getNetworkProvider(request),
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction | void> {
   if (!(await hasErc20Approval(request, account, signerOrProvider))) {
@@ -124,7 +122,7 @@ export async function approveErc20IfNeeded(
  */
 export async function approveErc20(
   request: ClientTypes.IRequestData,
-  signerOrProvider: Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {
   const encodedTx = encodeApproveErc20(request, signerOrProvider);
@@ -147,7 +145,7 @@ export async function approveErc20(
  */
 export function encodeApproveErc20(
   request: ClientTypes.IRequestData,
-  signerOrProvider: Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
 ): string {
   const paymentNetworkId = (getPaymentNetworkExtension(request)
     ?.id as unknown) as PaymentTypes.PAYMENT_NETWORK_ID;
@@ -171,12 +169,12 @@ export function encodeApproveErc20(
 export function encodeApproveAnyErc20(
   tokenAddress: string,
   spenderAddress: string,
-  signerOrProvider: Provider | Signer = getProvider(),
+  signerOrProvider: providers.Provider | Signer = getProvider(),
 ): string {
   const erc20interface = ERC20Contract.connect(tokenAddress, signerOrProvider).interface;
-  return erc20interface.functions.approve.encode([
+  return erc20interface.encodeFunctionData('approve', [
     spenderAddress,
-    bigNumberify(2)
+    BigNumber.from(2)
       // tslint:disable-next-line: no-magic-numbers
       .pow(256)
       .sub(1),
@@ -192,7 +190,7 @@ export function encodeApproveAnyErc20(
 export async function getErc20Balance(
   request: ClientTypes.IRequestData,
   address: string,
-  provider: Provider = getNetworkProvider(request),
+  provider: providers.Provider = getNetworkProvider(request),
 ): Promise<BigNumberish> {
   return getAnyErc20Balance(request.currencyInfo.value, address, provider);
 }
@@ -206,7 +204,7 @@ export async function getErc20Balance(
 export async function getAnyErc20Balance(
   anyErc20Address: string,
   address: string,
-  provider: Provider,
+  provider: providers.Provider,
 ): Promise<BigNumberish> {
   const erc20Contract = ERC20Contract.connect(anyErc20Address, provider);
   return erc20Contract.balanceOf(address);

--- a/packages/payment-processor/src/payment/eth-input-data.ts
+++ b/packages/payment-processor/src/payment/eth-input-data.ts
@@ -1,6 +1,4 @@
-import { ContractTransaction, Signer } from 'ethers';
-import { Web3Provider } from 'ethers/providers';
-import { BigNumberish } from 'ethers/utils';
+import { ContractTransaction, Signer, BigNumberish, providers } from 'ethers';
 
 import { ClientTypes, PaymentTypes } from '@requestnetwork/types';
 
@@ -22,7 +20,7 @@ import {
  */
 export async function payEthInputDataRequest(
   request: ClientTypes.IRequestData,
-  signerOrProvider: Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   amount?: BigNumberish,
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {

--- a/packages/payment-processor/src/payment/eth-proxy.ts
+++ b/packages/payment-processor/src/payment/eth-proxy.ts
@@ -1,13 +1,7 @@
-import { ContractTransaction, Signer } from 'ethers';
-import { Web3Provider } from 'ethers/providers';
-import { BigNumberish } from 'ethers/utils';
-
+import { BigNumberish, ContractTransaction, providers, Signer } from 'ethers';
 import { ClientTypes, PaymentTypes } from '@requestnetwork/types';
-
 import { ethereumProxyArtifact } from '@requestnetwork/smart-contracts';
-
 import { EthProxyContract } from '../contracts/EthProxyContract';
-
 import { ITransactionOverrides } from './transaction-overrides';
 import {
   getAmountToPay,
@@ -26,7 +20,7 @@ import {
  */
 export async function payEthProxyRequest(
   request: ClientTypes.IRequestData,
-  signerOrProvider: Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   amount?: BigNumberish,
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {
@@ -51,7 +45,7 @@ export async function payEthProxyRequest(
  */
 export function encodePayEthProxyRequest(
   request: ClientTypes.IRequestData,
-  signerOrProvider: Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
 ): string {
   validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ETH_INPUT_DATA);
   const signer = getSigner(signerOrProvider);
@@ -61,7 +55,7 @@ export function encodePayEthProxyRequest(
   const { paymentReference, paymentAddress } = getRequestPaymentValues(request);
 
   const proxyContract = EthProxyContract.connect(proxyAddress, signer);
-  return proxyContract.interface.functions.transferWithReference.encode([
+  return proxyContract.interface.encodeFunctionData('transferWithReference', [
     paymentAddress,
     `0x${paymentReference}`,
   ]);

--- a/packages/payment-processor/src/payment/transaction-overrides.ts
+++ b/packages/payment-processor/src/payment/transaction-overrides.ts
@@ -1,4 +1,5 @@
-import { TransactionRequest } from 'ethers/providers';
+import { providers } from 'ethers';
 
 /** Custom values to pass to transaction */
-export interface ITransactionOverrides extends Omit<TransactionRequest, 'to' | 'data' | 'value'> {}
+export interface ITransactionOverrides
+  extends Omit<providers.TransactionRequest, 'to' | 'data' | 'value'> {}

--- a/packages/payment-processor/test/payment/erc20-fee-proxy.test.ts
+++ b/packages/payment-processor/test/payment/erc20-fee-proxy.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable spellcheck/spell-checker */
-import { Wallet } from 'ethers';
-import { JsonRpcProvider } from 'ethers/providers';
+import { Wallet, BigNumber, providers } from 'ethers';
 
 import {
   ClientTypes,
@@ -17,7 +16,6 @@ import {
   payErc20FeeProxyRequest,
 } from '../../src/payment/erc20-fee-proxy';
 import { getRequestPaymentValues } from '../../src/payment/utils';
-import { bigNumberify } from 'ethers/utils';
 
 // tslint:disable: no-magic-numbers
 // tslint:disable: no-unused-expression
@@ -27,7 +25,7 @@ const erc20ContractAddress = '0x9FBDa871d559710256a2502A2517b794B482Db40';
 const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
 const paymentAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
 const feeAddress = '0xC5fdf4076b8F3A5357c5E395ab970B5B54098Fef';
-const provider = new JsonRpcProvider('http://localhost:8545');
+const provider = new providers.JsonRpcProvider('http://localhost:8545');
 const wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
 
 const validRequest: ClientTypes.IRequestData = {
@@ -166,9 +164,13 @@ describe('erc20-fee-proxy', () => {
       expect(balanceEthAfter.lte(balanceEthBefore)).toBeTruthy(); // 'ETH balance should be lower'
 
       // ERC20 balance should be lower
-      expect(bigNumberify(balanceErc20After).eq(bigNumberify(balanceErc20Before).sub(102))).toBeTruthy();
+      expect(
+        BigNumber.from(balanceErc20After).eq(BigNumber.from(balanceErc20Before).sub(102)),
+      ).toBeTruthy();
       // fee ERC20 balance should be higher
-      expect(bigNumberify(feeBalanceErc20After).eq(bigNumberify(feeBalanceErc20Before).add(2))).toBeTruthy();
+      expect(
+        BigNumber.from(feeBalanceErc20After).eq(BigNumber.from(feeBalanceErc20Before).add(2)),
+      ).toBeTruthy();
     });
   });
 

--- a/packages/payment-processor/test/payment/erc20-proxy.test.ts
+++ b/packages/payment-processor/test/payment/erc20-proxy.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable spellcheck/spell-checker */
-import { Wallet } from 'ethers';
-import { JsonRpcProvider } from 'ethers/providers';
+import { Wallet, BigNumber, providers } from 'ethers';
 
 import {
   ClientTypes,
@@ -13,7 +12,6 @@ import Utils from '@requestnetwork/utils';
 import { approveErc20, getErc20Balance } from '../../src/payment/erc20';
 import { _getErc20ProxyPaymentUrl, payErc20ProxyRequest } from '../../src/payment/erc20-proxy';
 import { getRequestPaymentValues } from '../../src/payment/utils';
-import { bigNumberify } from 'ethers/utils';
 
 // tslint:disable: no-unused-expression
 // tslint:disable: await-promise
@@ -22,7 +20,7 @@ const erc20ContractAddress = '0x9FBDa871d559710256a2502A2517b794B482Db40';
 
 const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
 const paymentAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
-const provider = new JsonRpcProvider('http://localhost:8545');
+const provider = new providers.JsonRpcProvider('http://localhost:8545');
 const wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
 
 const validRequest: ClientTypes.IRequestData = {
@@ -147,10 +145,10 @@ describe('payErc20ProxyRequest', () => {
     expect(tx.hash).not.toBeUndefined();
 
     expect(balanceEthAfter.lte(balanceEthBefore)).toBeTruthy(); // 'ETH balance should be lower'
-    expect(bigNumberify(balanceErc20After).lte(balanceErc20Before)).toBeTruthy(); // 'ERC20 balance should be lower'
+    expect(BigNumber.from(balanceErc20After).lte(balanceErc20Before)).toBeTruthy(); // 'ERC20 balance should be lower'
 
     expect(balanceErc20Before.toString()).toBe(
-      bigNumberify(balanceErc20After).add(validRequest.expectedAmount).toString(),
+      BigNumber.from(balanceErc20After).add(validRequest.expectedAmount).toString(),
     );
   });
 });

--- a/packages/payment-processor/test/payment/erc20.test.ts
+++ b/packages/payment-processor/test/payment/erc20.test.ts
@@ -7,9 +7,7 @@ import {
   PaymentTypes,
   RequestLogicTypes,
 } from '@requestnetwork/types';
-import { Wallet } from 'ethers';
-import { JsonRpcProvider } from 'ethers/providers';
-import { bigNumberify } from 'ethers/utils';
+import { Wallet, providers, BigNumber } from 'ethers';
 import {
   _getErc20PaymentUrl,
   approveErc20,
@@ -24,7 +22,7 @@ const erc20ContractAddress = '0x9FBDa871d559710256a2502A2517b794B482Db40';
 const paymentAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
 const feeAddress = '0xC5fdf4076b8F3A5357c5E395ab970B5B54098Fef';
 const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
-const provider = new JsonRpcProvider('http://localhost:8545');
+const provider = new providers.JsonRpcProvider('http://localhost:8545');
 const wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
 
 const erc20FeeProxyRequest: ClientTypes.IRequestData = {
@@ -141,12 +139,28 @@ describe('hasErc20approval & approveErc20', () => {
       // Warning: this test can run only once!
       // 'already has approval'
       expect(hasApproval).toBe(false);
-      expect(await checkErc20Allowance(otherWallet.address, feeProxyAddres, provider, erc20ContractAddress, 1)).toBe(false);
+      expect(
+        await checkErc20Allowance(
+          otherWallet.address,
+          feeProxyAddres,
+          provider,
+          erc20ContractAddress,
+          1,
+        ),
+      ).toBe(false);
       await approveErc20(erc20FeeProxyRequest, otherWallet);
       hasApproval = await hasErc20Approval(erc20FeeProxyRequest, otherWallet.address, provider);
       // 'approval did not succeed'
       expect(hasApproval).toBe(true);
-      expect(await checkErc20Allowance(otherWallet.address, feeProxyAddres, provider, erc20ContractAddress, 1)).toBe(true);
+      expect(
+        await checkErc20Allowance(
+          otherWallet.address,
+          feeProxyAddres,
+          provider,
+          erc20ContractAddress,
+          1,
+        ),
+      ).toBe(true);
     });
   });
 
@@ -187,12 +201,12 @@ describe('hasErc20approval & approveErc20', () => {
 describe('getErc20Balance', () => {
   it('should read the balance for ERC20 Fee Proxy payment network', async () => {
     const balance = await getErc20Balance(erc20FeeProxyRequest, wallet.address, provider);
-    expect(bigNumberify(balance).gte('100')).toBeTruthy();
+    expect(BigNumber.from(balance).gte('100')).toBeTruthy();
   });
 
   it('should read the balance for ERC20 Proxy payment network', async () => {
     const balance = await getErc20Balance(erc20ProxyRequest, wallet.address, provider);
-    expect(bigNumberify(balance).gte('100')).toBeTruthy();
+    expect(BigNumber.from(balance).gte('100')).toBeTruthy();
   });
 });
 

--- a/packages/payment-processor/test/payment/eth-input-data.test.ts
+++ b/packages/payment-processor/test/payment/eth-input-data.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable spellcheck/spell-checker */
-import { Wallet } from 'ethers';
-import { JsonRpcProvider } from 'ethers/providers';
+import { Wallet, providers, BigNumber } from 'ethers';
 
 import {
   ClientTypes,
@@ -13,14 +12,13 @@ import Utils from '@requestnetwork/utils';
 
 import { _getEthPaymentUrl, payEthInputDataRequest } from '../../src/payment/eth-input-data';
 import { getRequestPaymentValues } from '../../src/payment/utils';
-import { BigNumber } from 'ethers/utils';
 
 // tslint:disable: no-unused-expression
 // tslint:disable: await-promise
 
 const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
 const paymentAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
-const provider = new JsonRpcProvider('http://localhost:8545');
+const provider = new providers.JsonRpcProvider('http://localhost:8545');
 const wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
 
 const validRequest: ClientTypes.IRequestData = {
@@ -113,7 +111,7 @@ describe('payEthInputDataRequest', () => {
       data: '0x86dfbccad783599a',
       gasPrice: '20000000001',
       to: '0xf17f52151EbEF6C7334FAD080c5704D77216b732',
-      value: new BigNumber(1),
+      value: BigNumber.from(1),
     });
     wallet.sendTransaction = originalSendTransaction;
   });

--- a/packages/payment-processor/test/payment/eth-proxy.test.ts
+++ b/packages/payment-processor/test/payment/eth-proxy.test.ts
@@ -1,5 +1,4 @@
-import { Wallet } from 'ethers';
-import { JsonRpcProvider } from 'ethers/providers';
+import { Wallet, BigNumber, providers } from 'ethers';
 
 import {
   ClientTypes,
@@ -10,7 +9,6 @@ import {
 } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 
-import { bigNumberify } from 'ethers/utils';
 import { encodePayEthProxyRequest, payEthProxyRequest } from '../../src/payment/eth-proxy';
 import { getRequestPaymentValues } from '../../src/payment/utils';
 
@@ -19,7 +17,7 @@ import { getRequestPaymentValues } from '../../src/payment/utils';
 
 const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
 const paymentAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
-const provider = new JsonRpcProvider('http://localhost:8545');
+const provider = new providers.JsonRpcProvider('http://localhost:8545');
 const wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
 
 const validRequest: ClientTypes.IRequestData = {
@@ -111,7 +109,7 @@ describe('payEthProxyRequest', () => {
         '0xeb7d8df3000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b7320000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000886dfbccad783599a000000000000000000000000000000000000000000000000',
       gasPrice: '20000000000',
       to: '0xf204a4Ef082f5c04bB89F7D5E6568B796096735a',
-      value: bigNumberify('0x64'),
+      value: BigNumber.from('0x64'),
     });
     wallet.sendTransaction = originalSendTransaction;
   });

--- a/packages/payment-processor/test/payment/index.test.ts
+++ b/packages/payment-processor/test/payment/index.test.ts
@@ -1,6 +1,4 @@
-import { Wallet } from 'ethers';
-import { JsonRpcProvider } from 'ethers/providers';
-import { BigNumber, bigNumberify } from 'ethers/utils';
+import { Wallet, providers, BigNumber } from 'ethers';
 
 import { ExtensionTypes, PaymentTypes, RequestLogicTypes } from '@requestnetwork/types';
 
@@ -9,7 +7,7 @@ import {
   hasSufficientFunds,
   payRequest,
   swapToPayRequest,
-  isSolvent
+  isSolvent,
 } from '../../src/payment';
 import * as btcModule from '../../src/payment/btc-address-based';
 import * as erc20Module from '../../src/payment/erc20';
@@ -19,7 +17,7 @@ import * as ethModule from '../../src/payment/eth-input-data';
 // tslint:disable: await-promise
 
 const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
-const provider = new JsonRpcProvider('http://localhost:8545');
+const provider = new providers.JsonRpcProvider('http://localhost:8545');
 const wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
 const fakeErc20: RequestLogicTypes.ICurrency = {
   type: RequestLogicTypes.CURRENCY.ERC20,
@@ -102,7 +100,7 @@ describe('swapToPayRequest', () => {
   const swapSettings = {
     // tslint:disable-next-line: no-magic-numbers
     deadline: Date.now() + 1000,
-    maxInputAmount: new BigNumber('204'),
+    maxInputAmount: BigNumber.from('204'),
     // eslint-disable-next-line spellcheck/spell-checker
     path: ['0xany', '0xanyother'],
   };
@@ -204,7 +202,7 @@ describe('hasSufficientFunds', () => {
 
   it('should call the ETH payment method', async () => {
     const fakeProvider: any = {
-      getBalance: jest.fn().mockReturnValue(Promise.resolve(bigNumberify('200'))),
+      getBalance: jest.fn().mockReturnValue(Promise.resolve(BigNumber.from('200'))),
     };
     const request: any = {
       balance: {
@@ -232,9 +230,9 @@ describe('hasSufficientFunds', () => {
   it('should call the ERC20 payment method', async () => {
     const spy = jest
       .spyOn(erc20Module, 'getAnyErc20Balance')
-      .mockReturnValue(Promise.resolve(bigNumberify('200')));
+      .mockReturnValue(Promise.resolve(BigNumber.from('200')));
     const fakeProvider: any = {
-      getBalance: () => Promise.resolve(bigNumberify('200')),
+      getBalance: () => Promise.resolve(BigNumber.from('200')),
     };
     const request: any = {
       balance: {
@@ -264,20 +262,20 @@ describe('hasSufficientFunds', () => {
   it('should skip ETH balance checks for smart contract wallets', async () => {
     const walletConnectProvider = {
       ...provider,
-      getBalance: jest.fn().mockReturnValue(Promise.resolve(bigNumberify('0'))),
+      getBalance: jest.fn().mockReturnValue(Promise.resolve(BigNumber.from('0'))),
 
       provider: {
         wc: {
           _peerMeta: {
             name: 'Gnosis Safe Multisig',
-          }
-        }
-      }
+          },
+        },
+      },
     };
 
     const mock = jest
       .spyOn(erc20Module, 'getAnyErc20Balance')
-      .mockReturnValue(Promise.resolve(bigNumberify('200')));
+      .mockReturnValue(Promise.resolve(BigNumber.from('200')));
     // tslint:disable-next-line: no-magic-numbers
     const solvency = await isSolvent('any', fakeErc20, 100, walletConnectProvider as any);
     expect(solvency).toBeTruthy();
@@ -287,20 +285,20 @@ describe('hasSufficientFunds', () => {
   it('should check ETH balance checks for non-smart contract wallets', async () => {
     const walletConnectProvider = {
       ...provider,
-      getBalance: jest.fn().mockReturnValue(Promise.resolve(bigNumberify('0'))),
+      getBalance: jest.fn().mockReturnValue(Promise.resolve(BigNumber.from('0'))),
 
       provider: {
         wc: {
           _peerMeta: {
             name: 'Definitely not a smart contract wallet',
-          }
-        }
-      }
+          },
+        },
+      },
     };
 
     const mock = jest
       .spyOn(erc20Module, 'getAnyErc20Balance')
-      .mockReturnValue(Promise.resolve(bigNumberify('200')));
+      .mockReturnValue(Promise.resolve(BigNumber.from('200')));
     // tslint:disable-next-line: no-magic-numbers
     const solvency = await isSolvent('any', fakeErc20, 100, walletConnectProvider as any);
     expect(solvency).toBeFalsy();

--- a/packages/payment-processor/test/payment/utils.test.ts
+++ b/packages/payment-processor/test/payment/utils.test.ts
@@ -1,6 +1,4 @@
-import { Wallet } from 'ethers';
-import { BaseProvider } from 'ethers/providers';
-import { bigNumberify } from 'ethers/utils';
+import { Wallet, providers, BigNumber } from 'ethers';
 
 import {
   getAmountToPay,
@@ -18,7 +16,7 @@ describe('getAmountToPay', () => {
         },
         expectedAmount: '1000000',
       } as any),
-    ).toEqual(bigNumberify('1000000'));
+    ).toEqual(BigNumber.from('1000000'));
   });
 
   it('returns the remaining amount if balance is not 0', () => {
@@ -29,7 +27,7 @@ describe('getAmountToPay', () => {
         },
         expectedAmount: '1000000',
       } as any),
-    ).toEqual(bigNumberify('600000'));
+    ).toEqual(BigNumber.from('600000'));
   });
 
   it('returns the given amount if defined', () => {
@@ -43,7 +41,7 @@ describe('getAmountToPay', () => {
         } as any,
         '3000',
       ),
-    ).toEqual(bigNumberify('3000'));
+    ).toEqual(BigNumber.from('3000'));
   });
 
   it('fails on a negative amount', () => {
@@ -85,7 +83,9 @@ describe('getAmountToPay', () => {
 
 describe('getProvider', () => {
   it('fails if ethereum not defined', () => {
-    expect(() => getProvider()).toThrowError('ethereum not found, you must pass your own web3 provider');
+    expect(() => getProvider()).toThrowError(
+      'ethereum not found, you must pass your own web3 provider',
+    );
   });
 });
 
@@ -96,7 +96,7 @@ describe('getNetworkProvider', () => {
         network: 'mainnet',
       },
     };
-    expect(getNetworkProvider(request)).toBeInstanceOf(BaseProvider);
+    expect(getNetworkProvider(request)).toBeInstanceOf(providers.BaseProvider);
   });
 
   it('returns a provider for rinkeby', () => {
@@ -105,7 +105,7 @@ describe('getNetworkProvider', () => {
         network: 'rinkeby',
       },
     };
-    expect(getNetworkProvider(request)).toBeInstanceOf(BaseProvider);
+    expect(getNetworkProvider(request)).toBeInstanceOf(providers.BaseProvider);
   });
 
   it('fails for other network', () => {
@@ -114,7 +114,9 @@ describe('getNetworkProvider', () => {
         network: 'ropsten',
       },
     };
-    expect(() => getNetworkProvider(request)).toThrowError('Currency network ropsten is not supported');
+    expect(() => getNetworkProvider(request)).toThrowError(
+      'Currency network ropsten is not supported',
+    );
   });
 });
 

--- a/packages/request-client.js/package.json
+++ b/packages/request-client.js/package.json
@@ -57,7 +57,7 @@
     "@requestnetwork/utils": "0.30.0",
     "axios": "0.21.1",
     "bn.js": "5.1.3",
-    "ethers": "4.0.48"
+    "ethers": "5.0.32"
   },
   "devDependencies": {
     "@compodoc/compodoc": "1.1.11",

--- a/packages/request-client.js/test/ethers-mock.ts
+++ b/packages/request-client.js/test/ethers-mock.ts
@@ -1,9 +1,9 @@
-import { BigNumber } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 
 /**
- * Mockup etherscan calls
+ * Mock etherscan calls
  */
-export default class EtherscanProviderMockup {
+export default class EtherscanProviderMock {
   public async getHistory(address: string): Promise<any> {
     return ({
       '0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB': [
@@ -14,10 +14,10 @@ export default class EtherscanProviderMockup {
           transactionIndex: 120,
           confirmations: 2106906,
           from: '0x47672c15A8328C83Fc6935A33BE8479C2c42433d',
-          gasPrice: new BigNumber('0x77359400'),
-          gasLimit: new BigNumber('0x5208'),
+          gasPrice: BigNumber.from('0x77359400'),
+          gasLimit: BigNumber.from('0x5208'),
           to: '0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB',
-          value: new BigNumber('0x5c5edcbc290000'),
+          value: BigNumber.from('0x5c5edcbc290000'),
           nonce: 10,
           data: '0x',
           creates: null,
@@ -32,10 +32,10 @@ export default class EtherscanProviderMockup {
           transactionIndex: 120,
           confirmations: 988128,
           from: '0x74Ef019C1E9F11366c5c8DC4Ab556C16fe13B51F',
-          gasPrice: new BigNumber('0x059682f000'),
-          gasLimit: new BigNumber('0x5428'),
+          gasPrice: BigNumber.from('0x059682f000'),
+          gasLimit: BigNumber.from('0x5428'),
           to: '0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB',
-          value: new BigNumber('0x02dd231b00'),
+          value: BigNumber.from('0x02dd231b00'),
           nonce: 205,
           data: '0xc19da4923539c37f',
           creates: null,
@@ -52,10 +52,10 @@ export default class EtherscanProviderMockup {
           transactionIndex: 112,
           confirmations: 6617977,
           from: '0x716A22779846078Df6B8c591F3ebEEE3Ad32e153',
-          gasPrice: new BigNumber('0x3b9aca00'),
-          gasLimit: new BigNumber('0x01d978'),
+          gasPrice: BigNumber.from('0x3b9aca00'),
+          gasLimit: BigNumber.from('0x01d978'),
           to: '0x0000000000000000000000000000000000000002',
-          value: new BigNumber('0x00'),
+          value: BigNumber.from('0x00'),
           nonce: 0,
           data: '0xe5e1',
           creates: null,

--- a/packages/request-client.js/test/etherscan-mock.ts
+++ b/packages/request-client.js/test/etherscan-mock.ts
@@ -1,10 +1,11 @@
 import { BigNumber } from 'ethers';
+import { TransactionResponse } from '@ethersproject/abstract-provider';
 
 /**
  * Mock etherscan calls
  */
 export default class EtherscanProviderMock {
-  public async getHistory(address: string): Promise<any> {
+  async getHistory(addressOrName: string | Promise<string>): Promise<Array<TransactionResponse>> {
     return ({
       '0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB': [
         {
@@ -64,7 +65,7 @@ export default class EtherscanProviderMock {
           timestamp: 1508334278,
         },
       ],
-    } as any)[address];
+    } as any)[await addressOrName];
   }
   public getNetwork(): any {
     return {

--- a/packages/request-client.js/test/index.test.ts
+++ b/packages/request-client.js/test/index.test.ts
@@ -19,7 +19,7 @@ import * as TestData from './data-test';
 import * as TestDataRealBTC from './data-test-real-btc';
 
 import { PaymentReferenceCalculator } from '@requestnetwork/payment-detection';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import EtherscanProviderMockup from './ethers-mockup';
 
 const packageJson = require('../package.json');
@@ -1176,11 +1176,11 @@ describe('index', () => {
 
       jest.advanceTimersByTime(150);
       expect((await fetchedRequest.refresh()).expectedAmount).toBe(
-        String(new BigNumber(TestData.parametersWithoutExtensionsData.expectedAmount).mul(2)),
+        String(BigNumber.from(TestData.parametersWithoutExtensionsData.expectedAmount).mul(2)),
       );
 
       await fetchedRequest.reduceExpectedAmountRequest(
-        new BigNumber(TestData.parametersWithoutExtensionsData.expectedAmount).mul(2).toString(),
+        BigNumber.from(TestData.parametersWithoutExtensionsData.expectedAmount).mul(2).toString(),
         payeeIdentity,
       );
 

--- a/packages/request-client.js/test/index.test.ts
+++ b/packages/request-client.js/test/index.test.ts
@@ -20,7 +20,7 @@ import * as TestDataRealBTC from './data-test-real-btc';
 
 import { PaymentReferenceCalculator } from '@requestnetwork/payment-detection';
 import { BigNumber } from 'ethers';
-import EtherscanProviderMockup from './ethers-mockup';
+import EtherscanProviderMock from './ethers-mock';
 
 const packageJson = require('../package.json');
 const REQUEST_CLIENT_VERSION_HEADER = 'X-Request-Network-Client-Version';
@@ -1376,7 +1376,7 @@ describe('index', () => {
       jest.useFakeTimers('modern');
       jest
         .spyOn(ethers.providers, 'EtherscanProvider')
-        .mockImplementation(() => new EtherscanProviderMockup() as any);
+        .mockImplementation(() => new EtherscanProviderMock() as any);
 
       const requestNetwork = new RequestNetwork({
         signatureProvider: fakeSignatureProvider,
@@ -1443,7 +1443,7 @@ describe('index', () => {
 
       jest
         .spyOn(ethers.providers, 'EtherscanProvider')
-        .mockImplementation(() => new EtherscanProviderMockup() as any);
+        .mockImplementation(() => new EtherscanProviderMock() as any);
 
       const requestNetwork = new RequestNetwork({
         signatureProvider: fakeSignatureProvider,
@@ -1535,7 +1535,7 @@ describe('index', () => {
 
       jest
         .spyOn(ethers.providers, 'EtherscanProvider')
-        .mockImplementation(() => new EtherscanProviderMockup() as any);
+        .mockImplementation(() => new EtherscanProviderMock() as any);
 
       const requestNetwork = new RequestNetwork({
         signatureProvider: fakeSignatureProvider,

--- a/packages/request-client.js/test/index.test.ts
+++ b/packages/request-client.js/test/index.test.ts
@@ -20,7 +20,7 @@ import * as TestDataRealBTC from './data-test-real-btc';
 
 import { PaymentReferenceCalculator } from '@requestnetwork/payment-detection';
 import { BigNumber } from 'ethers';
-import EtherscanProviderMock from './ethers-mock';
+import EtherscanProviderMock from './etherscan-mock';
 
 const packageJson = require('../package.json');
 const REQUEST_CLIENT_VERSION_HEADER = 'X-Request-Network-Client-Version';
@@ -1374,9 +1374,13 @@ describe('index', () => {
     // This test checks that 2 payments with reference `c19da4923539c37f` have reached 0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB
     it('can get the balance of an ETH request', async () => {
       jest.useFakeTimers('modern');
-      jest
-        .spyOn(ethers.providers, 'EtherscanProvider')
-        .mockImplementation(() => new EtherscanProviderMock() as any);
+      const etherscanMock = new EtherscanProviderMock();
+      ethers.providers.EtherscanProvider.prototype.getHistory = jest
+        .fn()
+        .mockImplementation(etherscanMock.getHistory);
+      ethers.providers.EtherscanProvider.prototype.getNetwork = jest
+        .fn()
+        .mockImplementation(etherscanMock.getNetwork);
 
       const requestNetwork = new RequestNetwork({
         signatureProvider: fakeSignatureProvider,
@@ -1436,14 +1440,18 @@ describe('index', () => {
         '0x38c44820c37d31fbfe3fcee9d4bcf1b887d3f90fb67d62d924af03b065a80ced',
       );
       jest.useRealTimers();
-    }, 20000);
+    });
 
     it('can disable and enable the get the balance of a request', async () => {
       jest.useFakeTimers('modern');
 
-      jest
-        .spyOn(ethers.providers, 'EtherscanProvider')
-        .mockImplementation(() => new EtherscanProviderMock() as any);
+      const etherscanMock = new EtherscanProviderMock();
+      ethers.providers.EtherscanProvider.prototype.getHistory = jest
+        .fn()
+        .mockImplementation(etherscanMock.getHistory);
+      ethers.providers.EtherscanProvider.prototype.getNetwork = jest
+        .fn()
+        .mockImplementation(etherscanMock.getNetwork);
 
       const requestNetwork = new RequestNetwork({
         signatureProvider: fakeSignatureProvider,
@@ -1528,14 +1536,18 @@ describe('index', () => {
         '0x38c44820c37d31fbfe3fcee9d4bcf1b887d3f90fb67d62d924af03b065a80ced',
       );
       jest.useRealTimers();
-    }, 20000);
+    });
 
     it('can get the balance on a skipped payment detection request', async () => {
       jest.useFakeTimers('modern');
 
-      jest
-        .spyOn(ethers.providers, 'EtherscanProvider')
-        .mockImplementation(() => new EtherscanProviderMock() as any);
+      const etherscanMock = new EtherscanProviderMock();
+      ethers.providers.EtherscanProvider.prototype.getHistory = jest
+        .fn()
+        .mockImplementation(etherscanMock.getHistory);
+      ethers.providers.EtherscanProvider.prototype.getNetwork = jest
+        .fn()
+        .mockImplementation(etherscanMock.getNetwork);
 
       const requestNetwork = new RequestNetwork({
         signatureProvider: fakeSignatureProvider,
@@ -1615,7 +1627,7 @@ describe('index', () => {
       );
 
       jest.useRealTimers();
-    }, 20000);
+    });
   });
 
   describe('ERC20 address based requests', () => {

--- a/packages/smart-contracts/package.json
+++ b/packages/smart-contracts/package.json
@@ -52,7 +52,7 @@
     "@types/node": "14.14.16",
     "chai-as-promised": "7.1.1",
     "chai-bn": "0.2.1",
-    "ethers": "4.0.48",
+    "ethers": "5.0.32",
     "ganache-cli": "6.12.0",
     "lint-staged": "10.3.0",
     "shx": "0.3.2",

--- a/packages/smart-contracts/test/contracts/EthereumProxy.js
+++ b/packages/smart-contracts/test/contracts/EthereumProxy.js
@@ -9,8 +9,8 @@ contract('EthereumProxy', function (accounts) {
   const otherGuy = accounts[2];
   let ethProxy;
   const referenceExample = '0xaaaa';
-  const DEFAULT_GAS_PRICE = new ethers.utils.BigNumber('100000000000');
-  const amount = new ethers.utils.BigNumber('10000000000000000');
+  const DEFAULT_GAS_PRICE = ethers.BigNumber.from('100000000000');
+  const amount = ethers.BigNumber.from('10000000000000000');
   const provider = new ethers.providers.JsonRpcProvider();
 
   beforeEach(async () => {
@@ -43,7 +43,7 @@ contract('EthereumProxy', function (accounts) {
       gasPrice: DEFAULT_GAS_PRICE,
     });
 
-    const gasCost = DEFAULT_GAS_PRICE.mul(new ethers.utils.BigNumber(tx.receipt.gasUsed));
+    const gasCost = DEFAULT_GAS_PRICE.mul(ethers.BigNumber.from(tx.receipt.gasUsed));
 
     const fromNewBalance = await provider.getBalance(from);
     const toNewBalance = await provider.getBalance(to);

--- a/packages/types/src/storage-types.ts
+++ b/packages/types/src/storage-types.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 /** Interface of the storage */
 export interface IStorage {
@@ -205,7 +205,7 @@ export enum GasPriceType {
 /** Interface of the class to retrieve gas price through a provider API */
 export interface IGasPriceProvider {
   providerUrl: string;
-  getGasPrice: (type: GasPriceType) => Promise<typeof bigNumber>;
+  getGasPrice: (type: GasPriceType) => Promise<BigNumber | null>;
 }
 
 /** Configuration for the IPFS error handling parameters */

--- a/packages/usage-examples/package.json
+++ b/packages/usage-examples/package.json
@@ -38,7 +38,7 @@
     "@requestnetwork/transaction-manager": "0.26.4",
     "@requestnetwork/types": "0.30.0",
     "@requestnetwork/utils": "0.30.0",
-    "ethers": "4.0.48"
+    "ethers": "5.0.32"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "4.1.1",

--- a/packages/usage-examples/tsconfig.json
+++ b/packages/usage-examples/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../epk-signature" },
     { "path": "../multi-format" },
     { "path": "../payment-processor" },
+    { "path": "../payment-detection" },
     { "path": "../transaction-manager" },
     { "path": "../request-logic" },
     { "path": "../request-client.js" },

--- a/packages/utils/src/amount.ts
+++ b/packages/utils/src/amount.ts
@@ -1,7 +1,7 @@
 import { RequestLogicTypes } from '@requestnetwork/types';
 import Utils from './utils';
 
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 /**
  * Function to manage amounts
@@ -24,7 +24,7 @@ const regexInteger = RegExp(/^[\d]+$/);
 function isValid(amount: RequestLogicTypes.Amount): boolean {
   return (
     (Utils.isString(amount) && regexInteger.test(amount as string)) ||
-    (typeof amount === 'number' && (Number.isSafeInteger(Number(amount)) && Number(amount) >= 0))
+    (typeof amount === 'number' && Number.isSafeInteger(Number(amount)) && Number(amount) >= 0)
   );
 }
 
@@ -44,8 +44,8 @@ function add(amount: RequestLogicTypes.Amount, delta: RequestLogicTypes.Amount):
     throw Error('delta must represent a positive integer');
   }
 
-  const amountBN: typeof bigNumber = new bigNumber(amount);
-  const deltaBN: typeof bigNumber = new bigNumber(delta);
+  const amountBN: BigNumber = new BigNumber(amount);
+  const deltaBN: BigNumber = new BigNumber(delta);
   return amountBN.add(deltaBN).toString();
 }
 
@@ -67,8 +67,8 @@ function reduce(amount: RequestLogicTypes.Amount, delta: RequestLogicTypes.Amoun
     throw Error('delta must represent a positive integer');
   }
 
-  const amountBN: typeof bigNumber = new bigNumber(amount);
-  const deltaBN: typeof bigNumber = new bigNumber(delta);
+  const amountBN: BigNumber = new BigNumber(amount);
+  const deltaBN: BigNumber = new BigNumber(delta);
   const newAmount = amountBN.sub(deltaBN).toString();
 
   // Check if the new amount is valid (basically it is not negative)

--- a/packages/utils/src/amount.ts
+++ b/packages/utils/src/amount.ts
@@ -21,7 +21,7 @@ const regexInteger = RegExp(/^[\d]+$/);
  *
  * @returns boolean true if amount is a valid amount
  */
-function isValid(amount: RequestLogicTypes.Amount): boolean {
+function isValid(amount: RequestLogicTypes.Amount | BigNumber): boolean {
   return (
     (Utils.isString(amount) && regexInteger.test(amount as string)) ||
     (typeof amount === 'number' && Number.isSafeInteger(Number(amount)) && Number(amount) >= 0)

--- a/packages/utils/test/amount.test.ts
+++ b/packages/utils/test/amount.test.ts
@@ -1,4 +1,4 @@
-const bigNumber: any = require('bn.js');
+import * as BigNumber from 'bn.js';
 
 import Amount from '../src/amount';
 
@@ -27,7 +27,7 @@ describe('Amount', () => {
     });
     it('cannot valid amount as bn', () => {
       // 'BN should not be valid'
-      expect(Amount.isValid(new bigNumber('1000000000000000000000000'))).toBe(false);
+      expect(Amount.isValid(new BigNumber('1000000000000000000000000'))).toBe(false);
     });
     it('can valid amount as string representing integer', () => {
       // 'integer as string should be valid'
@@ -69,28 +69,42 @@ describe('Amount', () => {
 
   describe('add', () => {
     it('cannot add amounts not number', () => {
-      expect(() => Amount.add('Not a number', '1000000000000000000')).toThrowError('amount must represent a positive integer');
+      expect(() => Amount.add('Not a number', '1000000000000000000')).toThrowError(
+        'amount must represent a positive integer',
+      );
 
-      expect(() => Amount.add('1000000000000000000', 'Not a number')).toThrowError('delta must represent a positive integer');
+      expect(() => Amount.add('1000000000000000000', 'Not a number')).toThrowError(
+        'delta must represent a positive integer',
+      );
     });
     it('can add two amounts', () => {
       // 'add() result is wrong'
-      expect(Amount.add(arbitraryExpectedAmount, arbitraryDeltaAmount)).toBe(arbitraryExpectedAmountPlusDelta);
+      expect(Amount.add(arbitraryExpectedAmount, arbitraryDeltaAmount)).toBe(
+        arbitraryExpectedAmountPlusDelta,
+      );
     });
   });
 
   describe('reduce', () => {
     it('cannot reduce amounts not number', () => {
-      expect(() => Amount.reduce('Not a number', '1000000000000000000')).toThrowError('amount must represent a positive integer');
+      expect(() => Amount.reduce('Not a number', '1000000000000000000')).toThrowError(
+        'amount must represent a positive integer',
+      );
 
-      expect(() => Amount.reduce('1000000000000000000', 'Not a number')).toThrowError('delta must represent a positive integer');
+      expect(() => Amount.reduce('1000000000000000000', 'Not a number')).toThrowError(
+        'delta must represent a positive integer',
+      );
     });
     it('can reduce two amounts', () => {
       // 'reduce() result is wrong'
-      expect(Amount.reduce(arbitraryExpectedAmount, arbitraryDeltaAmount)).toBe(arbitraryExpectedAmountMinusDelta);
+      expect(Amount.reduce(arbitraryExpectedAmount, arbitraryDeltaAmount)).toBe(
+        arbitraryExpectedAmountMinusDelta,
+      );
     });
     it('cannot reduce lower zero', () => {
-      expect(() => Amount.reduce(arbitraryDeltaAmount, arbitraryExpectedAmount)).toThrowError('result of reduce is not valid');
+      expect(() => Amount.reduce(arbitraryDeltaAmount, arbitraryExpectedAmount)).toThrowError(
+        'result of reduce is not valid',
+      );
     });
   });
 });

--- a/packages/web3-signature/package.json
+++ b/packages/web3-signature/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@requestnetwork/types": "0.30.0",
     "@requestnetwork/utils": "0.30.0",
-    "ethers": "4.0.48"
+    "ethers": "5.0.32"
   },
   "devDependencies": {
     "@types/jest": "26.0.13",

--- a/packages/web3-signature/test/web3-signature-provider.test.ts
+++ b/packages/web3-signature/test/web3-signature-provider.test.ts
@@ -19,13 +19,20 @@ const id1Raw = {
 
 const data = { What: 'ever', the: 'data', are: true };
 const hashData = Utils.crypto.normalizeKeccak256Hash(data).value;
-const signatureValueExpected = Utils.crypto.EcUtils.sign(id1Raw.signatureParams.privateKey, hashData);
+const signatureValueExpected = Utils.crypto.EcUtils.sign(
+  id1Raw.signatureParams.privateKey,
+  hashData,
+);
 
 const mockWeb3: any = {
-  getSigner: jest.fn().mockImplementation(() => ({signMessage: () => {return signatureValueExpected;} }))
-}
+  getSigner: jest.fn().mockImplementation(() => ({
+    signMessage: () => {
+      return signatureValueExpected;
+    },
+  })),
+};
 
-// use of infura only to initialize Web3SignatureProvider - but web3 is mockup afterward
+// use of infura only to initialize Web3SignatureProvider - but web3 is mocked afterward
 const signProvider = new Web3SignatureProvider(new providers.InfuraProvider());
 
 /* tslint:disable:no-unused-expression */
@@ -43,15 +50,19 @@ describe('web3-signature-provider', () => {
 
     it('cannot sign if web3 throw', async () => {
       const mockWeb3Throw: any = {
-        getSigner: () => ({signMessage: () => {throw {code: -32602};} })
-      }
+        getSigner: () => ({
+          signMessage: () => {
+            throw { code: -32602 };
+          },
+        }),
+      };
 
       // we mock eth as ganache don't support personal.sign anymore
       signProvider.web3Provider = mockWeb3Throw;
 
-      await expect(
-        signProvider.sign(data, id1Raw.identity),
-      ).rejects.toThrowError(`Impossible to sign for the identity: ${id1Raw.identity.value}`);
+      await expect(signProvider.sign(data, id1Raw.identity)).rejects.toThrowError(
+        `Impossible to sign for the identity: ${id1Raw.identity.value}`,
+      );
     });
 
     it('cannot sign with different identity than ethereum address', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8989,21 +8989,6 @@ ethers@4.0.0-beta.3:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@4.0.48, ethers@^4.0.0-beta.1, ethers@^4.0.32:
-  version "4.0.48"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.48.tgz#330c65b8133e112b0613156e57e92d9009d8fbbe"
-  integrity sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==
-  dependencies:
-    aes-js "3.0.0"
-    bn.js "^4.4.0"
-    elliptic "6.5.3"
-    hash.js "1.1.3"
-    js-sha3 "0.5.7"
-    scrypt-js "2.0.4"
-    setimmediate "1.0.4"
-    uuid "2.0.1"
-    xmlhttprequest "1.8.0"
-
 ethers@5.0.13:
   version "5.0.13"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.0.13.tgz#843e98d344acbef74f4d2ab40922bbda1f83e322"
@@ -9075,6 +9060,21 @@ ethers@5.0.32:
     "@ethersproject/wallet" "5.0.12"
     "@ethersproject/web" "5.0.14"
     "@ethersproject/wordlists" "5.0.10"
+
+ethers@^4.0.0-beta.1, ethers@^4.0.32:
+  version "4.0.48"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.48.tgz#330c65b8133e112b0613156e57e92d9009d8fbbe"
+  integrity sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==
+  dependencies:
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.5.3"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.4"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
 
 ethjs-abi@^0.2.1:
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1611,6 +1611,21 @@
     "@ethersproject/properties" ">=5.0.0-beta.131"
     "@ethersproject/strings" ">=5.0.0-beta.130"
 
+"@ethersproject/abi@5.0.13", "@ethersproject/abi@^5.0.10":
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.13.tgz#600a559c3730467716595658beaa2894b4352bcc"
+  integrity sha512-2coOH3D7ra1lwamKEH0HVc+Jbcsw5yfeCgmY8ekhCDualEiyyovD2qDcMBBcY3+kjoLHVTmo7ost6MNClxdOrg==
+  dependencies:
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/constants" "^5.0.8"
+    "@ethersproject/hash" "^5.0.10"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
+
 "@ethersproject/abi@^5.0.5":
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.5.tgz#6e7bbf9d014791334233ba18da85331327354aa1"
@@ -1626,6 +1641,19 @@
     "@ethersproject/properties" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
 
+"@ethersproject/abstract-provider@5.0.10", "@ethersproject/abstract-provider@^5.0.8":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.0.10.tgz#a533aed39a5f27312745c8c4c40fa25fc884831c"
+  integrity sha512-OSReY5iz94iIaPlRvLiJP8YVIvQLx4aUvMMnHWSaA/vTU8QHZmgNlt4OBdYV1+aFY8Xl+VRYiWBHq72ZDKXXCQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/networks" "^5.0.7"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/transactions" "^5.0.9"
+    "@ethersproject/web" "^5.0.12"
+
 "@ethersproject/abstract-provider@^5.0.4":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.0.4.tgz#ef12df8cb5e66d0d47b567ad6ed642d682043773"
@@ -1639,6 +1667,17 @@
     "@ethersproject/transactions" "^5.0.5"
     "@ethersproject/web" "^5.0.6"
 
+"@ethersproject/abstract-signer@5.0.14", "@ethersproject/abstract-signer@^5.0.10":
+  version "5.0.14"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.0.14.tgz#30ef912b0f86599d90fdffc65c110452e7b55cf1"
+  integrity sha512-JztBwVO7o5OHLh2vyjordlS4/1EjRyaECtc8vPdXTF1i4dXN+J0coeRoPN6ZFbBvi/YbaB6br2fvqhst1VQD/g==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.0.8"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+
 "@ethersproject/abstract-signer@^5.0.4":
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.0.5.tgz#d1cdea6b0b82fb8e4a83f6899ba84d3dc3bb6e66"
@@ -1649,6 +1688,17 @@
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/properties" "^5.0.3"
+
+"@ethersproject/address@5.0.11", "@ethersproject/address@^5.0.9":
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.0.11.tgz#12022e8c590c33939beb5ab18b401ecf585eac59"
+  integrity sha512-Et4GBdD8/tsBGjCEOKee9upN29qjL5kbRcmJifb4Penmiuh9GARXL2/xpXvEp5EW+EIW/rfCHFJrkYBgoQFQBw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/rlp" "^5.0.7"
 
 "@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.0.3":
   version "5.0.3"
@@ -1674,12 +1724,27 @@
     "@ethersproject/rlp" "^5.0.3"
     bn.js "^4.4.0"
 
+"@ethersproject/base64@5.0.9", "@ethersproject/base64@^5.0.7":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.0.9.tgz#bb1f35d3dba92082a574d5e2418f9202a0a1a7e6"
+  integrity sha512-37RBz5LEZ9SlTNGiWCYFttnIN9J7qVs9Xo2EbqGqDH5LfW9EIji66S+YDMpXVo1zWDax1FkEldAoatxHK2gfgA==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+
 "@ethersproject/base64@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.0.3.tgz#d0aaa32c9ab08e2d62a6238581607ab6e929297e"
   integrity sha512-sFq+/UwGCQsLxMvp7yO7yGWni87QXoV3C3IfjqUSY2BHkbZbCDm+PxZviUkiKf+edYZ2Glp0XnY7CgKSYUN9qw==
   dependencies:
     "@ethersproject/bytes" "^5.0.4"
+
+"@ethersproject/basex@5.0.9", "@ethersproject/basex@^5.0.7":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.0.9.tgz#00d727a031bac563cb8bb900955206f1bf3cf1fc"
+  integrity sha512-FANswl1IN3PS0eltQxH2aM2+utPrkLUVG4XVFi6SafRG9EpAqXCgycxC8PU90mPGhigYTpg9cnTB5mCZ6ejQjw==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/properties" "^5.0.7"
 
 "@ethersproject/basex@^5.0.3":
   version "5.0.3"
@@ -1688,6 +1753,15 @@
   dependencies:
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/properties" "^5.0.3"
+
+"@ethersproject/bignumber@5.0.15", "@ethersproject/bignumber@^5.0.13":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.0.15.tgz#b089b3f1e0381338d764ac1c10512f0c93b184ed"
+  integrity sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    bn.js "^4.4.0"
 
 "@ethersproject/bignumber@>=5.0.0-beta.130", "@ethersproject/bignumber@^5.0.6":
   version "5.0.6"
@@ -1707,12 +1781,26 @@
     "@ethersproject/logger" "^5.0.5"
     bn.js "^4.4.0"
 
+"@ethersproject/bytes@5.0.11", "@ethersproject/bytes@^5.0.9":
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.0.11.tgz#21118e75b1d00db068984c15530e316021101276"
+  integrity sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==
+  dependencies:
+    "@ethersproject/logger" "^5.0.8"
+
 "@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.0.4":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.0.4.tgz#328d9d929a3e970964ecf5d62e12568a187189f1"
   integrity sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==
   dependencies:
     "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/constants@5.0.10", "@ethersproject/constants@^5.0.8":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.0.10.tgz#eb0c604fbc44c53ba9641eed31a1d0c9e1ebcadc"
+  integrity sha512-OSo8jxkHLDXieCy8bgOFR7lMfgPxEzKvSDdP+WAWHCDM8+orwch0B6wzkTmiQFgryAtIctrBt5glAdJikZ3hGw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.13"
 
 "@ethersproject/constants@>=5.0.0-beta.128", "@ethersproject/constants@^5.0.3":
   version "5.0.3"
@@ -1728,6 +1816,21 @@
   dependencies:
     "@ethersproject/bignumber" "^5.0.7"
 
+"@ethersproject/contracts@5.0.12":
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.0.12.tgz#6d488db46221258399dfe80b89bf849b3afd7897"
+  integrity sha512-srijy31idjz8bE+gL1I6IRj2H4I9dUwfQ+QroLrIgNdGArqY8y2iFUKa3QTy+JBX26fJsdYiCQi1kKkaNpnMpQ==
+  dependencies:
+    "@ethersproject/abi" "^5.0.10"
+    "@ethersproject/abstract-provider" "^5.0.8"
+    "@ethersproject/abstract-signer" "^5.0.10"
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/constants" "^5.0.8"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+
 "@ethersproject/contracts@^5.0.4":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.0.4.tgz#27a2d7e3a7eef9bd8d006824ac2a74157b523988"
@@ -1742,6 +1845,20 @@
     "@ethersproject/constants" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/properties" "^5.0.3"
+
+"@ethersproject/hash@5.0.12", "@ethersproject/hash@^5.0.10":
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.0.12.tgz#1074599f7509e2ca2bb7a3d4f4e39ab3a796da42"
+  integrity sha512-kn4QN+fhNFbUgX3XZTZUaQixi0oyfIEY+hfW+KtkHu+rq7dV76oAIvaLEEynu1/4npOL38E4X4YI42gGZk+C0Q==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.0.10"
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
 
 "@ethersproject/hash@>=5.0.0-beta.128":
   version "5.0.3"
@@ -1763,6 +1880,24 @@
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/strings" "^5.0.4"
 
+"@ethersproject/hdnode@5.0.10", "@ethersproject/hdnode@^5.0.8":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.0.10.tgz#f7cdf154bf5d104c76dce2940745fc71d9e7eb1b"
+  integrity sha512-ZLwMtIcXK7xz2lSITDCl40W04CtRq4K9NwBxhCzdzPdaz6XnoJMwGz2YMVLg+8ksseq+RYtTwIIXtlK6vyvQyg==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.0.10"
+    "@ethersproject/basex" "^5.0.7"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/pbkdf2" "^5.0.7"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/sha2" "^5.0.7"
+    "@ethersproject/signing-key" "^5.0.8"
+    "@ethersproject/strings" "^5.0.8"
+    "@ethersproject/transactions" "^5.0.9"
+    "@ethersproject/wordlists" "^5.0.8"
+
 "@ethersproject/hdnode@^5.0.4":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.0.4.tgz#9c07a87781b24b9cae3507fe9404361c5870f1b7"
@@ -1780,6 +1915,25 @@
     "@ethersproject/strings" "^5.0.4"
     "@ethersproject/transactions" "^5.0.5"
     "@ethersproject/wordlists" "^5.0.4"
+
+"@ethersproject/json-wallets@5.0.12", "@ethersproject/json-wallets@^5.0.10":
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.0.12.tgz#8946a0fcce1634b636313a50330b7d30a24996e8"
+  integrity sha512-nac553zGZnOewpjlqbfy7WBl8m3y7qudzRsI2dCxrediYtPIVIs9f6Pbnou8vDmmp8X4/U4W788d+Ma88o+Gbg==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.0.10"
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/hdnode" "^5.0.8"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/pbkdf2" "^5.0.7"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/random" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
+    "@ethersproject/transactions" "^5.0.9"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
 
 "@ethersproject/json-wallets@^5.0.6":
   version "5.0.6"
@@ -1800,6 +1954,14 @@
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
+"@ethersproject/keccak256@5.0.9", "@ethersproject/keccak256@^5.0.7":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.0.9.tgz#ca0d86e4af56c13b1ef25e533bde3e96d28f647d"
+  integrity sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    js-sha3 "0.5.7"
+
 "@ethersproject/keccak256@>=5.0.0-beta.127", "@ethersproject/keccak256@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.0.3.tgz#f094a8fca3bb913c044593c4f382be424292e588"
@@ -1808,10 +1970,22 @@
     "@ethersproject/bytes" "^5.0.4"
     js-sha3 "0.5.7"
 
+"@ethersproject/logger@5.0.10", "@ethersproject/logger@^5.0.8":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.0.10.tgz#fd884688b3143253e0356ef92d5f22d109d2e026"
+  integrity sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw==
+
 "@ethersproject/logger@>=5.0.0-beta.129", "@ethersproject/logger@^5.0.5":
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.0.5.tgz#e3ba3d0bcf9f5be4da5f043b1e328eb98b80002f"
   integrity sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==
+
+"@ethersproject/networks@5.0.9", "@ethersproject/networks@^5.0.7":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.0.9.tgz#ec5da11e4d4bfd69bec4eaebc9ace33eb9569279"
+  integrity sha512-L8+VCQwArBLGkxZb/5Ns/OH/OxP38AcaveXIxhUTq+VWpXYjrObG3E7RDQIKkUx1S1IcQl/UWTz5w4DK0UitJg==
+  dependencies:
+    "@ethersproject/logger" "^5.0.8"
 
 "@ethersproject/networks@^5.0.3":
   version "5.0.3"
@@ -1819,6 +1993,14 @@
   integrity sha512-Gjpejul6XFetJXyvHCd37IiCC00203kYGU9sMaRMZcAcYKszCkbOeo/Q7Mmdr/fS7YBbB5iTOahDJWiRLu/b7A==
   dependencies:
     "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/pbkdf2@5.0.9", "@ethersproject/pbkdf2@^5.0.7":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.0.9.tgz#be39c7f0a66c0d3cb1ad1dbb12a78e9bcdf9b5ae"
+  integrity sha512-ItE/wQ/WVw/ajEHPUVgfu0aEvksPgOQc+278bke8sGKnGO3ppjmqp0MHh17tHc1EBTzJbSms5aLIqc56qZ/oiA==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/sha2" "^5.0.7"
 
 "@ethersproject/pbkdf2@^5.0.3":
   version "5.0.3"
@@ -1828,12 +2010,44 @@
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/sha2" "^5.0.3"
 
+"@ethersproject/properties@5.0.9", "@ethersproject/properties@^5.0.7":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.0.9.tgz#d7aae634680760136ea522e25c3ef043ec15b5c2"
+  integrity sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==
+  dependencies:
+    "@ethersproject/logger" "^5.0.8"
+
 "@ethersproject/properties@>=5.0.0-beta.131", "@ethersproject/properties@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.0.3.tgz#991aef39a5f87d4645cee76cec4df868bfb08be6"
   integrity sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==
   dependencies:
     "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/providers@5.0.24":
+  version "5.0.24"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.0.24.tgz#4c638a029482d052faa18364b5e0e2d3ddd9c0cb"
+  integrity sha512-M4Iw1r4gGJkt7ZUa++iREuviKL/DIpmIMsaUlVlXtV+ZrUXeN8xQ3zOTrbz7R4h9W9oljBZM7i4D3Kn1krJ30A==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.0.8"
+    "@ethersproject/abstract-signer" "^5.0.10"
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/basex" "^5.0.7"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/constants" "^5.0.8"
+    "@ethersproject/hash" "^5.0.10"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/networks" "^5.0.7"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/random" "^5.0.7"
+    "@ethersproject/rlp" "^5.0.7"
+    "@ethersproject/sha2" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
+    "@ethersproject/transactions" "^5.0.9"
+    "@ethersproject/web" "^5.0.12"
+    bech32 "1.1.4"
+    ws "7.2.3"
 
 "@ethersproject/providers@^5.0.8":
   version "5.0.9"
@@ -1860,6 +2074,14 @@
     bech32 "1.1.4"
     ws "7.2.3"
 
+"@ethersproject/random@5.0.9", "@ethersproject/random@^5.0.7":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.0.9.tgz#1903d4436ba66e4c8ac77968b16f756abea3a0d0"
+  integrity sha512-DANG8THsKqFbJOantrxumtG6gyETNE54VfbsWa+SQAT8WKpDo9W/X5Zhh73KuhClaey1UI32uVmISZeq/Zxn1A==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+
 "@ethersproject/random@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.0.3.tgz#ec16546fffdc10b9082f1207bd3a09f54cbcf5e6"
@@ -1867,6 +2089,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/rlp@5.0.9", "@ethersproject/rlp@^5.0.7":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.0.9.tgz#da205bf8a34d3c3409eb73ddd237130a4b376aff"
+  integrity sha512-ns1U7ZMVeruUW6JXc4om+1w3w4ynHN/0fpwmeNTsAjwGKoF8SAUgue6ylKpHKWSti2idx7jDxbn8hNNFHk67CA==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
 
 "@ethersproject/rlp@^5.0.3":
   version "5.0.3"
@@ -1876,6 +2106,15 @@
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
 
+"@ethersproject/sha2@5.0.9", "@ethersproject/sha2@^5.0.7":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.0.9.tgz#41275ee03e6e1660b3c997754005e089e936adc6"
+  integrity sha512-5FH4s47gM7N1fFAYQ1+m7aX0SbLg0Xr+6tvqndmNqc382/qBIbzXiGlUookrsjlPb6gLNurnTssCXjNM72J6lQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    hash.js "1.1.3"
+
 "@ethersproject/sha2@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.0.3.tgz#52c16edc1135d0ec7d242d88eed035dae72800c0"
@@ -1884,6 +2123,16 @@
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
     hash.js "1.1.3"
+
+"@ethersproject/signing-key@5.0.11", "@ethersproject/signing-key@^5.0.8":
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.0.11.tgz#19fc5c4597e18ad0a5efc6417ba5b74069fdd2af"
+  integrity sha512-Jfcru/BGwdkXhLxT+8WCZtFy7LL0TPFZw05FAb5asxB/MyVsEfNdNxGDtjVE9zXfmRSPe/EusXYY4K7wcygOyQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+    elliptic "6.5.4"
 
 "@ethersproject/signing-key@^5.0.4":
   version "5.0.4"
@@ -1895,6 +2144,17 @@
     "@ethersproject/properties" "^5.0.3"
     elliptic "6.5.3"
 
+"@ethersproject/solidity@5.0.10":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.0.10.tgz#128c9289761cf83d81ff62a1195d6079a924a86c"
+  integrity sha512-8OG3HLqynWXDA6mVIHuHfF/ojTTwBahON7hc9GAKCqglzXCkVA3OpyxOJXPzjHClRIAUUiU7r9oy9Z/nsjtT/g==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/sha2" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
+
 "@ethersproject/solidity@^5.0.4":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.0.4.tgz#67022cbfb50cb73b72d1739178537a9e798945bf"
@@ -1905,6 +2165,15 @@
     "@ethersproject/keccak256" "^5.0.3"
     "@ethersproject/sha2" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
+
+"@ethersproject/strings@5.0.10", "@ethersproject/strings@^5.0.8":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.0.10.tgz#ddce1e9724f4ac4f3f67e0cac0b48748e964bfdb"
+  integrity sha512-KAeoS1tZ9/5ECXiIZA6S6hywbD0so2VmuW+Wfyo5EDXeyZ6Na1nxTPhTnW7voQmjbeYJffCrOc0qLFJeylyg7w==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/constants" "^5.0.8"
+    "@ethersproject/logger" "^5.0.8"
 
 "@ethersproject/strings@>=5.0.0-beta.130", "@ethersproject/strings@^5.0.3":
   version "5.0.3"
@@ -1923,6 +2192,21 @@
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/constants" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/transactions@5.0.11", "@ethersproject/transactions@^5.0.9":
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.0.11.tgz#b31df5292f47937136a45885d6ee6112477c13df"
+  integrity sha512-ftsRvR9+gQp7L63F6+XmstvsZ4w8GtWvQB08e/zB+oB86Fnhq8+i/tkgpJplSHC8I/qgiCisva+M3u2GVhDFPA==
+  dependencies:
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/constants" "^5.0.8"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/rlp" "^5.0.7"
+    "@ethersproject/signing-key" "^5.0.8"
 
 "@ethersproject/transactions@^5.0.0-beta.135":
   version "5.0.3"
@@ -1954,6 +2238,15 @@
     "@ethersproject/rlp" "^5.0.3"
     "@ethersproject/signing-key" "^5.0.4"
 
+"@ethersproject/units@5.0.11":
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.0.11.tgz#f82f6e353ac0d6fa43b17337790f1f9aa72cb4c8"
+  integrity sha512-nOSPmcCWyB/dwoBRhhTtPGCsTbiXqmc7Q0Adwvafc432AC7hy3Fj3IFZtnSXsbtJ/GdHCIUIoA8gtvxSsFuBJg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/constants" "^5.0.8"
+    "@ethersproject/logger" "^5.0.8"
+
 "@ethersproject/units@^5.0.4":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.0.4.tgz#e08876b54e1f6b362a841dcd986496a425875735"
@@ -1962,6 +2255,27 @@
     "@ethersproject/bignumber" "^5.0.7"
     "@ethersproject/constants" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/wallet@5.0.12":
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.0.12.tgz#bfb96f95e066b4b1b4591c4615207b87afedda8b"
+  integrity sha512-rboJebGf47/KPZrKZQdYg9BAYuXbc/OwcUyML1K1f2jnJeo1ObWV11U1PAWTjTbhhSy6/Fg+34GO2yMb5Dt1Rw==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.0.8"
+    "@ethersproject/abstract-signer" "^5.0.10"
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/hash" "^5.0.10"
+    "@ethersproject/hdnode" "^5.0.8"
+    "@ethersproject/json-wallets" "^5.0.10"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/random" "^5.0.7"
+    "@ethersproject/signing-key" "^5.0.8"
+    "@ethersproject/transactions" "^5.0.9"
+    "@ethersproject/wordlists" "^5.0.8"
 
 "@ethersproject/wallet@^5.0.4":
   version "5.0.4"
@@ -1984,6 +2298,17 @@
     "@ethersproject/transactions" "^5.0.5"
     "@ethersproject/wordlists" "^5.0.4"
 
+"@ethersproject/web@5.0.14", "@ethersproject/web@^5.0.12":
+  version "5.0.14"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.0.14.tgz#6e7bebdd9fb967cb25ee60f44d9218dc0803bac4"
+  integrity sha512-QpTgplslwZ0Sp9oKNLoRuS6TKxnkwfaEk3gr7zd7XLF8XBsYejsrQO/03fNfnMx/TAT/RR6WEw/mbOwpRSeVRA==
+  dependencies:
+    "@ethersproject/base64" "^5.0.7"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
+
 "@ethersproject/web@^5.0.6":
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.0.7.tgz#ab8ccffa9cee9469a8b49af8b8fee30e384e59d8"
@@ -1994,6 +2319,17 @@
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/properties" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
+
+"@ethersproject/wordlists@5.0.10", "@ethersproject/wordlists@^5.0.8":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.0.10.tgz#177b9a0b4d72b9c4f304d08b36612d6c60e9b896"
+  integrity sha512-jWsEm1iJzpg9SCXnNfFz+tcp4Ofzv0TJb6mj+soCNcar9GcT0yGz62ZsHC3pLQWaF4LkCzGwRJHJTXKjHQfG1A==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/hash" "^5.0.10"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
 
 "@ethersproject/wordlists@^5.0.4":
   version "5.0.4"
@@ -3288,6 +3624,33 @@
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/@redocly/react-dropdown-aria/-/react-dropdown-aria-2.0.11.tgz#532b864b329237e646abe45d0f8edc923e77370a"
   integrity sha512-rmuSC2JFFl4DkPDdGVrmffT9KcbG2AB5jvhxPIrOc1dO9mHRMUUftQY35KZlvWqqSSqVn+AM+J9dhiTo1ZqR8A==
+
+"@requestnetwork/currency@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@requestnetwork/currency/-/currency-0.2.0.tgz#4a0a96110b3b17be9533257d23b1d42ad389bfe1"
+  integrity sha512-8Fkjpb7i6gLFxEcyJFmqtXQfERQ80bk1K5bH42a8CSGPX9D2tOK0PK1vnUkW4bZ1orlH8z4WLxzbEpikD2HSYQ==
+  dependencies:
+    "@metamask/contract-metadata" "1.23.0"
+    "@requestnetwork/types" "0.29.3"
+    "@requestnetwork/utils" "0.29.0"
+    node-dijkstra "2.5.0"
+
+"@requestnetwork/types@0.29.3":
+  version "0.29.3"
+  resolved "https://registry.yarnpkg.com/@requestnetwork/types/-/types-0.29.3.tgz#0d48e4535ff91f3244b4adfcc6c2353b279bd07f"
+  integrity sha512-MUnvMQ66Q42pt2wo5FfTspaHR5Jo+5ABuF2gx4cdNKkckdCTXZeSFvAgKyJfRTZHo4JxLzJHoncvzKyyTgEDTA==
+  dependencies:
+    bn.js "5.1.3"
+    events "3.2.0"
+
+"@requestnetwork/utils@0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@requestnetwork/utils/-/utils-0.29.0.tgz#14a700904e7d1116a19161b491b6503d31137ae5"
+  integrity sha512-OUqmhDkYajP/6Al09j16QlVJbx8iGw8/qS4QTyB2Jjo+fy0qH36HLCYv48KN4RL7roccZOYOPdaC+TdjvsCGng==
+  dependencies:
+    "@requestnetwork/types" "0.29.3"
+    bn.js "5.1.3"
+    eth-crypto "1.8.0"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -5307,7 +5670,7 @@ brfs@^2.0.0, brfs@^2.0.2:
     static-module "^3.0.2"
     through2 "^2.0.0"
 
-brorand@^1.0.1:
+brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
@@ -7832,6 +8195,19 @@ elliptic@6.5.3, elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.2, elliptic@^6.5
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+elliptic@6.5.4:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
+  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
+
 emittery@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.7.1.tgz#c02375a927a40948c0345cc903072597f5270451"
@@ -8663,6 +9039,42 @@ ethers@5.0.13:
     "@ethersproject/wallet" "^5.0.4"
     "@ethersproject/web" "^5.0.6"
     "@ethersproject/wordlists" "^5.0.4"
+
+ethers@5.0.32:
+  version "5.0.32"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.0.32.tgz#f009970be31d96a589bf0ce597a39c10c7e297a6"
+  integrity sha512-rORfGWR0HsA4pjKMMcWZorw12DHsXqfIAuPVHJsXt+vI24jvXcVqx+rLsSvgOoLdaCMdxiN5qlIq2+4axKG31g==
+  dependencies:
+    "@ethersproject/abi" "5.0.13"
+    "@ethersproject/abstract-provider" "5.0.10"
+    "@ethersproject/abstract-signer" "5.0.14"
+    "@ethersproject/address" "5.0.11"
+    "@ethersproject/base64" "5.0.9"
+    "@ethersproject/basex" "5.0.9"
+    "@ethersproject/bignumber" "5.0.15"
+    "@ethersproject/bytes" "5.0.11"
+    "@ethersproject/constants" "5.0.10"
+    "@ethersproject/contracts" "5.0.12"
+    "@ethersproject/hash" "5.0.12"
+    "@ethersproject/hdnode" "5.0.10"
+    "@ethersproject/json-wallets" "5.0.12"
+    "@ethersproject/keccak256" "5.0.9"
+    "@ethersproject/logger" "5.0.10"
+    "@ethersproject/networks" "5.0.9"
+    "@ethersproject/pbkdf2" "5.0.9"
+    "@ethersproject/properties" "5.0.9"
+    "@ethersproject/providers" "5.0.24"
+    "@ethersproject/random" "5.0.9"
+    "@ethersproject/rlp" "5.0.9"
+    "@ethersproject/sha2" "5.0.9"
+    "@ethersproject/signing-key" "5.0.11"
+    "@ethersproject/solidity" "5.0.10"
+    "@ethersproject/strings" "5.0.10"
+    "@ethersproject/transactions" "5.0.11"
+    "@ethersproject/units" "5.0.11"
+    "@ethersproject/wallet" "5.0.12"
+    "@ethersproject/web" "5.0.14"
+    "@ethersproject/wordlists" "5.0.10"
 
 ethjs-abi@^0.2.1:
   version "0.2.1"
@@ -10365,7 +10777,7 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-hmac-drbg@^1.0.0:
+hmac-drbg@^1.0.0, hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
   integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=


### PR DESCRIPTION
Upgrade to the latest major version of Ethers.

Doc about upgrade: https://docs.ethers.io/v5/migration/ethers-v4

Important change, not documented above: the default INFURA key has changed from v4 to v5. It seems it does not have the same limits and our tests don't pass. I made some changes so that we can configure the INFURA key, and that the v4 key is used by default