### PR TITLE
fix: currencyManager in PN factory from request

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "mochaExplorer.require": "ts-node/register",
   "mochaExplorer.files": "**/test/**/*.test.ts",
-  "mochaExplorer.cwd": "./"
+  "mochaExplorer.cwd": "./",
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/payment-detection/src/payment-network-factory.ts
+++ b/packages/payment-detection/src/payment-network-factory.ts
@@ -107,9 +107,11 @@ export default class PaymentNetworkFactory {
     request,
     bitcoinDetectionProvider,
     explorerApiKeys,
+    currencyManager,
   }: {
     advancedLogic: AdvancedLogicTypes.IAdvancedLogic;
     request: RequestLogicTypes.IRequest;
+    currencyManager: ICurrencyManager;
     bitcoinDetectionProvider?: PaymentTypes.IBitcoinDetectionProvider;
     explorerApiKeys?: Record<string, string>;
   }): PaymentTypes.IPaymentNetwork | null {
@@ -137,6 +139,7 @@ export default class PaymentNetworkFactory {
       advancedLogic,
       bitcoinDetectionProvider,
       explorerApiKeys,
+      currencyManager,
     });
   }
 }

--- a/packages/payment-detection/test/near-native.test.ts
+++ b/packages/payment-detection/test/near-native.test.ts
@@ -4,6 +4,7 @@ import {
   PaymentTypes,
   RequestLogicTypes,
 } from '@requestnetwork/types';
+import { CurrencyManager } from '@requestnetwork/currency';
 import PaymentNetworkFactory from '../src/payment-network-factory';
 import PaymentReferenceCalculator from '../src/payment-reference-calculator';
 import NearNativeTokenPaymentDetector from '../src/near-detector';
@@ -13,6 +14,8 @@ import { deepCopy } from 'ethers/lib/utils';
 const mockNearPaymentNetwork = {
   supportedNetworks: ['aurora', 'aurora-testnet'],
 };
+const currencyManager = CurrencyManager.getDefault();
+
 const mockAdvancedLogic: AdvancedLogicTypes.IAdvancedLogic = {
   applyActionToExtensions(): any {
     return;
@@ -68,6 +71,7 @@ describe('Near payments detection', () => {
       PaymentNetworkFactory.getPaymentNetworkFromRequest({
         advancedLogic: mockAdvancedLogic,
         request,
+        currencyManager,
       }),
     ).toBeInstanceOf(NearNativeTokenPaymentDetector);
   });
@@ -77,6 +81,7 @@ describe('Near payments detection', () => {
       PaymentNetworkFactory.getPaymentNetworkFromRequest({
         advancedLogic: mockAdvancedLogic,
         request: { ...request, currency: { ...request.currency, network: 'aurora' } },
+        currencyManager,
       }),
     ).toBeInstanceOf(NearNativeTokenPaymentDetector);
   });

--- a/packages/payment-detection/test/payment-network-factory.test.ts
+++ b/packages/payment-detection/test/payment-network-factory.test.ts
@@ -114,6 +114,7 @@ describe('api/payment-network/payment-network-factory', () => {
         PaymentNetworkFactory.getPaymentNetworkFromRequest({
           advancedLogic: mockAdvancedLogic,
           request,
+          currencyManager,
         }),
       ).toBeInstanceOf(BTCAddressedBased);
     });
@@ -137,6 +138,7 @@ describe('api/payment-network/payment-network-factory', () => {
         PaymentNetworkFactory.getPaymentNetworkFromRequest({
           advancedLogic: mockAdvancedLogic,
           request,
+          currencyManager,
         }),
       ).toBeNull();
     });
@@ -160,6 +162,7 @@ describe('api/payment-network/payment-network-factory', () => {
         PaymentNetworkFactory.getPaymentNetworkFromRequest({
           advancedLogic: mockAdvancedLogic,
           request,
+          currencyManager,
         });
       }).toThrowError(
         'the payment network id: content-data is not supported for the currency: BTC',
@@ -182,6 +185,7 @@ describe('api/payment-network/payment-network-factory', () => {
         PaymentNetworkFactory.getPaymentNetworkFromRequest({
           advancedLogic: mockAdvancedLogic,
           request,
+          currencyManager,
         }),
       ).toBeInstanceOf(Declarative);
     });
@@ -203,6 +207,7 @@ describe('api/payment-network/payment-network-factory', () => {
       const pn = PaymentNetworkFactory.getPaymentNetworkFromRequest({
         advancedLogic: mockAdvancedLogic,
         request,
+        currencyManager,
         explorerApiKeys: {
           homestead: 'abcd',
         },

--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -193,6 +193,7 @@ export default class RequestNetwork {
         bitcoinDetectionProvider: this.bitcoinDetectionProvider,
         request: requestState,
         explorerApiKeys: options?.explorerApiKeys,
+        currencyManager: this.currencyManager,
       },
     );
 
@@ -287,6 +288,7 @@ export default class RequestNetwork {
             advancedLogic: this.advancedLogic,
             bitcoinDetectionProvider: this.bitcoinDetectionProvider,
             request: requestState,
+            currencyManager: this.currencyManager,
           },
         );
 
@@ -348,6 +350,7 @@ export default class RequestNetwork {
             advancedLogic: this.advancedLogic,
             bitcoinDetectionProvider: this.bitcoinDetectionProvider,
             request: requestState,
+            currencyManager: this.currencyManager,
           },
         );
 

--- a/packages/request-client.js/test/index.test.ts
+++ b/packages/request-client.js/test/index.test.ts
@@ -420,6 +420,41 @@ describe('index', () => {
     expect(requestFromId.requestId).toBe(request.requestId);
   });
 
+  it('allows to get a request from its ID with a payment network', async () => {
+    const requestNetwork = new RequestNetwork({
+      signatureProvider: fakeSignatureProvider,
+      useMockStorage: true,
+    });
+
+    const paymentNetwork: PaymentTypes.IPaymentNetworkCreateParameters = {
+      id: PaymentTypes.PAYMENT_NETWORK_ID.DECLARATIVE,
+      parameters: {},
+    };
+
+    const request = await requestNetwork.createRequest({
+      paymentNetwork,
+      requestInfo: TestData.parametersWithoutExtensionsData,
+      signer: payeeIdentity,
+    });
+    await request.waitForConfirmation();
+
+    const requestFromId = await requestNetwork.fromRequestId(request.requestId);
+
+    expect(requestFromId.getData()).toMatchObject({
+      requestId: request.requestId,
+      currency: 'BTC-testnet-testnet',
+      currencyInfo: {
+        network: 'testnet',
+        type: RequestLogicTypes.CURRENCY.BTC,
+        value: 'BTC',
+      },
+      balance: {
+        balance: '0',
+        events: [],
+      },
+    });
+  });
+
   it('allows to refresh a request', async () => {
     const mock = new AxiosMockAdapter(axios);
     mock.onPost('/persistTransaction').reply(200, { result: {} });


### PR DESCRIPTION
The currencyManager is not passed down the Payment Network when the PN is constructed from the Request. 
