### PR TITLE
chore: Token and Currency classes

### DIFF
--- a/packages/currency/README.md
+++ b/packages/currency/README.md
@@ -12,14 +12,33 @@ npm install @requestnetwork/currency
 ## Usage
 
 ```javascript
-import Currency from '@requestnetwork/currency';
+import { RequestLogicTypes } from '@requestnetwork/types';
+import { getDecimalsForCurrency, getCurrencyHash, Currency, Token } from '@requestnetwork/currency';
 
-const decimals = Currency.getDecimalsForCurrency({
+const decimals = getDecimalsForCurrency({
   type: RequestLogicTypes.CURRENCY.ETH,
   value: 'ETH',
-};
+});
 
 console.log(decimals); // 18
+
+const ETHHash = getCurrencyHash({
+  type: RequestLogicTypes.CURRENCY.ETH,
+  value: 'ETH',
+});
+
+console.log(ETHHash); // 0xF5AF88e117747e87fC5929F2ff87221B1447652E
+
+// Get currencies from their symbol
+const ETHCurrency: RequestLogicTypes.ICurrency = Currency.from('ETH');
+const FAUCurrency: RequestLogicTypes.ICurrency = Currency.from('DAI');
+// Get currencies from their address
+const DAICurrency: RequestLogicTypes.ICurrency = Currency.from(
+  '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+);
+
+console.log(FAUCurrency.toString()); // FAU-rinkeby
+console.log(DAICurrency.toString()); // DAI
 ```
 
 ## Contributing

--- a/packages/currency/README.md
+++ b/packages/currency/README.md
@@ -39,6 +39,11 @@ const DAICurrency: RequestLogicTypes.ICurrency = Currency.from(
 
 console.log(FAUCurrency.toString()); // FAU-rinkeby
 console.log(DAICurrency.toString()); // DAI
+
+// Get a token symbol from its address
+const FAUToken = Token.from('0xFab46E002BbF0b4509813474841E0716E6730136');
+
+console.log(FAUToken.symbol); // FAU
 ```
 
 ## Contributing

--- a/packages/currency/src/chainlink-path-aggregators.ts
+++ b/packages/currency/src/chainlink-path-aggregators.ts
@@ -1,7 +1,6 @@
 import { RequestLogicTypes } from '@requestnetwork/types';
-import { getCurrencyHash } from './index';
-
 import GRAPH from 'node-dijkstra';
+import { Currency } from './currency';
 
 // List of currencies supported by network (can be generated from requestNetwork/toolbox/src/chainlinkConversionPathTools.ts)
 // Network => currencyFrom => currencyTo => cost
@@ -155,7 +154,7 @@ export function getPath(
 
   // Get the path
   return route.path(
-    getCurrencyHash(currencyFrom).toLowerCase(),
-    getCurrencyHash(currencyTo).toLowerCase(),
+    new Currency(currencyFrom).getHash().toLowerCase(),
+    new Currency(currencyTo).getHash().toLowerCase(),
   );
 }

--- a/packages/currency/src/currency.ts
+++ b/packages/currency/src/currency.ts
@@ -1,0 +1,79 @@
+import { RequestLogicTypes } from '@requestnetwork/types';
+import { currencyToString } from '.';
+import { getSupportedERC20Currencies, getErc20Currency } from './erc20';
+import iso4217 from './iso4217';
+
+/**
+ * @class Currency implements ICurrency with helpers
+ * Represents a currency supported by the Request Logic, with minimum required
+ * information: value, type and network (optional).
+ */
+export class Currency implements RequestLogicTypes.ICurrency {
+  public value: string;
+  public type: RequestLogicTypes.CURRENCY;
+  public network?: string;
+  constructor(currency: RequestLogicTypes.ICurrency) {
+    ({ value: this.value, type: this.type, network: this.network } = currency);
+  }
+
+  /**
+   * Gets a supported currency from a symbol, symbol-network or address.
+   * Iterates over all the supported networks if needed
+   * @param symbolOrAddress e.g. 'DAI', 'FAU', 'FAU-rinkeby' or '0xFab46E002BbF0b4509813474841E0716E6730136'
+   * @returns an ICurrency object
+   */
+  static from(symbolOrAddress: string): Currency {
+    try {
+      const currencyFromSymbol = this.fromSymbol(symbolOrAddress);
+      return currencyFromSymbol;
+    } catch (e) {
+      const erc20Currencies = getSupportedERC20Currencies();
+      const currencyFromAddress = erc20Currencies.find((c) => c.value === symbolOrAddress);
+      if (!currencyFromAddress) {
+        throw new Error(`The currency ${symbolOrAddress} does not exist or is not supported`);
+      }
+      return new Currency(currencyFromAddress);
+    }
+  }
+
+  /**
+   * Get currency from its symbol and network.
+   * @param symbol
+   * @param network
+   * @returns RequestLogicTypes.ICurrency
+   */
+  static fromSymbol = (symbol: string, network?: string): Currency => {
+    // Check if it's a supported cryptocurrency
+    if (symbol === 'BTC') {
+      return new Currency({
+        type: RequestLogicTypes.CURRENCY.BTC,
+        value: 'BTC',
+      });
+    }
+    if (symbol === 'ETH') {
+      return new Currency({
+        type: RequestLogicTypes.CURRENCY.ETH,
+        value: 'ETH',
+      });
+    }
+
+    // Check if it's an ERC20 token and return it if found
+    const erc20Currency = getErc20Currency(symbol, network);
+    if (erc20Currency) {
+      return new Currency(erc20Currency);
+    }
+
+    // Check if it's one of ISO4217 currencies
+    if (iso4217.find((i) => i.code === symbol)) {
+      return new Currency({
+        type: RequestLogicTypes.CURRENCY.ISO4217,
+        value: symbol,
+      });
+    }
+    throw new Error(`The currency ${symbol} is not supported`);
+  };
+
+  public toString(): string {
+    return currencyToString(this);
+  }
+}

--- a/packages/currency/src/erc20/index.ts
+++ b/packages/currency/src/erc20/index.ts
@@ -15,7 +15,6 @@ export function getErc20Currency(
     return supportedNetworks[network].get(symbol);
   }
   for (network of Object.keys(supportedNetworks)) {
-    // console.log(network, symbol);
     if (supportedNetworks[network].has(symbol)) {
       // console.log(supportedNetworks[network].get(symbol));
       return supportedNetworks[network].get(symbol);

--- a/packages/currency/src/erc20/index.ts
+++ b/packages/currency/src/erc20/index.ts
@@ -11,8 +11,11 @@ export function getErc20Currency(
   network?: string,
 ): RequestLogicTypes.ICurrency | undefined {
   // Check if it's on one of the other supported networks
-  if (network && network in supportedNetworks && supportedNetworks[network].has(symbol)) {
-    return supportedNetworks[network].get(symbol);
+  if (network) {
+    if (network in supportedNetworks && supportedNetworks[network].has(symbol)) {
+      return supportedNetworks[network].get(symbol);
+    }
+    return;
   }
   for (network of Object.keys(supportedNetworks)) {
     if (supportedNetworks[network].has(symbol)) {

--- a/packages/currency/src/erc20/index.ts
+++ b/packages/currency/src/erc20/index.ts
@@ -16,7 +16,6 @@ export function getErc20Currency(
   }
   for (network of Object.keys(supportedNetworks)) {
     if (supportedNetworks[network].has(symbol)) {
-      // console.log(supportedNetworks[network].get(symbol));
       return supportedNetworks[network].get(symbol);
     }
   }

--- a/packages/currency/src/erc20/index.ts
+++ b/packages/currency/src/erc20/index.ts
@@ -8,11 +8,18 @@ import { supportedNetworks, supportedNetworksDetails, ERC20SymbolDetails } from 
  */
 export function getErc20Currency(
   symbol: string,
-  network = 'mainnet',
+  network?: string,
 ): RequestLogicTypes.ICurrency | undefined {
   // Check if it's on one of the other supported networks
-  if (network in supportedNetworks && supportedNetworks[network].has(symbol)) {
+  if (network && network in supportedNetworks && supportedNetworks[network].has(symbol)) {
     return supportedNetworks[network].get(symbol);
+  }
+  for (network of Object.keys(supportedNetworks)) {
+    // console.log(network, symbol);
+    if (supportedNetworks[network].has(symbol)) {
+      // console.log(supportedNetworks[network].get(symbol));
+      return supportedNetworks[network].get(symbol);
+    }
   }
 
   return;
@@ -70,19 +77,41 @@ export function getErc20Symbol(currency: RequestLogicTypes.ICurrency): string | 
 interface ERC20TokenDetails extends ERC20SymbolDetails {
   symbol: string;
 }
+
+/**
+ * Returns a list of supported ERC20 tokens
+ *
+ * @returns List of supported ERC20 tokens
+ */
+export function getSupportedERC20Tokens(): ERC20TokenDetails[] {
+  return Object.entries(supportedNetworksDetails).reduce(
+    (acc: ERC20TokenDetails[], [networkName, supportedCurrencies]) => {
+      return [
+        ...acc,
+        ...Object.entries(supportedCurrencies).map(([symbol, token]) => ({
+          ...token,
+          symbol: `${symbol}${networkName !== 'mainnet' ? `-${networkName}` : ''}`,
+        })),
+      ];
+    },
+    [],
+  );
+}
+
 /**
  * Returns a list of supported ERC20 currencies
  *
  * @returns List of supported ERC20 currencies
  */
-export function getSupportedERC20Tokens(): ERC20TokenDetails[] {
+export function getSupportedERC20Currencies(): RequestLogicTypes.ICurrency[] {
   return Object.entries(supportedNetworksDetails).reduce(
-    (acc: ERC20TokenDetails[], [networkName, network]) => {
+    (acc: RequestLogicTypes.ICurrency[], [networkName, supportedCurrencies]) => {
       return [
         ...acc,
-        ...Object.entries(network).map(([symbol, token]) => ({
-          ...token,
-          symbol: `${symbol}${networkName !== 'mainnet' ? `-${networkName}` : ''}`,
+        ...Object.entries(supportedCurrencies).map(([, token]) => ({
+          network: networkName,
+          value: token.address,
+          type: RequestLogicTypes.CURRENCY.ERC20,
         })),
       ];
     },

--- a/packages/currency/src/erc20/networks/rinkeby.ts
+++ b/packages/currency/src/erc20/networks/rinkeby.ts
@@ -31,6 +31,7 @@ export const supportedRinkebyERC20Details = {
     address: '0x995d6A8C21F24be1Dd04E105DD0d83758343E258',
     decimals: 18,
     name: 'Central Bank Token',
+    symbol: 'CTBK',
   },
   // Faucet Token on rinkeby network.
   FAU: {
@@ -38,5 +39,6 @@ export const supportedRinkebyERC20Details = {
     address: '0xFab46E002BbF0b4509813474841E0716E6730136',
     decimals: 18,
     name: 'Faucet Token',
+    symbol: 'FAU',
   },
 };

--- a/packages/currency/src/index.ts
+++ b/packages/currency/src/index.ts
@@ -128,20 +128,7 @@ export function getAllSupportedCurrencies(): {
  * @deprecated use new Currency().getHash() instead
  */
 export function getCurrencyHash(currency: RequestLogicTypes.ICurrency): string {
-  if (currency.type === RequestLogicTypes.CURRENCY.ERC20) {
-    return currency.value;
-  }
-  if (
-    currency.type === RequestLogicTypes.CURRENCY.ETH ||
-    currency.type === RequestLogicTypes.CURRENCY.BTC
-  ) {
-    // ignore the network
-    return Utils.crypto.last20bytesOfNormalizedKeccak256Hash({
-      type: currency.type,
-      value: currency.value,
-    });
-  }
-  return Utils.crypto.last20bytesOfNormalizedKeccak256Hash(currency);
+  return new Currency(currency).getHash();
 }
 
 export default {

--- a/packages/currency/src/index.ts
+++ b/packages/currency/src/index.ts
@@ -2,47 +2,12 @@ import { RequestLogicTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import iso4217 from './iso4217';
 import othersCurrencies from './others';
-
-import {
-  getErc20Currency,
-  getErc20Decimals,
-  getErc20Symbol,
-  getSupportedERC20Tokens,
-} from './erc20';
+import { getErc20Decimals, getErc20Symbol, getSupportedERC20Tokens } from './erc20';
+import { Currency } from './currency';
+export { Currency } from './currency';
+export { Token } from './token';
 
 export { getPath as getConversionPath } from './chainlink-path-aggregators';
-
-// Simple function to get the currency from the value alone
-const getCurrency = (currencyValue: string, network: string): RequestLogicTypes.ICurrency => {
-  // Check if it's a supported cryptocurrency
-  if (currencyValue === 'BTC') {
-    return {
-      type: RequestLogicTypes.CURRENCY.BTC,
-      value: 'BTC',
-    };
-  }
-  if (currencyValue === 'ETH') {
-    return {
-      type: RequestLogicTypes.CURRENCY.ETH,
-      value: 'ETH',
-    };
-  }
-
-  // Check if it's an ERC20 token and return it if found
-  const erc20Currency = getErc20Currency(currencyValue, network);
-  if (erc20Currency) {
-    return erc20Currency;
-  }
-
-  // Check if it's one of ISO4217 currencies
-  if (iso4217.find((i) => i.code === currencyValue)) {
-    return {
-      type: RequestLogicTypes.CURRENCY.ISO4217,
-      value: currencyValue,
-    };
-  }
-  throw new Error(`The currency ${currencyValue} is not supported`);
-};
 
 /**
  * Returns a Currency object from a user-friendly currency string.
@@ -61,7 +26,7 @@ export function stringToCurrency(currencyString: string): RequestLogicTypes.ICur
   // Split the currency string value and network (if available)
   const [value, network] = currencyString.split('-');
 
-  const currency = getCurrency(value, network);
+  const currency = Currency.fromSymbol(value, network);
 
   // If a network was declared, add it to the currency object
   if (network) {

--- a/packages/currency/src/index.ts
+++ b/packages/currency/src/index.ts
@@ -1,5 +1,4 @@
 import { RequestLogicTypes } from '@requestnetwork/types';
-import Utils from '@requestnetwork/utils';
 import iso4217 from './iso4217';
 import othersCurrencies from './others';
 import { getErc20Decimals, getSupportedERC20Tokens } from './erc20';

--- a/packages/currency/src/index.ts
+++ b/packages/currency/src/index.ts
@@ -2,7 +2,7 @@ import { RequestLogicTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import iso4217 from './iso4217';
 import othersCurrencies from './others';
-import { getErc20Decimals, getErc20Symbol, getSupportedERC20Tokens } from './erc20';
+import { getErc20Decimals, getSupportedERC20Tokens } from './erc20';
 import { Currency } from './currency';
 export { Currency } from './currency';
 export { Token } from './token';
@@ -14,7 +14,7 @@ export { getPath as getConversionPath } from './chainlink-path-aggregators';
  * The string format is: [CURRENCY_NAME]-[network].
  * The network is optional.
  * E.g: BTC, ETH, ETH-rinkeby, SAI, USD, EUR
- *
+ * @deprecated use Currency.from() or Currency.fromSymbol() instead
  * @param currencyString The currency string to be formatted
  */
 export function stringToCurrency(currencyString: string): RequestLogicTypes.ICurrency {
@@ -26,7 +26,7 @@ export function stringToCurrency(currencyString: string): RequestLogicTypes.ICur
   // Split the currency string value and network (if available)
   const [value, network] = currencyString.split('-');
 
-  const currency = Currency.fromSymbol(value, network);
+  const currency = Currency.fromSymbol(value, network) as RequestLogicTypes.ICurrency;
 
   // If a network was declared, add it to the currency object
   if (network) {
@@ -43,37 +43,12 @@ export function stringToCurrency(currencyString: string): RequestLogicTypes.ICur
 
 /**
  * Converts a Currency object to a readable currency string
- *
+ * @deprecated use new Currency(currency).toString() instead.
  * @param currency The currency object to get the string from
  * @returns The currency string identifier
  */
 export function currencyToString(currency: RequestLogicTypes.ICurrency): string {
-  let symbol: string;
-
-  switch (currency.type) {
-    case RequestLogicTypes.CURRENCY.BTC:
-    case RequestLogicTypes.CURRENCY.ETH:
-      symbol = currency.type;
-      break;
-    case RequestLogicTypes.CURRENCY.ISO4217:
-      symbol = currency.value;
-      break;
-    case RequestLogicTypes.CURRENCY.ERC20:
-      symbol = getErc20Symbol(currency) || 'unknown';
-      break;
-    default:
-      symbol = 'unknown';
-  }
-
-  // Return without network if we don't recognize the symbol
-  if (symbol === 'unknown') {
-    return symbol;
-  }
-
-  // If the currency have a network, append it to the currency symbol
-  const network = currency.network && currency.network !== 'mainnet' ? `-${currency.network}` : '';
-
-  return symbol + network;
+  return new Currency(currency).toString();
 }
 
 /**
@@ -150,6 +125,7 @@ export function getAllSupportedCurrencies(): {
  * @param currency
  *
  * @returns the hash of the currency
+ * @deprecated use new Currency().getHash() instead
  */
 export function getCurrencyHash(currency: RequestLogicTypes.ICurrency): string {
   if (currency.type === RequestLogicTypes.CURRENCY.ERC20) {

--- a/packages/currency/src/token.ts
+++ b/packages/currency/src/token.ts
@@ -7,19 +7,18 @@ import { getSupportedERC20Tokens } from './erc20';
  */
 export class Token extends Currency {
   constructor(
-    public value: string,
-    public type: RequestLogicTypes.CURRENCY,
-    public symbol: string,
-    public network?: string,
+    value: string,
+    type: RequestLogicTypes.CURRENCY,
+    public readonly symbol: string,
+    network?: string,
   ) {
     super({ value, type, network });
   }
 
   /**
-   * Gets a supported currency from a symbol, symbol-network or address.
+   * Gets a supported token from a symbol, symbol-network or address.
    * Iterates over all the supported networks if needed
    * @param symbolOrAddress e.g. 'DAI', 'FAU', 'FAU-rinkeby' or '0xFab46E002BbF0b4509813474841E0716E6730136'
-   * @returns an ICurrency object
    */
   static from(symbolOrAddress: string): Token {
     try {
@@ -48,8 +47,8 @@ export class Token extends Currency {
   /**
    * Same result as Currency.toString() but with a faster implementation because symbol is known
    */
-  toString = (): string => {
+  public toString(): string {
     const networkSuffix = this.network && this.network !== 'mainnet' ? `-${this.network}` : '';
     return this.symbol + networkSuffix;
-  };
+  }
 }

--- a/packages/currency/src/token.ts
+++ b/packages/currency/src/token.ts
@@ -1,0 +1,56 @@
+import { RequestLogicTypes } from '@requestnetwork/types';
+import { Currency } from './currency';
+import { getSupportedERC20Tokens } from './erc20';
+
+/**
+ * @class Token extends Currency to reference the symbol
+ */
+export class Token extends Currency {
+  constructor(
+    public value: string,
+    public type: RequestLogicTypes.CURRENCY,
+    public symbol: string,
+    public network?: string,
+  ) {
+    super({ value, type, network });
+  }
+
+  /**
+   * Gets a supported currency from a symbol, symbol-network or address.
+   * Iterates over all the supported networks if needed
+   * @param symbolOrAddress e.g. 'DAI', 'FAU', 'FAU-rinkeby' or '0xFab46E002BbF0b4509813474841E0716E6730136'
+   * @returns an ICurrency object
+   */
+  static from(symbolOrAddress: string): Token {
+    try {
+      const currencyFromSymbol = this.fromSymbol(symbolOrAddress);
+      return new Token(
+        currencyFromSymbol.value,
+        currencyFromSymbol.type,
+        symbolOrAddress,
+        currencyFromSymbol.network,
+      );
+    } catch (e) {
+      const erc20Currencies = getSupportedERC20Tokens();
+      const currencyFromAddress = erc20Currencies.find((c) => c.address === symbolOrAddress);
+      if (!currencyFromAddress) {
+        throw new Error(`The currency ${symbolOrAddress} does not exist or is not supported`);
+      }
+      return new Token(
+        currencyFromAddress.address,
+        RequestLogicTypes.CURRENCY.ERC20,
+        currencyFromAddress.symbol.split('-')[0],
+        currencyFromAddress.symbol.split('-')[1] || 'mainnet',
+      );
+    }
+  }
+
+  /**
+   * Same result as Currency.toString() but with a faster implementation because symbol is known
+   * @returns
+   */
+  toString = (): string => {
+    const networkSuffix = this.network && this.network !== 'mainnet' ? `-${this.network}` : '';
+    return this.symbol + networkSuffix;
+  };
+}

--- a/packages/currency/src/token.ts
+++ b/packages/currency/src/token.ts
@@ -47,7 +47,6 @@ export class Token extends Currency {
 
   /**
    * Same result as Currency.toString() but with a faster implementation because symbol is known
-   * @returns
    */
   toString = (): string => {
     const networkSuffix = this.network && this.network !== 'mainnet' ? `-${this.network}` : '';

--- a/packages/currency/test/currency.test.ts
+++ b/packages/currency/test/currency.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-magic-numbers */
 import { RequestLogicTypes } from '@requestnetwork/types';
 import {
+  Currency,
   currencyToString,
   getAllSupportedCurrencies,
   getCurrencyHash,
@@ -467,6 +468,100 @@ describe('api/currency', () => {
     describe('ERC20 currency hash', () => {
       it('can get currency hash of ERC20', () => {
         expect(getCurrencyHash(DAI)).toBe('0x38cF23C52Bb4B13F051Aec09580a2dE845a7FA35');
+      });
+    });
+  });
+
+  describe('Currency.from()', () => {
+    describe('mainnet', () => {
+      it('ETH from ETH', () => {
+        expect(Currency.from('ETH')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ETH,
+          value: 'ETH',
+        });
+      });
+
+      it('DAI from DAI', () => {
+        expect(Currency.from('DAI')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+          network: 'mainnet',
+        });
+        expect(Currency.from('DAI').toString()).toEqual('DAI');
+      });
+
+      it('REQ from REQ', () => {
+        expect(Currency.from('REQ')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x8f8221aFbB33998d8584A2B05749bA73c37a938a',
+          network: 'mainnet',
+        });
+      });
+
+      it('MPH from MPH', () => {
+        expect(Currency.from('MPH')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x8888801af4d980682e47f1a9036e589479e835c5',
+          network: 'mainnet',
+        });
+      });
+
+      it('INDA from INDA', () => {
+        expect(Currency.from('INDA')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x433d86336dB759855A66cCAbe4338313a8A7fc77',
+          network: 'mainnet',
+        });
+      });
+
+      it('DAI from 0x6B175474E89094C44Da98b954EedeAC495271d0F', () => {
+        expect(Currency.from('0x6B175474E89094C44Da98b954EedeAC495271d0F')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+          network: 'mainnet',
+        });
+      });
+
+      it('EUR from EUR', () => {
+        expect(Currency.from('EUR')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ISO4217,
+          value: 'EUR',
+        });
+      });
+    });
+
+    describe('rinkeby', () => {
+      it('FAU from FAU', () => {
+        expect(Currency.from('FAU')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0xFab46E002BbF0b4509813474841E0716E6730136',
+          network: 'rinkeby',
+        });
+        expect(Currency.from('FAU').toString()).toEqual('FAU-rinkeby');
+      });
+
+      it('FAU from FAU-rinkeby', () => {
+        expect(Currency.from('FAU')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0xFab46E002BbF0b4509813474841E0716E6730136',
+          network: 'rinkeby',
+        });
+      });
+
+      it('CTBK from CTBK', () => {
+        expect(Currency.from('CTBK')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x995d6A8C21F24be1Dd04E105DD0d83758343E258',
+          network: 'rinkeby',
+        });
+      });
+    });
+
+    describe('errors', () => {
+      it('Unsupported currencies should throw', () => {
+        expect(() => Currency.from('UNSUPPORTED')).toThrow(
+          'The currency UNSUPPORTED does not exist or is not supported',
+        );
       });
     });
   });

--- a/packages/currency/test/token.test.ts
+++ b/packages/currency/test/token.test.ts
@@ -1,0 +1,109 @@
+/* eslint-disable no-magic-numbers */
+import { RequestLogicTypes } from '@requestnetwork/types';
+import { Token } from '../src';
+
+describe('api/currency Token', () => {
+  describe('Token.from()', () => {
+    describe('mainnet', () => {
+      it('ETH from ETH', () => {
+        expect(Token.from('ETH')).toMatchObject({
+          symbol: 'ETH',
+          type: RequestLogicTypes.CURRENCY.ETH,
+          value: 'ETH',
+        });
+      });
+
+      it('DAI from DAI', () => {
+        expect(Token.from('DAI')).toMatchObject({
+          symbol: 'DAI',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+          network: 'mainnet',
+        });
+        expect(Token.from('DAI').toString()).toEqual('DAI');
+      });
+
+      it('REQ from REQ', () => {
+        expect(Token.from('REQ')).toMatchObject({
+          symbol: 'REQ',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x8f8221aFbB33998d8584A2B05749bA73c37a938a',
+          network: 'mainnet',
+        });
+      });
+
+      it('MPH from MPH', () => {
+        expect(Token.from('MPH')).toMatchObject({
+          symbol: 'MPH',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x8888801af4d980682e47f1a9036e589479e835c5',
+          network: 'mainnet',
+        });
+      });
+
+      it('INDA from INDA', () => {
+        expect(Token.from('INDA')).toMatchObject({
+          symbol: 'INDA',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x433d86336dB759855A66cCAbe4338313a8A7fc77',
+          network: 'mainnet',
+        });
+      });
+
+      it('DAI from 0x6B175474E89094C44Da98b954EedeAC495271d0F', () => {
+        expect(Token.from('0x6B175474E89094C44Da98b954EedeAC495271d0F')).toMatchObject({
+          symbol: 'DAI',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+          network: 'mainnet',
+        });
+      });
+
+      it('EUR from EUR', () => {
+        expect(Token.from('EUR')).toMatchObject({
+          symbol: 'EUR',
+          type: RequestLogicTypes.CURRENCY.ISO4217,
+          value: 'EUR',
+        });
+      });
+    });
+
+    describe('rinkeby', () => {
+      it('FAU from FAU', () => {
+        expect(Token.from('FAU')).toMatchObject({
+          symbol: 'FAU',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0xFab46E002BbF0b4509813474841E0716E6730136',
+          network: 'rinkeby',
+        });
+        expect(Token.from('FAU').toString()).toEqual('FAU-rinkeby');
+      });
+
+      it('FAU from FAU-rinkeby', () => {
+        expect(Token.from('FAU')).toMatchObject({
+          symbol: 'FAU',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0xFab46E002BbF0b4509813474841E0716E6730136',
+          network: 'rinkeby',
+        });
+      });
+
+      it('CTBK from CTBK', () => {
+        expect(Token.from('CTBK')).toMatchObject({
+          symbol: 'CTBK',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x995d6A8C21F24be1Dd04E105DD0d83758343E258',
+          network: 'rinkeby',
+        });
+      });
+    });
+
+    describe('errors', () => {
+      it('Unsupported tokens should throw', () => {
+        expect(() => Token.from('UNSUPPORTED')).toThrow(
+          'The currency UNSUPPORTED does not exist or is not supported',
+        );
+      });
+    });
+  });
+});

--- a/packages/payment-detection/src/any/any-to-erc20-proxy-info-retriever.ts
+++ b/packages/payment-detection/src/any/any-to-erc20-proxy-info-retriever.ts
@@ -1,4 +1,4 @@
-import { getDecimalsForCurrency, getCurrencyHash } from '@requestnetwork/currency';
+import { getDecimalsForCurrency, Currency } from '@requestnetwork/currency';
 import { PaymentTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { BigNumber, ethers } from 'ethers';
 import { getDefaultProvider } from '../provider';
@@ -145,7 +145,7 @@ export default class ProxyERC20InfoRetriever
           // check the rate timespan
           this.maxRateTimespan >= conversionLog.maxRateTimespan.toNumber() &&
           // check the requestCurrency
-          getCurrencyHash(this.requestCurrency).toLowerCase() ===
+          new Currency(this.requestCurrency).getHash().toLowerCase() ===
             conversionLog.currency.toLowerCase() &&
           // check to address
           proxyLog.to.toLowerCase() === this.toAddress.toLowerCase(),

--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -16,7 +16,7 @@ import {
 import Utils from '@requestnetwork/utils';
 import * as Types from '../types';
 import ContentDataExtension from './content-data-extension';
-import { stringToCurrency } from '@requestnetwork/currency';
+import { Currency } from '@requestnetwork/currency';
 import { utils as ethersUtils } from 'ethers';
 import Request from './request';
 import localUtils from './utils';
@@ -351,7 +351,7 @@ export default class RequestNetwork {
     const requestParameters = {
       ...parameters.requestInfo,
       // if request currency is a string, convert it to currency object
-      currency: typeof currency === 'string' ? stringToCurrency(currency) : currency,
+      currency: typeof currency === 'string' ? Currency.from(currency) : currency,
     };
     const paymentNetworkCreationParameters = parameters.paymentNetwork;
     const contentData = parameters.contentData;

--- a/packages/request-client.js/src/api/request.ts
+++ b/packages/request-client.js/src/api/request.ts
@@ -5,7 +5,7 @@ import { IdentityTypes, PaymentTypes, RequestLogicTypes } from '@requestnetwork/
 import Utils from '@requestnetwork/utils';
 import * as Types from '../types';
 import ContentDataExtension from './content-data-extension';
-import { currencyToString } from '@requestnetwork/currency';
+import { Currency } from '@requestnetwork/currency';
 import localUtils from './utils';
 
 /**
@@ -679,7 +679,7 @@ export default class Request {
       ...requestData,
       balance: this.balance,
       contentData: this.contentData,
-      currency: requestData.currency ? currencyToString(requestData.currency) : 'unknown',
+      currency: requestData.currency ? new Currency(requestData.currency).toString() : 'unknown',
       currencyInfo: requestData.currency,
       meta: this.requestMeta,
       pending,

--- a/packages/toolbox/src/chainlinkConversionPathTools.ts
+++ b/packages/toolbox/src/chainlinkConversionPathTools.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import { chainlinkConversionPath } from '@requestnetwork/smart-contracts';
 import { ChainlinkConversionPath__factory } from '@requestnetwork/smart-contracts/types';
-import { getCurrencyHash, stringToCurrency } from '@requestnetwork/currency';
+import { Currency } from '@requestnetwork/currency';
 import { RequestLogicTypes } from '@requestnetwork/types';
 import iso4217 from '@requestnetwork/currency/dist/iso4217';
 import { LogDescription } from 'ethers/lib/utils';
@@ -110,16 +110,17 @@ class ChainlinkConversionPathTools {
   }
 }
 
-const knownCurrencies = [...iso4217.map((x) => x.code), 'ETH'].reduce(
-  (prev, curr) => ({
+// Record currency [currency hash] => {value (address or symbol), type}
+const knownCurrencies = [...iso4217.map((x) => x.code), 'ETH'].reduce((prev, symbol) => {
+  const currency = Currency.fromSymbol(symbol);
+  return {
     ...prev,
-    [getCurrencyHash(stringToCurrency(curr)).toLowerCase()]: {
-      value: curr,
-      type: stringToCurrency(curr).type,
+    [currency.getHash().toLowerCase()]: {
+      value: currency.value,
+      type: currency.type,
     },
-  }),
-  {} as Record<string, { value: string; type: RequestLogicTypes.CURRENCY }>,
-);
+  };
+}, {} as Record<string, { value: string; type: RequestLogicTypes.CURRENCY }>);
 
 const addSupportedCurrency = (
   ccy: string,
@@ -190,6 +191,6 @@ export const showCurrencyHash = async (options?: IOptions): Promise<void> => {
   }
   console.log('#####################################################################');
   console.log(`Currency hash of: ${options.currencyCode}`);
-  console.log(getCurrencyHash(stringToCurrency(options.currencyCode)));
+  console.log(Currency.fromSymbol(options.currencyCode).getHash());
   console.log('#####################################################################');
 };


### PR DESCRIPTION
Motivation: ease the use of the different helpers we have for currencies.

This is a first step, we should migrate all the similar utilities to class or object method, IMO.

* chore: Token an Currency classes design
* feat: fetch a currency from its address with `Currency.from(...)`