### PR TITLE
feat: upgrade near references to 0.2.0

### DIFF
--- a/packages/advanced-logic/src/extensions/payment-network/near-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/near-native.ts
@@ -3,7 +3,7 @@ import { UnsupportedNetworkError } from './address-based';
 
 import NativeTokenPaymentNetwork from './native-token';
 
-const CURRENT_VERSION = '0.1.0';
+const CURRENT_VERSION = '0.2.0';
 const supportedNetworks = ['aurora', 'aurora-testnet'];
 
 /**

--- a/packages/advanced-logic/test/utils/payment-network/any/generator-data-create.ts
+++ b/packages/advanced-logic/test/utils/payment-network/any/generator-data-create.ts
@@ -72,7 +72,7 @@ export const actionCreationWithNativeTokenPayment: ExtensionTypes.IAction<Extens
     refundAddress: 'refund.near',
     salt,
   },
-  version: '0.1.0',
+  version: '0.2.0',
 };
 
 export const actionAddDelegate = {
@@ -201,7 +201,7 @@ export const extensionStateWithNativeTokenPaymentAndRefund: RequestLogicTypes.IE
       refundAddress: 'refund.near',
       salt,
     },
-    version: '0.1.0',
+    version: '0.2.0',
   },
 };
 export const extensionStateWithPaymentAddressAdded: RequestLogicTypes.IExtensionStates = {
@@ -228,7 +228,7 @@ export const extensionStateWithPaymentAddressAdded: RequestLogicTypes.IExtension
       paymentAddress: 'pay.near',
       salt,
     },
-    version: '0.1.0',
+    version: '0.2.0',
   },
 };
 

--- a/packages/payment-detection/src/near-detector.ts
+++ b/packages/payment-detection/src/near-detector.ts
@@ -27,7 +27,7 @@ export default class NearNativeTokenPaymentDetector extends ReferenceBasedDetect
 
   public static getNearContractName = (
     chainName: string,
-    paymentNetworkVersion = '0.1.0',
+    paymentNetworkVersion = '0.2.0',
   ): string => {
     const version = NearNativeTokenPaymentDetector.getVersionOrThrow(paymentNetworkVersion);
     const versionMap: Record<string, Record<string, string>> = {

--- a/packages/payment-detection/src/near-detector.ts
+++ b/packages/payment-detection/src/near-detector.ts
@@ -11,6 +11,7 @@ interface IProxyContractVersion {
 // the versions 0.1.0 and 0.2.0 have the same contracts
 const CONTRACT_ADDRESS_MAP: IProxyContractVersion = {
   ['0.1.0']: '0.1.0',
+  ['0.2.0']: '0.2.0',
 };
 
 /**
@@ -24,16 +25,33 @@ export default class NearNativeTokenPaymentDetector extends ReferenceBasedDetect
     super(advancedLogic.extensions.nativeToken[0], ExtensionTypes.ID.PAYMENT_NETWORK_NATIVE_TOKEN);
   }
 
-  public static getNearContractName = (chainName: string, paymentNetworkVersion = '0.1.0') => {
+  public static getNearContractName = (
+    chainName: string,
+    paymentNetworkVersion = '0.1.0',
+  ): string => {
+    const version = NearNativeTokenPaymentDetector.getVersionOrThrow(paymentNetworkVersion);
+    const versionMap: Record<string, Record<string, string>> = {
+      aurora: { '0.1.0': 'requestnetwork.near', '0.2.0': 'TODO-MISSING' },
+      'aurora-testnet': { '0.1.0': 'dev-1626339335241-5544297', '0.2.0': 'TODO-MISSING' },
+    };
+    if (versionMap[chainName]?.[version]) {
+      return versionMap[chainName][version];
+    }
+    throw Error(`Unconfigured chain '${chainName}' and version '${version}'.`);
+  };
+
+  /**
+   * Documentation: https://github.com/near/near-indexer-for-explorer
+   */
+  public static getProcedureName = (chainName: string, paymentNetworkVersion: string): string => {
     NearNativeTokenPaymentDetector.getVersionOrThrow(paymentNetworkVersion);
     switch (chainName) {
       case 'aurora':
-        return 'requestnetwork.near';
+        return 'com.nearprotocol.mainnet.explorer.select:INDEXER_BACKEND';
       case 'aurora-testnet':
-        return 'dev-1626339335241-5544297';
-      default:
-        throw Error(`Unconfigured chain '${chainName}'.`);
+        return 'com.nearprotocol.testnet.explorer.select:INDEXER_BACKEND';
     }
+    throw new Error(`Invalid chain name '${chainName} for Near info retriever.`);
   };
 
   /**
@@ -66,21 +84,7 @@ export default class NearNativeTokenPaymentDetector extends ReferenceBasedDetect
     return events;
   }
 
-  /**
-   * Documentation: https://github.com/near/near-indexer-for-explorer
-   */
-  protected static getProcedureName = (chainName: string, paymentNetworkVersion: string) => {
-    NearNativeTokenPaymentDetector.getVersionOrThrow(paymentNetworkVersion);
-    switch (chainName) {
-      case 'aurora':
-        return 'com.nearprotocol.mainnet.explorer.select:INDEXER_BACKEND';
-      case 'aurora-testnet':
-        return 'com.nearprotocol.testnet.explorer.select:INDEXER_BACKEND';
-    }
-    throw new Error(`Invalid chain name '${chainName} for Near info retriever.`);
-  };
-
-  protected static getVersionOrThrow = (paymentNetworkVersion: string) => {
+  protected static getVersionOrThrow = (paymentNetworkVersion: string): string => {
     if (!CONTRACT_ADDRESS_MAP[paymentNetworkVersion]) {
       throw Error(`Near payment detection not implemented for version ${paymentNetworkVersion}`);
     }

--- a/packages/payment-detection/src/near-detector.ts
+++ b/packages/payment-detection/src/near-detector.ts
@@ -31,8 +31,11 @@ export default class NearNativeTokenPaymentDetector extends ReferenceBasedDetect
   ): string => {
     const version = NearNativeTokenPaymentDetector.getVersionOrThrow(paymentNetworkVersion);
     const versionMap: Record<string, Record<string, string>> = {
-      aurora: { '0.1.0': 'requestnetwork.near', '0.2.0': 'TODO-MISSING' },
-      'aurora-testnet': { '0.1.0': 'dev-1626339335241-5544297', '0.2.0': 'TODO-MISSING' },
+      aurora: { '0.1.0': 'requestnetwork.near', '0.2.0': 'requestnetwork.near' },
+      'aurora-testnet': {
+        '0.1.0': 'dev-1626339335241-5544297',
+        '0.2.0': 'dev-1631521265288-35171138540673',
+      },
     };
     if (versionMap[chainName]?.[version]) {
       return versionMap[chainName][version];

--- a/packages/payment-detection/src/near-info-retriever.ts
+++ b/packages/payment-detection/src/near-info-retriever.ts
@@ -30,7 +30,7 @@ export class NearInfoRetriever {
   public async getTransferEvents(): Promise<PaymentTypes.ETHPaymentNetworkEvent[]> {
     const events = await this.getTransactionsFromNearIndexerDatabase();
     return events.map((transaction) => ({
-      amount: transaction.amount,
+      amount: transaction.deposit,
       name: this.eventName,
       parameters: {
         block: transaction.block,
@@ -55,7 +55,6 @@ export class NearInfoRetriever {
         COALESCE(a.args::json->>'deposit', '') as deposit,
         COALESCE(a.args::json->>'method_name', '') as method_name,
         COALESCE((a.args::json->'args_json')::json->>'to', '') as "to",
-        COALESCE((a.args::json->'args_json')::json->>'amount', '') as amount,
         (a.args::json->'args_json')::json->>'payment_reference' as paymentReference,
         (select MAX(block_height) from blocks) - b.block_height as confirmations
       FROM transactions t
@@ -123,6 +122,5 @@ export type NearIndexerTransaction = {
   deposit: string;
   method_name: string;
   to: string;
-  amount: string;
   paymentReference: string;
 };

--- a/packages/payment-processor/src/payment/near-input-data.ts
+++ b/packages/payment-processor/src/payment/near-input-data.ts
@@ -3,8 +3,13 @@ import { WalletConnection } from 'near-api-js';
 
 import { ClientTypes, PaymentTypes } from '@requestnetwork/types';
 
-import { getRequestPaymentValues, validateRequest, getAmountToPay } from './utils';
-import { isNearNetwork, isValidNearAddress, processNearPayment } from './utils-near';
+import {
+  getRequestPaymentValues,
+  validateRequest,
+  getAmountToPay,
+  getPaymentExtensionVersion,
+} from './utils';
+import { isNearNetwork, processNearPayment } from './utils-near';
 
 /**
  * processes the transaction to pay a Near request.
@@ -24,17 +29,15 @@ export async function payNearInputDataRequest(
   validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN);
 
   const { paymentReference, paymentAddress } = getRequestPaymentValues(request);
-
-  if (!(await isValidNearAddress(walletConnection._near, paymentAddress))) {
-    throw new Error(`Invalid NEAR payment address: ${paymentAddress}`);
-  }
-
   const amountToPay = getAmountToPay(request, amount).toString();
+  const version = getPaymentExtensionVersion(request);
+
   return processNearPayment(
     walletConnection,
     request.currencyInfo.network,
     amountToPay,
     paymentAddress,
     paymentReference,
+    version,
   );
 }

--- a/packages/payment-processor/src/payment/utils-near.ts
+++ b/packages/payment-processor/src/payment/utils-near.ts
@@ -3,14 +3,14 @@ import { Contract } from 'near-api-js';
 import { Near, WalletConnection } from 'near-api-js';
 import { Near as NearPaymentDetection } from '@requestnetwork/payment-detection';
 
-export async function isValidNearAddress(nearNetwork: Near, address: string) {
+export const isValidNearAddress = async (nearNetwork: Near, address: string): Promise<boolean> => {
   try {
     await nearNetwork.connection.provider.query(`account/${address}`, '');
     return true;
   } catch (e) {
     return false;
   }
-}
+};
 
 export const isNearNetwork = (network?: string): boolean => {
   return !!network && (network === 'aurora-testnet' || network === 'aurora');
@@ -19,7 +19,7 @@ export const isNearNetwork = (network?: string): boolean => {
 export const isNearAccountSolvent = (
   amount: BigNumberish,
   nearWalletConnection: WalletConnection,
-) => {
+): Promise<boolean> => {
   return nearWalletConnection
     .account()
     .state()
@@ -35,13 +35,13 @@ const GAS_LIMIT = ethers.utils.parseUnits(GAS_LIMIT_IN_TGAS.toString(), 12);
 /**
  * Used for mocking only.
  */
-export async function processNearPayment(
+export const processNearPayment = async (
   walletConnection: WalletConnection,
   network: string,
   amount: BigNumberish,
   to: string,
   payment_reference: string,
-) {
+): Promise<void> => {
   try {
     const contract = new Contract(
       walletConnection.account(),
@@ -54,7 +54,6 @@ export async function processNearPayment(
     await contract.transfer_with_reference(
       {
         to,
-        amount: amount.toString(),
         payment_reference,
       },
       GAS_LIMIT.toString(),
@@ -64,4 +63,4 @@ export async function processNearPayment(
   } catch (e) {
     throw new Error(`Could not pay Near request. Got ${e.message}`);
   }
-}
+};

--- a/packages/payment-processor/src/payment/utils-near.ts
+++ b/packages/payment-processor/src/payment/utils-near.ts
@@ -41,7 +41,7 @@ export const processNearPayment = async (
   amount: BigNumberish,
   to: string,
   payment_reference: string,
-  version: string = '0.2.0',
+  version = '0.2.0',
 ): Promise<void> => {
   if (version !== '0.2.0') {
     if (version === '0.1.0') {

--- a/packages/payment-processor/src/payment/utils-near.ts
+++ b/packages/payment-processor/src/payment/utils-near.ts
@@ -33,7 +33,7 @@ const GAS_LIMIT_IN_TGAS = 30;
 const GAS_LIMIT = ethers.utils.parseUnits(GAS_LIMIT_IN_TGAS.toString(), 12);
 
 /**
- * Used for mocking only.
+ * Export used for mocking only.
  */
 export const processNearPayment = async (
   walletConnection: WalletConnection,
@@ -41,11 +41,24 @@ export const processNearPayment = async (
   amount: BigNumberish,
   to: string,
   payment_reference: string,
+  version: string = '0.2.0',
 ): Promise<void> => {
+  if (version !== '0.2.0') {
+    if (version === '0.1.0') {
+      throw new Error(
+        'Native Token payments on Near with extension v0.1.0 are not supported anymore',
+      );
+    }
+    throw new Error('Native Token payments on Near only support v0.2.0 extensions');
+  }
+  if (!(await isValidNearAddress(walletConnection._near, to))) {
+    throw new Error(`Invalid NEAR payment address: ${to}`);
+  }
+
   try {
     const contract = new Contract(
       walletConnection.account(),
-      NearPaymentDetection.getContractName(network),
+      NearPaymentDetection.getContractName(network, version),
       {
         changeMethods: ['transfer_with_reference'],
         viewMethods: [],

--- a/packages/payment-processor/src/payment/utils.ts
+++ b/packages/payment-processor/src/payment/utils.ts
@@ -119,6 +119,14 @@ export function getRequestPaymentValues(
   };
 }
 
+export function getPaymentExtensionVersion(request: ClientTypes.IRequestData): string {
+  const extension = getPaymentNetworkExtension(request);
+  if (!extension) {
+    throw new Error('no payment network found');
+  }
+  return extension.version;
+}
+
 const {
   ERC20_PROXY_CONTRACT,
   ETH_INPUT_DATA,

--- a/packages/payment-processor/test/payment/index.test.ts
+++ b/packages/payment-processor/test/payment/index.test.ts
@@ -127,11 +127,14 @@ describe('payRequest', () => {
       'Payment currency network aurora is not supported',
     );
   });
+});
 
-  it('pays a NEAR request with NEAR payment method', async () => {
-    const addressValiditySpy = jest
-      .spyOn(nearUtils, 'isValidNearAddress')
-      .mockReturnValue(Promise.resolve(true));
+describe('payNearInputDataRequest', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it('pays a NEAR request with NEAR payment method (with mock)', async () => {
+    // A mock is used to bypass Near wallet connection for address validation and contract interaction
     const paymentSpy = jest
       .spyOn(nearUtils, 'processNearPayment')
       .mockReturnValue(Promise.resolve());
@@ -153,20 +156,53 @@ describe('payRequest', () => {
             salt: '0x456',
             paymentAddress: '0x789',
           },
-          version: '1.0',
+          version: '0.2.0',
         },
       },
     };
 
     await payNearInputDataRequest(request, mockedNearWalletConnection, '1');
-    expect(addressValiditySpy).toHaveBeenCalledTimes(1);
     expect(paymentSpy).toHaveBeenCalledWith(
       expect.anything(),
       'aurora',
       '1',
       '0x789',
       '700912030bd973e3',
+      '0.2.0',
     );
+  });
+  it('throws when tyring to pay another payment extension', async () => {
+    // A mock is used to bypass Near wallet connection for address validation and contract interaction
+    const paymentSpy = jest
+      .spyOn(nearUtils, 'processNearPayment')
+      .mockReturnValue(Promise.resolve());
+    const mockedNearWalletConnection = {
+      account: () => ({
+        functionCall: () => true,
+        state: () => Promise.resolve({ amount: 100 }),
+      }),
+    } as any;
+    const request: any = {
+      requestId: '0x123',
+      currencyInfo: nearCurrency,
+      extensions: {
+        [PaymentTypes.PAYMENT_NETWORK_ID.ETH_INPUT_DATA]: {
+          events: [],
+          id: ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA,
+          type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+          values: {
+            salt: '0x456',
+            paymentAddress: '0x789',
+          },
+          version: '0.2.0',
+        },
+      },
+    };
+
+    await expect(
+      payNearInputDataRequest(request, mockedNearWalletConnection, '1'),
+    ).rejects.toThrowError('request cannot be processed, or is not an pn-native-token request');
+    expect(paymentSpy).toHaveBeenCalledTimes(0);
   });
 });
 


### PR DESCRIPTION
## Description of the changes
feat: Near contract will drop the references to `amount` (extension version 0.2.0)
chore: improved testing coverage