### PR TITLE
feat: fantom/fuse RPC url & explorer api key per network

### DIFF
--- a/packages/payment-detection/src/eth/info-retriever.ts
+++ b/packages/payment-detection/src/eth/info-retriever.ts
@@ -11,14 +11,14 @@ export default class ETHInfoRetriever
    * @param eventName Indicate if it is an address for payment or refund
    * @param network The id of network we want to check
    * @param paymentReference The reference to identify the payment
-   * @param etherscanApiToken The etherscan API token
+   * @param explorerApiKey The explorer (etherscan...) API key
    */
   constructor(
     private toAddress: string,
     private eventName: PaymentTypes.EVENTS_NAMES,
     private network: string,
     private paymentReference: string,
-    private etherscanApiKey?: string,
+    private explorerApiKey?: string,
   ) {}
 
   public async getTransferEvents(): Promise<PaymentTypes.ETHPaymentNetworkEvent[]> {
@@ -27,7 +27,7 @@ export default class ETHInfoRetriever
         'ETH input data info-retriever works with etherscan and cannot work on a local network',
       );
     }
-    const provider = new MultichainExplorerApiProvider(this.network, this.etherscanApiKey);
+    const provider = new MultichainExplorerApiProvider(this.network, this.explorerApiKey);
     const history = await provider.getHistory(this.toAddress);
 
     const events = history

--- a/packages/payment-detection/src/eth/info-retriever.ts
+++ b/packages/payment-detection/src/eth/info-retriever.ts
@@ -18,7 +18,7 @@ export default class ETHInfoRetriever
     private eventName: PaymentTypes.EVENTS_NAMES,
     private network: string,
     private paymentReference: string,
-    private etherscanApiKey: string = 'TCVQQU5V39TAS1V6HF61P9K7IJZVEHH1D9',
+    private etherscanApiKey?: string,
   ) {}
 
   public async getTransferEvents(): Promise<PaymentTypes.ETHPaymentNetworkEvent[]> {

--- a/packages/payment-detection/src/eth/input-data.ts
+++ b/packages/payment-detection/src/eth/input-data.ts
@@ -42,11 +42,19 @@ const PROXY_CONTRACT_ADDRESS_MAP: IProxyContractVersion = {
 export default class PaymentNetworkETHInputData
   implements PaymentTypes.IPaymentNetwork<PaymentTypes.IETHPaymentEventParameters> {
   private extension: ExtensionTypes.PnReferenceBased.IReferenceBased;
+  private explorerApiKeys: Record<string, string>;
   /**
    * @param extension The advanced logic payment network extensions
    */
-  public constructor({ advancedLogic }: { advancedLogic: AdvancedLogicTypes.IAdvancedLogic }) {
+  public constructor({
+    advancedLogic,
+    explorerApiKeys,
+  }: {
+    advancedLogic: AdvancedLogicTypes.IAdvancedLogic;
+    explorerApiKeys?: Record<string, string>;
+  }) {
     this.extension = advancedLogic.extensions.ethereumInputData;
+    this.explorerApiKeys = explorerApiKeys || {};
   }
 
   /**
@@ -209,6 +217,7 @@ export default class PaymentNetworkETHInputData
       eventName,
       network,
       paymentReference,
+      this.explorerApiKeys[network],
     );
 
     const events = await infoRetriever.getTransferEvents();

--- a/packages/payment-detection/src/eth/multichainExplorerApiProvider.ts
+++ b/packages/payment-detection/src/eth/multichainExplorerApiProvider.ts
@@ -15,6 +15,9 @@ export class MultichainExplorerApiProvider extends ethers.providers.EtherscanPro
     if (typeof network === 'string' && networks[network]) {
       network = networks[network];
     }
+    if (!apiKey && (network === 'mainnet' || network === 'rinkeby')) {
+      apiKey = 'TCVQQU5V39TAS1V6HF61P9K7IJZVEHH1D9';
+    }
     super(network, apiKey);
   }
 

--- a/packages/payment-detection/src/payment-network-factory.ts
+++ b/packages/payment-detection/src/payment-network-factory.ts
@@ -90,16 +90,19 @@ export default class PaymentNetworkFactory {
    * @param advancedLogic the advanced-logic layer in charge of the extensions
    * @param request the request
    * @param bitcoinDetectionProvider bitcoin detection provider
+   * @param explorerApiKeys the explorer API (eg Etherscan) api keys, for PNs that rely on it. Record by network name.
    * @returns the module to handle the payment network or null if no payment network found
    */
   public static getPaymentNetworkFromRequest({
     advancedLogic,
     request,
     bitcoinDetectionProvider,
+    explorerApiKeys,
   }: {
     advancedLogic: AdvancedLogicTypes.IAdvancedLogic;
     request: RequestLogicTypes.IRequest;
     bitcoinDetectionProvider?: PaymentTypes.IBitcoinDetectionProvider;
+    explorerApiKeys?: Record<string, string>;
   }): PaymentTypes.IPaymentNetwork | null {
     const currency = request.currency;
     const extensionPaymentNetwork = Object.values(request.extensions || {}).find(
@@ -124,6 +127,7 @@ export default class PaymentNetworkFactory {
     return new paymentNetworkForCurrency[paymentNetworkId]({
       advancedLogic,
       bitcoinDetectionProvider,
+      explorerApiKeys,
     });
   }
 }

--- a/packages/payment-detection/src/provider.ts
+++ b/packages/payment-detection/src/provider.ts
@@ -34,6 +34,8 @@ export const initPaymentDetectionApiKeys = (
 const networkRpcs: Record<string, string> = {
   private: providers.JsonRpcProvider.defaultUrl(),
   matic: 'https://rpc-mainnet.matic.network/',
+  fantom: 'https://rpcapi.fantom.network',
+  fuse: 'https://rpc.fuse.io',
 };
 
 /**

--- a/packages/payment-detection/test/eth/info-retriever.test.ts
+++ b/packages/payment-detection/test/eth/info-retriever.test.ts
@@ -54,6 +54,7 @@ describe('api/eth/info-retriever', () => {
             PaymentTypes.EVENTS_NAMES.PAYMENT,
             network,
             '9649a1a4dd5854ed',
+            process.env[`EXPLORER_API_KEY_${network.toUpperCase()}`],
           );
           await expect(retriever.getTransferEvents()).resolves.not.toThrow();
         });
@@ -74,6 +75,7 @@ describe('api/eth/info-retriever', () => {
         PaymentTypes.EVENTS_NAMES.PAYMENT,
         'matic',
         paymentReference,
+        process.env[`EXPLORER_API_KEY_MATIC`],
       );
       const events = await infoRetriever.getTransferEvents();
       expect(events).toHaveLength(1);

--- a/packages/payment-detection/test/payment-network-factory.test.ts
+++ b/packages/payment-detection/test/payment-network-factory.test.ts
@@ -7,6 +7,7 @@ import {
 
 import BTCAddressedBased from '../src/btc/mainnet-address-based';
 import Declarative from '../src/declarative';
+import PaymentNetworkETHInputData from '../src/eth/input-data';
 
 import PaymentNetworkFactory from '../src/payment-network-factory';
 
@@ -178,6 +179,33 @@ describe('api/payment-network/payment-network-factory', () => {
           request,
         }),
       ).toBeInstanceOf(Declarative);
+    });
+
+    it('can pass options down to the paymentNetwork', async () => {
+      const request: any = {
+        currency: {
+          type: 'ETH',
+          network: 'mainnet',
+          value: 'ETH',
+        },
+        extensions: {
+          [ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA as string]: {
+            id: ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA,
+            type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+          },
+        },
+      };
+      const pn = PaymentNetworkFactory.getPaymentNetworkFromRequest({
+        advancedLogic: mockAdvancedLogic,
+        request,
+        explorerApiKeys: {
+          homestead: 'abcd',
+        },
+      });
+      expect(pn).toBeInstanceOf(PaymentNetworkETHInputData);
+      expect((pn as any).explorerApiKeys).toMatchObject({
+        homestead: 'abcd',
+      });
     });
   });
 });

--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -144,7 +144,11 @@ export default class RequestNetwork {
    */
   public async fromRequestId(
     requestId: RequestLogicTypes.RequestId,
-    options?: { disablePaymentDetection?: boolean; disableEvents?: boolean },
+    options?: {
+      disablePaymentDetection?: boolean;
+      disableEvents?: boolean;
+      explorerApiKeys?: Record<string, string>;
+    },
   ): Promise<Request> {
     const requestAndMeta: RequestLogicTypes.IReturnGetRequestFromId = await this.requestLogic.getRequestFromId(
       requestId,
@@ -164,6 +168,7 @@ export default class RequestNetwork {
         advancedLogic: this.advancedLogic,
         bitcoinDetectionProvider: this.bitcoinDetectionProvider,
         request: requestState,
+        explorerApiKeys: options?.explorerApiKeys,
       },
     );
 


### PR DESCRIPTION
Add a default RPC url for fantom and fuse (useful in frontend and low-usage calls), and remove the default etherscan API key that is only usable for etherscan, not ftmscan & co.