### PR TITLE
chore: currency.getDecimals() and fixes

### DIFF
--- a/packages/currency/README.md
+++ b/packages/currency/README.md
@@ -13,19 +13,19 @@ npm install @requestnetwork/currency
 
 ```javascript
 import { RequestLogicTypes } from '@requestnetwork/types';
-import { getDecimalsForCurrency, getCurrencyHash, Currency, Token } from '@requestnetwork/currency';
+import { Currency, Token } from '@requestnetwork/currency';
 
-const decimals = getDecimalsForCurrency({
+const decimals = new Currency({
   type: RequestLogicTypes.CURRENCY.ETH,
   value: 'ETH',
-});
+}).getDecimals();
 
 console.log(decimals); // 18
 
-const ETHHash = getCurrencyHash({
+const ETHHash = new Currency({
   type: RequestLogicTypes.CURRENCY.ETH,
   value: 'ETH',
-});
+}).getHash();
 
 console.log(ETHHash); // 0xF5AF88e117747e87fC5929F2ff87221B1447652E
 

--- a/packages/currency/src/erc20/networks/mainnet.ts
+++ b/packages/currency/src/erc20/networks/mainnet.ts
@@ -6,7 +6,7 @@ import * as metamaskContractMap from '@metamask/contract-metadata';
 // A Token description from the eth-contract-metadata list
 interface ITokenDescription {
   name: string;
-  logo: string;
+  logo?: string;
   erc20: boolean;
   symbol: string;
   decimals: number;

--- a/packages/currency/src/index.ts
+++ b/packages/currency/src/index.ts
@@ -1,7 +1,7 @@
 import { RequestLogicTypes } from '@requestnetwork/types';
 import iso4217 from './iso4217';
 import othersCurrencies from './others';
-import { getErc20Decimals, getSupportedERC20Tokens } from './erc20';
+import { getSupportedERC20Tokens } from './erc20';
 import { Currency } from './currency';
 export { Currency } from './currency';
 export { Token } from './token';
@@ -54,30 +54,11 @@ export function currencyToString(currency: RequestLogicTypes.ICurrency): string 
  * Returns the number of decimals for a currency
  *
  * @param currency The currency
+ * @deprecated Use new Currency().getDecimals() instead
  * @returns The number of decimals
  */
 export function getDecimalsForCurrency(currency: RequestLogicTypes.ICurrency): number {
-  // Return decimals if currency is an ERC20
-  if (currency.type === RequestLogicTypes.CURRENCY.ERC20) {
-    return getErc20Decimals(currency);
-  }
-
-  // Return the number of decimals for ISO-4217 currencies
-  if (currency.type === RequestLogicTypes.CURRENCY.ISO4217) {
-    const iso = iso4217.find((i) => i.code === currency.value);
-    if (!iso) {
-      throw new Error(`Unsupported ISO currency ${currency.value}`);
-    }
-    return iso.digits;
-  }
-
-  // other currencies
-  const otherCurrency = othersCurrencies[currency.type];
-  if (!otherCurrency) {
-    throw new Error(`Currency ${currency.type} not implemented`);
-  }
-
-  return otherCurrency.decimals;
+  return new Currency(currency).getDecimals();
 }
 
 /**

--- a/packages/currency/src/token.ts
+++ b/packages/currency/src/token.ts
@@ -31,7 +31,9 @@ export class Token extends Currency {
       );
     } catch (e) {
       const erc20Currencies = getSupportedERC20Tokens();
-      const currencyFromAddress = erc20Currencies.find((c) => c.address === symbolOrAddress);
+      const currencyFromAddress = erc20Currencies.find(
+        (c) => c.address.toLowerCase() === symbolOrAddress.toLowerCase(),
+      );
       if (!currencyFromAddress) {
         throw new Error(`The currency ${symbolOrAddress} does not exist or is not supported`);
       }
@@ -42,6 +44,13 @@ export class Token extends Currency {
         currencyFromAddress.symbol.split('-')[1] || 'mainnet',
       );
     }
+  }
+
+  /**
+   * Override for efficiency
+   */
+  public getSymbol(): string {
+    return this.symbol;
   }
 
   /**

--- a/packages/currency/test/currency.test.ts
+++ b/packages/currency/test/currency.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers */
 import { RequestLogicTypes } from '@requestnetwork/types';
-import { Currency, getAllSupportedCurrencies, getDecimalsForCurrency } from '../src';
+import { Currency, getAllSupportedCurrencies } from '../src';
 
 describe('api/currency', () => {
   describe('getAllSupportedCurrencies', () => {
@@ -69,77 +69,77 @@ describe('api/currency', () => {
     });
   });
 
-  describe('getDecimalsForCurrency', () => {
+  describe('currency.getDecimals()', () => {
     it('returns the correct number of decimals', () => {
       expect(
-        getDecimalsForCurrency({
+        new Currency({
           type: RequestLogicTypes.CURRENCY.ETH,
           value: 'ETH',
-        }),
+        }).getDecimals(),
       ).toEqual(18);
     });
 
     it('throws for invalid currencies', () => {
       expect(() =>
-        getDecimalsForCurrency({
+        new Currency({
           type: 'BANANA' as RequestLogicTypes.CURRENCY,
           value: 'SPLIT',
-        } as RequestLogicTypes.ICurrency),
+        } as RequestLogicTypes.ICurrency).getDecimals(),
       ).toThrow();
     });
 
     it('returns the correct number of decimals for a supported ERC20', () => {
       expect(
-        getDecimalsForCurrency({
+        new Currency({
           network: 'mainnet',
           type: RequestLogicTypes.CURRENCY.ERC20,
           value: '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359', // SAI
-        }),
+        }).getDecimals(),
       ).toEqual(18);
     });
 
     it('throws for a non-supported ERC20', () => {
       expect(() =>
-        getDecimalsForCurrency({
+        new Currency({
           network: 'private',
           type: RequestLogicTypes.CURRENCY.ERC20,
           value: '0x9FBDa871d559710256a2502A2517b794B482Db40', // local ERC20 contract
-        }),
+        }).getDecimals(),
       ).toThrow();
     });
 
     it('returns the correct number of decimals for a a celo ERC20', () => {
       expect(
-        getDecimalsForCurrency({
+        new Currency({
           network: 'celo',
           type: RequestLogicTypes.CURRENCY.ERC20,
           value: '0x765DE816845861e75A25fCA122bb6898B8B1282a', // Celo Dollar
-        }),
+        }).getDecimals(),
       ).toEqual(18);
     });
 
     it('return the correct currency for USD and EUR strings', () => {
       expect(
-        getDecimalsForCurrency({
+        new Currency({
           type: RequestLogicTypes.CURRENCY.ISO4217,
           value: 'USD',
-        }),
+        }).getDecimals(),
       ).toEqual(2);
 
       expect(
-        getDecimalsForCurrency({
+        new Currency({
           type: RequestLogicTypes.CURRENCY.ISO4217,
           value: 'EUR',
-        }),
+        }).getDecimals(),
       ).toEqual(2);
     });
 
     it('throws for unknown ISO4217 currency', () => {
       expect(() =>
-        getDecimalsForCurrency({
+        new Currency({
           type: RequestLogicTypes.CURRENCY.ISO4217,
           value: 'YOYO',
-        }),
+        }).getDecimals(),
       ).toThrow(`Unsupported ISO currency YOYO`);
     });
   });
@@ -200,27 +200,6 @@ describe('api/currency', () => {
       expect(Currency.fromSymbol('EUR')).toEqual({
         type: RequestLogicTypes.CURRENCY.ISO4217,
         value: 'EUR',
-      });
-    });
-  });
-
-  describe('Currency.fromSymbol()', () => {
-    it('throws for SAI not on mainnet', () => {
-      expect(() => Currency.fromSymbol('SAI-rinkeby')).toThrow();
-    });
-
-    it('throws for an unsupported currency', () => {
-      expect(() => Currency.fromSymbol('XXXXXXX')).toThrow();
-    });
-
-    describe('errors and edge cases', () => {
-      it('throws for empty symbol', () => {
-        expect(() => Currency.fromSymbol('')).toThrow(`Cannot guess currency from empty symbol.`);
-      });
-      it('Unsupported network should throw', () => {
-        expect(() => Currency.fromSymbol('ETH', 'UNSUPPORTED')).toThrow(
-          "The currency symbol 'ETH' on UNSUPPORTED is unknown or not supported",
-        );
       });
     });
   });
@@ -453,6 +432,27 @@ describe('api/currency', () => {
     });
   });
 
+  describe('Currency.fromSymbol()', () => {
+    it('throws for SAI not on mainnet', () => {
+      expect(() => Currency.fromSymbol('SAI-rinkeby')).toThrow();
+    });
+
+    it('throws for an unsupported currency', () => {
+      expect(() => Currency.fromSymbol('XXXXXXX')).toThrow();
+    });
+
+    describe('errors and edge cases', () => {
+      it('throws for empty symbol', () => {
+        expect(() => Currency.fromSymbol('')).toThrow(`Cannot guess currency from empty symbol.`);
+      });
+      it('Unsupported network should throw', () => {
+        expect(() => Currency.fromSymbol('ETH', 'UNSUPPORTED')).toThrow(
+          "The currency symbol 'ETH' on UNSUPPORTED is unknown or not supported",
+        );
+      });
+    });
+  });
+
   describe('Currency.from()', () => {
     describe('mainnet', () => {
       it('ETH from ETH', () => {
@@ -499,6 +499,14 @@ describe('api/currency', () => {
         expect(Currency.from('0x6B175474E89094C44Da98b954EedeAC495271d0F')).toMatchObject({
           type: RequestLogicTypes.CURRENCY.ERC20,
           value: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+          network: 'mainnet',
+        });
+      });
+
+      it('fetches extra-currency from address (INDA)', () => {
+        expect(Currency.from('0x433d86336db759855a66ccabe4338313a8a7fc77')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x433d86336db759855a66ccabe4338313a8a7fc77',
           network: 'mainnet',
         });
       });

--- a/packages/currency/test/currency.test.ts
+++ b/packages/currency/test/currency.test.ts
@@ -506,7 +506,7 @@ describe('api/currency', () => {
       it('fetches extra-currency from address (INDA)', () => {
         expect(Currency.from('0x433d86336db759855a66ccabe4338313a8a7fc77')).toMatchObject({
           type: RequestLogicTypes.CURRENCY.ERC20,
-          value: '0x433d86336db759855a66ccabe4338313a8a7fc77',
+          value: '0x433d86336dB759855A66cCAbe4338313a8A7fc77',
           network: 'mainnet',
         });
       });

--- a/packages/currency/test/token.test.ts
+++ b/packages/currency/test/token.test.ts
@@ -50,8 +50,28 @@ describe('api/currency Token', () => {
         });
       });
 
-      it('DAI from 0x6B175474E89094C44Da98b954EedeAC495271d0F', () => {
+      it('fetches extra-currency from address (INDA)', () => {
+        expect(Token.from('0x433d86336dB759855A66cCAbe4338313a8A7fc77')).toMatchObject({
+          symbol: 'INDA',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x433d86336dB759855A66cCAbe4338313a8A7fc77',
+          network: 'mainnet',
+        });
+      });
+
+      it('DAI from DAI address (checksum)', () => {
         expect(Token.from('0x6B175474E89094C44Da98b954EedeAC495271d0F')).toMatchObject({
+          symbol: 'DAI',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+          network: 'mainnet',
+        });
+      });
+
+      it('DAI from DAI address (lower case)', () => {
+        expect(
+          Token.from('0x6B175474E89094C44Da98b954EedeAC495271d0F'.toLowerCase()),
+        ).toMatchObject({
           symbol: 'DAI',
           type: RequestLogicTypes.CURRENCY.ERC20,
           value: '0x6B175474E89094C44Da98b954EedeAC495271d0F',

--- a/packages/payment-detection/src/any/any-to-erc20-proxy-info-retriever.ts
+++ b/packages/payment-detection/src/any/any-to-erc20-proxy-info-retriever.ts
@@ -1,4 +1,4 @@
-import { getDecimalsForCurrency, Currency } from '@requestnetwork/currency';
+import { Currency } from '@requestnetwork/currency';
 import { PaymentTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { BigNumber, ethers } from 'ethers';
 import { getDefaultProvider } from '../provider';
@@ -153,7 +153,7 @@ export default class ProxyERC20InfoRetriever
       // Creates the balance events
       .map(async ({ conversionLog, proxyLog, blockNumber, transactionHash }) => {
         const chainlinkDecimal = 8;
-        const decimalPadding = chainlinkDecimal - getDecimalsForCurrency(this.requestCurrency);
+        const decimalPadding = chainlinkDecimal - new Currency(this.requestCurrency).getDecimals();
 
         const amountWithRightDecimal = conversionLog.amount.div(10 ** decimalPadding).toString();
         const feeAmountWithRightDecimal = conversionLog.feeAmount

--- a/packages/payment-processor/src/payment/any-to-erc20-proxy.ts
+++ b/packages/payment-processor/src/payment/any-to-erc20-proxy.ts
@@ -1,6 +1,6 @@
 import { constants, ContractTransaction, Signer, providers, BigNumber, BigNumberish } from 'ethers';
 
-import { getDecimalsForCurrency, getConversionPath } from '@requestnetwork/currency';
+import { getConversionPath, Currency } from '@requestnetwork/currency';
 import { erc20ConversionProxy } from '@requestnetwork/smart-contracts';
 import { Erc20ConversionProxy__factory } from '@requestnetwork/smart-contracts/types';
 import { ClientTypes, RequestLogicTypes } from '@requestnetwork/types';
@@ -114,7 +114,7 @@ export async function encodePayAnyToErc20ProxyRequest(
 
   const chainlinkDecimal = 8;
   const decimalPadding = Math.max(
-    chainlinkDecimal - getDecimalsForCurrency(request.currencyInfo),
+    chainlinkDecimal - new Currency(request.currencyInfo).getDecimals(),
     0,
   );
 

--- a/packages/request-client.js/src/api/utils.ts
+++ b/packages/request-client.js/src/api/utils.ts
@@ -1,12 +1,10 @@
 import { RequestLogicTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
-import { getDecimalsForCurrency } from '@requestnetwork/currency';
 /**
  * Collection of utils functions related to the library, meant to simplify its use.
  */
 export default {
   formatGetRequestFromIdError,
-  getDecimalsForCurrency,
 
   /**
    * Returns the current timestamp in second


### PR DESCRIPTION
chore: deprecate getDecimalsForCurrency, replaced with currency.getDecimals()
fix: Currency.from() for lower case addresses