### PR TITLE
fix: Currency.fromSymbol for testnets of native tokens

### DIFF
--- a/packages/currency/src/currency.ts
+++ b/packages/currency/src/currency.ts
@@ -41,11 +41,17 @@ export class Currency implements RequestLogicTypes.ICurrency {
       return new Currency(currencyFromAddress);
     }
 
-    const currencyFromSymbol = this.fromSymbol(
-      symbolOrAddress.split('-')[0],
-      symbolOrAddress.split('-')[1],
-    );
-    return currencyFromSymbol;
+    try {
+      const currencyFromSymbol = this.fromSymbol(
+        symbolOrAddress.split('-')[0],
+        symbolOrAddress.split('-')[1],
+      );
+      return currencyFromSymbol;
+    } catch (e) {
+      // Testnet native tokens (ETH-rinkeby, NEAR-testnet etc.)
+      const currencyFromSymbol = this.fromSymbol(symbolOrAddress);
+      return currencyFromSymbol;
+    }
   }
 
   /**
@@ -63,8 +69,8 @@ export class Currency implements RequestLogicTypes.ICurrency {
       const currency = currencies.find(
         (cur) =>
           // test native tokens have the network in their symbol already
-          cur.symbol.toLowerCase().split('-')[0] === symbol.toLowerCase() &&
-          (!network || network === cur.network),
+          cur.symbol.toLowerCase() === symbol.toLowerCase() &&
+          (!network || network.toLowerCase() === cur.network?.toLowerCase()),
       );
 
       if (currency) {

--- a/packages/currency/src/native.ts
+++ b/packages/currency/src/native.ts
@@ -50,6 +50,18 @@ export const nativeCurrencies = {
       name: 'Fantom',
       network: 'fantom',
     },
+    {
+      symbol: 'NEAR',
+      decimals: 24,
+      name: 'Near',
+      network: 'aurora',
+    },
+    {
+      symbol: 'NEAR-testnet',
+      decimals: 24,
+      name: 'Near Testnet',
+      network: 'aurora-testnet',
+    },
   ],
   [RequestLogicTypes.CURRENCY.BTC]: [
     {

--- a/packages/currency/test/currency.test.ts
+++ b/packages/currency/test/currency.test.ts
@@ -327,7 +327,7 @@ describe('api/currency', () => {
     });
 
     it('return the correct currency for cUSD-celo string', () => {
-      expect(Currency.from('cUSD-celo')).toEqual({
+      expect(Currency.fromSymbol('cUSD')).toEqual({
         network: 'celo',
         type: RequestLogicTypes.CURRENCY.ERC20,
         value: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
@@ -335,7 +335,7 @@ describe('api/currency', () => {
     });
 
     it('return the correct currency for CUSD-celo string (with alternative casing)', () => {
-      expect(Currency.from('CUSD-celo')).toEqual({
+      expect(Currency.fromSymbol('CUSD', 'celo')).toEqual({
         network: 'celo',
         type: RequestLogicTypes.CURRENCY.ERC20,
         value: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
@@ -343,7 +343,7 @@ describe('api/currency', () => {
     });
 
     it('return the correct currency for cGLD-celo string', () => {
-      expect(Currency.from('cGLD-celo')).toEqual({
+      expect(Currency.fromSymbol('cGLD')).toEqual({
         network: 'celo',
         type: RequestLogicTypes.CURRENCY.ERC20,
         value: '0x471EcE3750Da237f93B8E339c536989b8978a438',
@@ -351,7 +351,7 @@ describe('api/currency', () => {
     });
 
     it('return the correct currency for CELO-celo string', () => {
-      expect(Currency.from('CELO-celo')).toEqual({
+      expect(Currency.fromSymbol('CELO')).toEqual({
         network: 'celo',
         type: RequestLogicTypes.CURRENCY.ETH,
         value: 'CELO',
@@ -359,17 +359,31 @@ describe('api/currency', () => {
     });
 
     it('return the correct currency for CTBK-rinkeby string', () => {
-      expect(Currency.from('CTBK-rinkeby')).toEqual({
+      expect(Currency.fromSymbol('CTBK')).toEqual({
         network: 'rinkeby',
         type: RequestLogicTypes.CURRENCY.ERC20,
         value: '0x995d6A8C21F24be1Dd04E105DD0d83758343E258',
       });
     });
     it('return the correct currency for DAI-matic string', () => {
-      expect(Currency.from('DAI-matic')).toEqual({
+      expect(Currency.fromSymbol('DAI', 'matic')).toEqual({
         network: 'matic',
         type: RequestLogicTypes.CURRENCY.ERC20,
         value: '0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063',
+      });
+    });
+    it('return the correct currency for NEAR', () => {
+      expect(Currency.fromSymbol('NEAR')).toEqual({
+        network: 'aurora',
+        type: RequestLogicTypes.CURRENCY.ETH,
+        value: 'NEAR',
+      });
+    });
+    it('return the correct currency for NEAR-testnet', () => {
+      expect(Currency.fromSymbol('NEAR-testnet')).toEqual({
+        network: 'aurora-testnet',
+        type: RequestLogicTypes.CURRENCY.ETH,
+        value: 'NEAR-testnet',
       });
     });
 
@@ -763,6 +777,55 @@ describe('api/currency', () => {
           network: 'rinkeby',
         });
       });
+
+      it('CTBK from CTBK-rinkeby', () => {
+        expect(Currency.from('CTBK-rinkeby')).toEqual({
+          network: 'rinkeby',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x995d6A8C21F24be1Dd04E105DD0d83758343E258',
+        });
+      });
+    });
+
+    describe('Celo', () => {
+      it('return the correct currency for cUSD-celo string', () => {
+        expect(Currency.from('cUSD-celo')).toEqual({
+          network: 'celo',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
+        });
+      });
+
+      it('return the correct currency for CUSD-celo string (with alternative casing)', () => {
+        expect(Currency.from('CUSD-celo')).toEqual({
+          network: 'celo',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
+        });
+      });
+
+      it('return the correct currency for cGLD-celo string', () => {
+        expect(Currency.from('cGLD-celo')).toEqual({
+          network: 'celo',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x471EcE3750Da237f93B8E339c536989b8978a438',
+        });
+      });
+
+      it('return the correct currency for CELO-celo string', () => {
+        expect(Currency.from('CELO-celo')).toEqual({
+          network: 'celo',
+          type: RequestLogicTypes.CURRENCY.ETH,
+          value: 'CELO',
+        });
+      });
+      it('return the correct currency for DAI-matic string', () => {
+        expect(Currency.from('DAI-matic')).toEqual({
+          network: 'matic',
+          type: RequestLogicTypes.CURRENCY.ERC20,
+          value: '0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063',
+        });
+      });
     });
 
     describe('native tokens', () => {
@@ -853,6 +916,20 @@ describe('api/currency', () => {
             network: 'fantom',
             type: RequestLogicTypes.CURRENCY.ETH,
             value: 'FTM',
+          });
+        });
+        it('NEAR', () => {
+          expect(Currency.from('NEAR')).toEqual({
+            network: 'aurora',
+            type: RequestLogicTypes.CURRENCY.ETH,
+            value: 'NEAR',
+          });
+        });
+        it('NEAR-testnet', () => {
+          expect(Currency.from('NEAR-testnet')).toEqual({
+            network: 'aurora-testnet',
+            type: RequestLogicTypes.CURRENCY.ETH,
+            value: 'NEAR-testnet',
           });
         });
       });


### PR DESCRIPTION
## Description of the changes
- Fix cases such as Currency.fromSymbol('NEAR-testnet')
- Re-organize a bit tests to split Currency.from and Currency.fromSymbol (no test was removed)