### PR TITLE
test: fix wrong chainlink test

### DIFF
--- a/packages/smart-contracts/package.json
+++ b/packages/smart-contracts/package.json
@@ -60,6 +60,7 @@
     "@types/chai": "4.2.21",
     "@types/mocha": "8.2.3",
     "@types/node": "14.14.16",
+    "chai": "4.3.4",
     "dotenv": "10.0.0",
     "ethereum-waffle": "3.4.0",
     "ethers": "5.2.0",

--- a/packages/smart-contracts/test/contracts/ChainlinkConversionPath.test.ts
+++ b/packages/smart-contracts/test/contracts/ChainlinkConversionPath.test.ts
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+import { expect } from 'chai';
 import { CurrencyManager } from '@requestnetwork/currency';
 import { ethers, network } from 'hardhat';
 import '@nomiclabs/hardhat-ethers';
@@ -30,7 +30,7 @@ describe('contract: ChainlinkConversionPath', () => {
   });
 
   describe('admin tasks', async () => {
-    it('can updateAggregator', async () => {
+    it('can updateAggregator and updateAggregatorsList', async () => {
       let addressAggregator = await conversionPathInstance.allAggregators(address1, address2);
       expect(addressAggregator).equal('0x0000000000000000000000000000000000000000');
 
@@ -38,21 +38,10 @@ describe('contract: ChainlinkConversionPath', () => {
 
       addressAggregator = await conversionPathInstance.allAggregators(address1, address2);
       expect(addressAggregator).equal(address3);
-    });
-
-    it('can updateAggregatorsList', async () => {
-      let addressAggregator = await conversionPathInstance.allAggregators(address1, address2);
-      expect(
-        addressAggregator,
-        '0x0000000000000000000000000000000000000000',
-        'addressAggregator must be 0x',
-      );
 
       addressAggregator = await conversionPathInstance.allAggregators(address4, address5);
-      expect(
-        addressAggregator,
+      expect(addressAggregator, 'addressAggregator must be 0x').equal(
         '0x0000000000000000000000000000000000000000',
-        'addressAggregator must be 0x',
       );
 
       await conversionPathInstance.updateAggregatorsList(
@@ -62,9 +51,9 @@ describe('contract: ChainlinkConversionPath', () => {
       );
 
       addressAggregator = await conversionPathInstance.allAggregators(address1, address2);
-      expect(addressAggregator, address3, 'addressAggregator must be 0x333..');
+      expect(addressAggregator, 'addressAggregator must be 0x333..').equal(address3);
       addressAggregator = await conversionPathInstance.allAggregators(address4, address5);
-      expect(addressAggregator, address6, 'addressAggregator must be 0x666..');
+      expect(addressAggregator, 'addressAggregator must be 0x666..').equal(address6);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8488,7 +8488,7 @@ chai-bn@^0.2.1:
   resolved "https://registry.yarnpkg.com/chai-bn/-/chai-bn-0.2.1.tgz#1dad95e24c3afcd8139ab0262e9bbefff8a30ab7"
   integrity sha512-01jt2gSXAw7UYFPT5K8d7HYjdXj2vyeIuE+0T/34FWzlNcVbs1JkPxRu7rYMfQnJhrHT8Nr6qjSf5ZwwLU2EYg==
 
-chai@^4.2.0:
+chai@^4.2.0, chai@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.4.tgz#b55e655b31e1eac7099be4c08c21964fce2e6c49"
   integrity sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==


### PR DESCRIPTION
## Description of the changes

Merging 2 tests because they are stateful, and based on the same instance of ganache, meaning the state of the contract was not 0x000 at the beginning of the test.

### Why it happened?
`chai` was imported with `require`, so there was no typing.

Because there was no typing, it was not highlighted that the `expect` was wrong

It was missing the `equal` call, without which the call was useless.



