### PR TITLE
fix: handle NEAR-near legacy naming

### DIFF
--- a/packages/currency/src/currency.ts
+++ b/packages/currency/src/currency.ts
@@ -65,6 +65,8 @@ export class Currency implements RequestLogicTypes.ICurrency {
       throw new Error(`Cannot guess currency from empty symbol.`);
     }
 
+    ({ symbol, network } = Currency.legacyTranslation(symbol, network));
+
     for (const [type, currencies] of Object.entries(getAllSupportedCurrencies())) {
       const currency = currencies.find(
         (cur) =>
@@ -87,6 +89,16 @@ export class Currency implements RequestLogicTypes.ICurrency {
         network ? ` on ${network}` : ''
       } is unknown or not supported`,
     );
+  };
+
+  private static legacyTranslation = (
+    symbol: string,
+    network?: string,
+  ): { symbol: string; network?: string } => {
+    if (symbol === 'NEAR' && network === 'near') {
+      return { symbol, network: 'aurora' };
+    }
+    return { symbol, network };
   };
 
   /**

--- a/packages/currency/test/currency.test.ts
+++ b/packages/currency/test/currency.test.ts
@@ -828,6 +828,33 @@ describe('api/currency', () => {
       });
     });
 
+    describe('near', () => {
+      it('NEAR from near', () => {
+        expect(Currency.from('NEAR')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ETH,
+          value: 'NEAR',
+          network: 'aurora',
+        });
+        expect(Currency.from('FAU').toString()).toEqual('FAU-rinkeby');
+      });
+
+      it('NEAR from NEAR-near (legacy)', () => {
+        expect(Currency.from('NEAR-near')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ETH,
+          value: 'NEAR',
+          network: 'aurora',
+        });
+      });
+
+      it('NEAR-testnet from NEAR-testnet', () => {
+        expect(Currency.from('NEAR-testnet')).toMatchObject({
+          type: RequestLogicTypes.CURRENCY.ETH,
+          value: 'NEAR-testnet',
+          network: 'aurora-testnet',
+        });
+      });
+    });
+
     describe('native tokens', () => {
       describe('Bitcoin', () => {
         it('BTC', () => {

--- a/packages/currency/test/token.test.ts
+++ b/packages/currency/test/token.test.ts
@@ -153,6 +153,33 @@ describe('api/currency Token', () => {
       });
     });
 
+    describe('near', () => {
+      it('NEAR from NEAR', () => {
+        expect(Token.from('NEAR')).toMatchObject({
+          symbol: 'NEAR',
+          type: RequestLogicTypes.CURRENCY.ETH,
+          value: 'NEAR',
+          network: 'aurora',
+        });
+      });
+      it('NEAR from NEAR-near (legacy)', () => {
+        expect(Token.from('NEAR-near')).toMatchObject({
+          symbol: 'NEAR',
+          type: RequestLogicTypes.CURRENCY.ETH,
+          value: 'NEAR',
+          network: 'aurora',
+        });
+      });
+      it('NEAR from NEAR-testnet', () => {
+        expect(Token.from('NEAR-testnet')).toMatchObject({
+          symbol: 'NEAR-testnet',
+          type: RequestLogicTypes.CURRENCY.ETH,
+          value: 'NEAR-testnet',
+          network: 'aurora-testnet',
+        });
+      });
+    });
+
     describe('errors', () => {
       it('Unsupported tokens should throw', () => {
         expect(() => Token.from('UNSUPPORTED')).toThrow(


### PR DESCRIPTION
## Description of the changes
- Tests NEAR token & currency methods
- Handle `NEAR-near`