### PR TITLE
fix: amount padding for conversion of crypto amounts

### DIFF
--- a/packages/payment-processor/src/payment/utils.ts
+++ b/packages/payment-processor/src/payment/utils.ts
@@ -276,13 +276,14 @@ export const padAmountForChainlink = (amount: BigNumberish, currency: Currency) 
       decimalPadding = Math.max(chainlinkFiatDecimal - currency.getDecimals(), 0);
       break;
     }
+    case RequestLogicTypes.CURRENCY.ETH:
     case RequestLogicTypes.CURRENCY.ERC20: {
       decimalPadding = 0;
       break;
     }
     default:
       throw new Error(
-        'Unsupported request currency for conversion with Chainlink. The request currency has to be fiat or ERC20.',
+        'Unsupported request currency for conversion with Chainlink. The request currency has to be fiat, ETH or ERC20.',
       );
   }
   // eslint-disable-next-line no-magic-numbers

--- a/packages/payment-processor/src/payment/utils.ts
+++ b/packages/payment-processor/src/payment/utils.ts
@@ -264,3 +264,27 @@ export function getAmountToPay(
   }
   return amountToPay;
 }
+
+/**
+ * Pads an amount to match Chainlink's own currency decimals (eg. for fiat amounts).
+ */
+export const padAmountForChainlink = (amount: BigNumberish, currency: Currency) => {
+  let decimalPadding: number;
+  switch (currency.type) {
+    case RequestLogicTypes.CURRENCY.ISO4217: {
+      const chainlinkFiatDecimal = 8;
+      decimalPadding = Math.max(chainlinkFiatDecimal - currency.getDecimals(), 0);
+      break;
+    }
+    case RequestLogicTypes.CURRENCY.ERC20: {
+      decimalPadding = 0;
+      break;
+    }
+    default:
+      throw new Error(
+        'Unsupported request currency for conversion with Chainlink. The request currency has to be fiat or ERC20.',
+      );
+  }
+  // eslint-disable-next-line no-magic-numbers
+  return BigNumber.from(amount).mul(10 ** decimalPadding);
+};

--- a/packages/payment-processor/test/payment/utils.test.ts
+++ b/packages/payment-processor/test/payment/utils.test.ts
@@ -1,10 +1,12 @@
 import { Wallet, providers, BigNumber } from 'ethers';
 
+import { Currency } from '@requestnetwork/currency';
 import {
   getAmountToPay,
   getNetworkProvider,
   getProvider,
   getSigner,
+  padAmountForChainlink,
 } from '../../src/payment/utils';
 
 describe('getAmountToPay', () => {
@@ -128,5 +130,30 @@ describe('getSigner', () => {
 
   it('should throw an error if the provider is not supported', () => {
     expect(() => getSigner({} as any)).toThrowError('cannot get signer');
+  });
+});
+
+describe('conversion: padding amounts for Chainlink', () => {
+  it('should throw on currencies not implemented in the library', () => {
+    const requestCurrency = Currency.fromSymbol('BTC');
+    const twentyBtc = '2000000000';
+    expect(() => padAmountForChainlink(twentyBtc, requestCurrency)).toThrowError(
+      'Unsupported request currency for conversion with Chainlink. The request currency has to be fiat or ERC20.',
+    );
+  });
+  it('should pad fiat amounts', () => {
+    const requestCurrency = Currency.fromSymbol('EUR');
+    const twentyEur = '2000';
+    expect(padAmountForChainlink(twentyEur, requestCurrency).toString()).toBe('2000000000');
+  });
+  it('should not pad crypto amounts (DAI)', () => {
+    const requestCurrency = Currency.fromSymbol('DAI');
+    const twentyDai = '20000000000000000000';
+    expect(padAmountForChainlink(twentyDai, requestCurrency).toString()).toBe(twentyDai);
+  });
+  it('should not pad crypto amounts (USDC)', () => {
+    const requestCurrency = Currency.fromSymbol('USDC');
+    const twentyUsdc = '20000000';
+    expect(padAmountForChainlink(twentyUsdc, requestCurrency).toString()).toBe(twentyUsdc);
   });
 });

--- a/packages/payment-processor/test/payment/utils.test.ts
+++ b/packages/payment-processor/test/payment/utils.test.ts
@@ -138,13 +138,18 @@ describe('conversion: padding amounts for Chainlink', () => {
     const requestCurrency = Currency.fromSymbol('BTC');
     const twentyBtc = '2000000000';
     expect(() => padAmountForChainlink(twentyBtc, requestCurrency)).toThrowError(
-      'Unsupported request currency for conversion with Chainlink. The request currency has to be fiat or ERC20.',
+      'Unsupported request currency for conversion with Chainlink. The request currency has to be fiat, ETH or ERC20.',
     );
   });
   it('should pad fiat amounts', () => {
     const requestCurrency = Currency.fromSymbol('EUR');
     const twentyEur = '2000';
     expect(padAmountForChainlink(twentyEur, requestCurrency).toString()).toBe('2000000000');
+  });
+  it('should not pad crypto amounts (ETH)', () => {
+    const requestCurrency = Currency.fromSymbol('ETH');
+    const twentyEth = '20000000000000000000';
+    expect(padAmountForChainlink(twentyEth, requestCurrency).toString()).toBe(twentyEth);
   });
   it('should not pad crypto amounts (DAI)', () => {
     const requestCurrency = Currency.fromSymbol('DAI');


### PR DESCRIPTION
This PR fixes the bug that makes it impossible to pay a request denominated in crypto with another crypto with on-payment conversion.