### PR TITLE
chore: re-use parseLogArgs

### DIFF
--- a/packages/payment-detection/src/index.ts
+++ b/packages/payment-detection/src/index.ts
@@ -7,7 +7,7 @@ import * as Erc20PaymentNetwork from './erc20';
 import * as EthPaymentNetwork from './eth';
 import { initPaymentDetectionApiKeys, setProviderFactory, getDefaultProvider } from './provider';
 import { getTheGraphClient, networkSupportsTheGraph } from './thegraph';
-import { padAmountForChainlink, unpadAmountFromChainlink } from './utils';
+import { parseLogArgs, padAmountForChainlink, unpadAmountFromChainlink } from './utils';
 export type { TheGraphClient } from './thegraph';
 
 export {
@@ -22,6 +22,7 @@ export {
   getDefaultProvider,
   getTheGraphClient,
   networkSupportsTheGraph,
+  parseLogArgs,
   padAmountForChainlink,
   unpadAmountFromChainlink,
 };

--- a/packages/payment-detection/test/utils.test.ts
+++ b/packages/payment-detection/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { Currency } from '@requestnetwork/currency';
-import { padAmountForChainlink, unpadAmountFromChainlink } from '../src/utils';
+import { padAmountForChainlink, unpadAmountFromChainlink } from '../src';
 
 describe('conversion: padding amounts for Chainlink', () => {
   it('should throw on currencies not implemented in the library', () => {

--- a/packages/toolbox/src/chainlinkConversionPathTools.ts
+++ b/packages/toolbox/src/chainlinkConversionPathTools.ts
@@ -1,11 +1,10 @@
 import { ethers } from 'ethers';
 import { chainlinkConversionPath } from '@requestnetwork/smart-contracts';
-import { getDefaultProvider } from '@requestnetwork/payment-detection';
+import { getDefaultProvider, parseLogArgs } from '@requestnetwork/payment-detection';
 import { ChainlinkConversionPath__factory } from '@requestnetwork/smart-contracts/types';
 import { Currency } from '@requestnetwork/currency';
 import { RequestLogicTypes } from '@requestnetwork/types';
 import iso4217 from '@requestnetwork/currency/dist/iso4217';
-import { LogDescription } from 'ethers/lib/utils';
 
 export interface IOptions {
   network?: string;
@@ -17,16 +16,6 @@ type AggregatorUpdatedArgs = {
   _input: string;
   _output: string;
   _aggregator: string;
-};
-
-/**
- * Converts the Log's args from array to an object with keys being the name of the arguments
- */
-export const parseLogArgs = <T>({ args, eventFragment }: LogDescription): T => {
-  return args.reduce((prev, current, i) => {
-    prev[eventFragment.inputs[i].name] = current;
-    return prev;
-  }, {});
 };
 
 /**


### PR DESCRIPTION
Code climate was complaining about it, it's not a big deal but it could prevent some mistakes.