### PR TITLE
fix: don't check ETH solvency for a Gnosis provider

### DIFF
--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -191,9 +191,11 @@ export async function isSolvent(
   }
   const provider = providerOptions.provider;
   const ethBalance = await provider.getBalance(fromAddress);
-  const needsGas = !['Safe Multisig WalletConnect', 'Gnosis Safe Multisig'].includes(
-    (provider as any)?.provider?.wc?._peerMeta?.name,
-  );
+  const needsGas =
+    !(provider as any)?.provider?.safe?.safeAddress &&
+    !['Safe Multisig WalletConnect', 'Gnosis Safe Multisig'].includes(
+      (provider as any)?.provider?.wc?._peerMeta?.name,
+    );
 
   if (currency.type === 'ETH') {
     return ethBalance.gt(amount);


### PR DESCRIPTION
## Description of the changes
* Since Gnosis is now a dedicated provider, we need to fix the check for ETH solvency need