### PR TITLE
fix: error message when payment address is missing

### DIFF
--- a/packages/advanced-logic/src/extensions/payment-network/erc20/fee-proxy-contract.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/fee-proxy-contract.ts
@@ -245,6 +245,9 @@ function applyCreation(
     throw Error('version is missing');
   }
   if (!extensionAction.parameters.paymentAddress) {
+    throw Error('paymentAddress is missing');
+  }
+  if (!extensionAction.parameters.salt) {
     throw Error('salt is missing');
   }
   if (


### PR DESCRIPTION
Note: we miss unit tests for `applyCreation()`, I add it to the backlog