### PR TITLE
specs: declarePayment action on main payment networks

### DIFF
--- a/packages/advanced-logic/specs/payment-network-any-to-erc20-proxy-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-any-to-erc20-proxy-0.1.0.md
@@ -1,21 +1,14 @@
 # Payment Network - Any currency - conversion to ERC20 with Fee
 
-You may be interested in this document if:
-
-- you want to create your own implementation of the Request protocol
-- you are curious enough to dive and see what is under the hood of the Request protocol
-
-Prerequisite: Having read the advanced logic specification (see [here](./advanced-logic-specs-0.1.0.md)).
-
 ## Description
 
-This extension allows the payments and the refunds to be made in ERC20 tokens on the Ethereum blockchain for a request made in others currencies.
-The rate is computing at the payment thanks to onchain oracles.
+This extension allows the payments and the refunds to be made in ERC20 tokens on Ethereum or EVM-compatible blockchains for a request made in others currencies.
+The rate is computed at the payment thanks to onchain oracles.
 This Payment Network is quite similar to the [ERC20 Fee Proxy Contract](./payment-network-erc20-fee-proxy-contract-0.1.0.md) extension, with a rate conversion before the payment.
 
-The payment is made through a proxy contract. This proxy contract call the [ERC20 Fee Proxy Contract](./payment-network-erc20-fee-proxy-contract-0.1.0.md) to do the ERC20 token transfer on behalf of the user. The contract ensures a link between an ERC20 transfer and a request through a `paymentReference`.
+The payment is primarly made through a proxy contract, and can also be declared manually. Fees shall not be paid for declarative payments.
 
-This `paymentReference` consists of the last 8 bytes of a salted hash of the requestId: `last8Bytes(hash(lowercase(requestId + salt + address)))`:
+The proxy contract calls the [ERC20 Fee Proxy Contract](./payment-network-erc20-fee-proxy-contract-0.1.0.md) to do the ERC20 token transfer on behalf of the user. The contract ensures a link between an ERC20 transfer and a request through a `paymentReference`, consisting of the last 8 bytes of a salted hash of the requestId: `last8Bytes(hash(lowercase(requestId + salt + address)))`:
 
 The contract also ensures that the `feeAmount` amount of the ERC20 transfer will be forwarded to the `feeAddress`.
 
@@ -34,6 +27,10 @@ The contract also ensures that the `feeAmount` amount of the ERC20 transfer will
 
 As a payment network, this extension allows to deduce a payment `balance` for the request. (see
 [Interpretation](#Interpretation))
+
+## Manual payment declaration
+
+The issuer can declare that he received a payment and give the amount, possibly with a `txHash` for documentation.
 
 ## Contract
 
@@ -59,86 +56,85 @@ The `TransferWithReferenceAndFee` event is emitted when the tokens are transfere
 
 [See smart contract source](https://github.com/RequestNetwork/requestNetwork/blob/master/packages/smart-contracts/src/contracts/Erc20ConversionProxy.sol)
 
-| Network | Contract Address                           |
-| ------- | ------------------------------------------ |
-| Mainnet | TODO                                       |
-| Rinkeby | 0x78334ed20da456e89cd7e5a90de429d705f5bc88 |
-| Private | 0xB9B7e0cb2EDF5Ea031C8B297A5A1Fa20379b6A0a |
+| Network                    | Contract Address                           |
+| -------------------------- | ------------------------------------------ |
+| Mainnet                    | 0xe72Ecea44b6d8B2b3cf5171214D9730E86213cA2 |
+| Matic                      | 0xf0f49873C50765239F6f9534Ba13c4fe16eD5f2E |
+| Ethereum Testnet - Rinkeby | 0x78334ed20da456e89cd7e5a90de429d705f5bc88 |
+| Private                    | 0xB9B7e0cb2EDF5Ea031C8B297A5A1Fa20379b6A0a |
 
 ## Properties
 
 | Property                  | Type   | Description                                                           | Requirement   |
 | ------------------------- | ------ | --------------------------------------------------------------------- | ------------- |
-| **id**                    | String | constant value: "pn-any-to-erc20-proxy"          | **Mandatory** |
+| **id**                    | String | constant value: "pn-any-to-erc20-proxy"                               | **Mandatory** |
 | **type**                  | String | constant value: "paymentNetwork"                                      | **Mandatory** |
 | **version**               | String | constant value: "0.1.0"                                               | **Mandatory** |
 | **events**                | Array  | List of the actions performed by the extension                        | **Mandatory** |
 | **values**                | Object |                                                                       |               |
 | **values.salt**           | String | Salt for the request                                                  | **Mandatory** |
-| **values.paymentAddress** | String | Ethereum address for the payment                                      | Optional      |
-| **values.refundAddress**  | String | Ethereum address for the refund                                       | Optional      |
-| **values.feeAddress**         | String | Ethereum address for the fee payment                                  | Optional      |
+| **values.paymentAddress** | String | Blockchain address for the payment                                    | Optional      |
+| **values.refundAddress**  | String | Blockchain address for the refund                                     | Optional      |
+| **values.feeAddress**     | String | Blockchain address for the fee payment                                | Optional      |
 | **values.feeAmount**      | String | The fee amount in the request `currency`                              | Optional      |
-| **values.network**        | String | Ethereum network for the payments                                     | Optional      |
+| **values.network**        | String | Blockchain network for the payments                                   | Optional      |
 | **values.maxTimespan**    | Number | Time span maximum accepted between the payment and the rate timestamp | Optional      |
 | **values.acceptedTokens** | Array  | The list of tokens addresses accepted for payments                    | Mandatory     |
 
 ---
 
-## Actions
+## Action: Creation
 
-### Creation
-
-#### Parameters
+### Parameters
 
 |                               | Type   | Description                                                           | Requirement   |
 | ----------------------------- | ------ | --------------------------------------------------------------------- | ------------- |
-| **id**                        | String | Constant value: "pn-any-to-erc20-proxy"          | **Mandatory** |
+| **id**                        | String | Constant value: "pn-any-to-erc20-proxy"                               | **Mandatory** |
 | **type**                      | String | Constant value: "paymentNetwork"                                      | **Mandatory** |
 | **version**                   | String | Constant value: "0.1.0"                                               | **Mandatory** |
 | **parameters**                | Object |                                                                       |               |
 | **parameters.salt**           | String | Salt for the request                                                  | **Mandatory** |
-| **parameters.paymentAddress** | String | Ethereum address for the payment                                      | Optional      |
-| **parameters.refundAddress**  | String | Ethereum address for the refund                                       | Optional      |
-| **parameters.feeAddress**         | String | Ethereum address for the fee payment                                  | Optional      |
+| **parameters.paymentAddress** | String | Blockchain address for the payment                                    | Optional      |
+| **parameters.refundAddress**  | String | Blockchain address for the refund                                     | Optional      |
+| **parameters.feeAddress**     | String | Blockchain address for the fee payment                                | Optional      |
 | **parameters.feeAmount**      | String | The fee amount in the request `currency`                              | Optional      |
-| **parameters.network**        | String | Ethereum network for the payments                                     | Optional      |
+| **parameters.network**        | String | Blockchain network for the payments                                   | Optional      |
 | **parameters.maxTimespan**    | Number | Time span maximum accepted between the payment and the rate timestamp | Optional      |
 | **parameters.acceptedTokens** | Array  | The list of tokens addresses accepted for payments                    | Mandatory     |
 
-#### Conditions
+### Conditions
 
 This action is valid if:
 
 - The `salt` is not empty and long enough (8 bytes of randomness minimum).
-- The `acceptedTokens` is not empty and contains only valid ethereum addresses.
+- The `acceptedTokens` is not empty and contains only valid addresses on the concerned blockchain.
 
-#### Warnings
+### Warnings
 
 This action must trigger the warnings:
 
 | Warning                                 | Condition                                                   |
 | --------------------------------------- | ----------------------------------------------------------- |
 | "paymentAddress is given by the payer"  | If `signer` is the payer **and** `paymentAddress` is given  |
-| "feeAddress is given by the payer"          | If `signer` is the payer **and** `feeAddress` is given          |
-| "feeAmount is given by the payer"       | If `signer` is the payer **and** `feeAddress` is given          |
+| "feeAddress is given by the payer"      | If `signer` is the payer **and** `feeAddress` is given      |
+| "feeAmount is given by the payer"       | If `signer` is the payer **and** `feeAddress` is given      |
 | "refundAddress is given by the payee"   | If `signer` is the payee **and** `refundAddress` is given   |
 
-Note: These warnings are necessary to highlight to avoid attempts of fake payments and refunds. For example, a payer could create a request using as the payment address one of his own addresses. A system could interpret a transaction to this address as a payment while the payee did not receive the funds.
+Note: These warnings are necessary to highlight and avoid attempts of fake payments and refunds. For example, a payer could create a request using as the payment address one of his own addresses. A system could interpret a transaction to this address as a payment while the payee did not receive the funds.
 
-#### Results
+### Results
 
 An extension state is created with the following properties:
 
 |  Property                 |  Value                                                         |
 | ------------------------- | -------------------------------------------------------------- |
-| **id**                    | "pn-any-to-erc20-proxy"                   |
+| **id**                    | "pn-any-to-erc20-proxy"                                        |
 | **type**                  | "paymentNetwork"                                               |
 | **version**               | "0.1.0"                                                        |
 | **values**                |                                                                |
 | **values.paymentAddress** | `paymentAddress` from parameters if given, undefined otherwise |
 | **values.refundAddress**  | `refundAddress` from parameters if given, undefined otherwise  |
-| **values.feeAddress**         | `feeAddress` from parameters if given, undefined otherwise         |
+| **values.feeAddress**     | `feeAddress` from parameters if given, undefined otherwise     |
 | **values.feeAmount**      | `feeAmount` from parameters if given, undefined otherwise      |
 | **values.salt**           | Salt for the request                                           |
 | **values.network**        | `network` from parameters if given, undefined otherwise        |
@@ -154,7 +150,7 @@ the 'create' event:
 | **parameters**                |                                                                |
 | **parameters.paymentAddress** | `paymentAddress` from parameters if given, undefined otherwise |
 | **parameters.refundAddress**  | `refundAddress` from parameters if given, undefined otherwise  |
-| **parameters.feeAddress**         | `feeAddress` from parameters if given, undefined otherwise         |
+| **parameters.feeAddress**     | `feeAddress` from parameters if given, undefined otherwise     |
 | **parameters.feeAmount**      | `feeAmount` from parameters if given, undefined otherwise      |
 | **values.network**            | `network` from parameters if given, undefined otherwise        |
 | **values.maxTimespan**        | `maxTimespan` from parameters if given, undefined otherwise    |
@@ -163,20 +159,18 @@ the 'create' event:
 
 ---
 
-### Updates
+## Action: addPaymentAddress
 
-#### addPaymentAddress
+### Parameters
 
-##### Parameters
-
-|                               | Type   | Description                                                  | Requirement   |
-| ----------------------------- | ------ | ------------------------------------------------------------ | ------------- |
+|                               | Type   | Description                             | Requirement   |
+| ----------------------------- | ------ | --------------------------------------- | ------------- |
 | **id**                        | String | Constant value: "pn-any-to-erc20-proxy" | **Mandatory** |
-| **action**                    | String | Constant value: "addPaymentAddress"                          | **Mandatory** |
-| **parameters**                | Object |                                                              |               |
-| **parameters.paymentAddress** | String | Ethereum address for the payment                             | **Mandatory** |
+| **action**                    | String | Constant value: "addPaymentAddress"     | **Mandatory** |
+| **parameters**                | Object |                                         |               |
+| **parameters.paymentAddress** | String | Blockchain address for the payment      | **Mandatory** |
 
-##### Conditions
+### Conditions
 
 This action is valid, if:
 
@@ -184,13 +178,13 @@ This action is valid, if:
 - The signer is the `payee`
 - The extension property `paymentAddress` is undefined
 
-##### Warnings
+### Warnings
 
 None.
 
-##### Results
+### Results
 
-An extension state is updated with the following properties:
+The extension state is updated with the following properties:
 
 |  Property                 |  Value                                               |
 | ------------------------- | ---------------------------------------------------- |
@@ -205,18 +199,18 @@ the 'addPaymentAddress' event:
 | **parameters**                |                                     |
 | **parameters.paymentAddress** | `paymentAddress` from parameters    |
 
-#### addRefundAddress
+## Action: addRefundAddress
 
-##### Parameters
+### Parameters
 
-|                              | Type   | Description                                                  | Requirement   |
-| ---------------------------- | ------ | ------------------------------------------------------------ | ------------- |
+|                              | Type   | Description                             | Requirement   |
+| ---------------------------- | ------ | --------------------------------------- | ------------- |
 | **id**                       | String | Constant value: "pn-any-to-erc20-proxy" | **Mandatory** |
-| **action**                   | String | Constant value: "addRefundAddress"                           | **Mandatory** |
-| **parameters**               | Object |                                                              |               |
-| **parameters.refundAddress** | String | Ethereum address for the refund                              | **Mandatory** |
+| **action**                   | String | Constant value: "addRefundAddress"      | **Mandatory** |
+| **parameters**               | Object |                                         |               |
+| **parameters.refundAddress** | String | Blockchain address for the refund       | **Mandatory** |
 
-##### Conditions
+### Conditions
 
 This action is valid if:
 
@@ -224,13 +218,13 @@ This action is valid if:
 - The signer is the `payer`
 - The extension property `refundAddress` is undefined
 
-##### Warnings
+### Warnings
 
 None.
 
-##### Results
+### Results
 
-An extension state is updated with the following properties:
+The extension state is updated with the following properties:
 
 |  Property                |  Value                                                 |
 | ------------------------ | ------------------------------------------------------ |
@@ -245,19 +239,19 @@ The 'addRefundAddress' event:
 | **parameters**               |                                 |
 | **parameters.refundAddress** | `refundAddress` from parameters |
 
-#### addFee
+## Action: addFee
 
-##### Parameters
+### Parameters
 
-|                          | Type   | Description                                                  | Requirement   |
-| ------------------------ | ------ | ------------------------------------------------------------ | ------------- |
-| **id**                   | String | Constant value: "pn-any-to-erc20-proxy" | **Mandatory** |
-| **action**               | String | Constant value: "addfeeAddress"                                  | **Mandatory** |
-| **parameters**           | Object |                                                              |               |
-| **parameters.feeAddress**    | String | Ethereum address for the fee payment                         | **Mandatory** |
-| **parameters.feeAmount** | String | The fee amount                                               | **Mandatory** |
+|                           | Type   | Description                             | Requirement   |
+| ------------------------- | ------ | --------------------------------------- | ------------- |
+| **id**                    | String | Constant value: "pn-any-to-erc20-proxy" | **Mandatory** |
+| **action**                | String | Constant value: "addfeeAddress"         | **Mandatory** |
+| **parameters**            | Object |                                         |               |
+| **parameters.feeAddress** | String | Blockchain address for the fee payment  | **Mandatory** |
+| **parameters.feeAmount**  | String | The fee amount                          | **Mandatory** |
 
-##### Conditions
+### Conditions
 
 This action is valid, if:
 
@@ -266,28 +260,62 @@ This action is valid, if:
 - The extension property `feeAddress` is undefined
 - The extension property `feeAmount` is undefined or represents an integer greater or equal than zero
 
-##### Warnings
+### Warnings
 
 None.
 
-##### Results
+### Results
 
-An extension state is updated with the following properties:
+The extension state is updated with the following properties:
 
-|  Property            |  Value                                   |
-| -------------------- | ---------------------------------------- |
-| **values.feeAddress**    | `feeAddress` from parameters                 |
-| **values.feeAmount** | `feeAmount` from parameters              |
-| **events**           | Add a 'fee' event (see below) at its end |
+|  Property             |  Value                                   |
+| --------------------- | ---------------------------------------- |
+| **values.feeAddress** | `feeAddress` from parameters             |
+| **values.feeAmount**  | `feeAmount` from parameters              |
+| **events**            | Add a 'fee' event (see below) at its end |
 
 the 'addFee' event:
 
-|  Property                |  Value                      |
-| ------------------------ | --------------------------- |
-| **name**                 | Constant value: "addfeeAddress" |
-| **parameters**           |                             |
-| **parameters.feeAddress**    | `feeAddress` from parameters    |
-| **parameters.feeAmount** | `feeAmount` from parameters |
+|  Property                 |  Value                          |
+| ------------------------- | ------------------------------- |
+| **name**                  | Constant value: "addfeeAddress" |
+| **parameters**            |                                 |
+| **parameters.feeAddress** | `feeAddress` from parameters    |
+| **parameters.feeAmount**  | `feeAmount` from parameters     |
+
+## Action: declarePayment
+
+### Parameters
+
+|                       | Type   | Description                                          | Requirement   |
+| --------------------- | ------ | ---------------------------------------------------- | ------------- |
+| **id**                | String | Constant value: "pn-any-to-erc20-proxy"              | **Mandatory** |
+| **action**            | String | Constant value: "declarePayment"                     | **Mandatory** |
+| **parameters**        | Object |                                                      |               |
+| **parameters.amount** | String | The amount declared as received, in request currency | **Mandatory** |
+| **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
+
+### Conditions
+
+This action is valid, if:
+
+- The extension state with the id "pn-any-to-erc20-proxy" exists
+- The signer is the `payee`
+
+### warnings
+
+None.
+
+### Results
+
+An event is added to the extension state events array:
+
+|  Property             |  Value                                |
+| --------------------- | ------------------------------------- |
+| **name**              | Constant value: "declarePayment"      |
+| **parameters**        |                                       |
+| **parameters.amount** | `amount` from parameters              |
+| **parameters.txHash** | `txHash` from parameters or undefined |
 
 ---
 
@@ -298,16 +326,18 @@ The fee proxy contract address is determined by the `paymentNetwork.values.netwo
 Any `TransferWithConversionAndReference` events emitted from the proxy contract with the following arguments are considered as a payment:
 
 - `tokenAddress` is contained in `paymentNetwork.values.tokenAccepted`
-- `to` `===` `paymentAddress`
-- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + payment address)))`
-- `maxRateTimespan` `===` `paymentNetwork.values.maxRateTimespan`
+- `to === paymentAddress`
+- `paymentReference === last8Bytes(hash(lowercase(requestId + salt + payment address)))`
+- `maxRateTimespan === paymentNetwork.values.maxRateTimespan`
+
+Any `declarePayment` event is considered a payment.
 
 Any `TransferWithConversionAndReference` events emitted from the proxy contract with the following arguments are considered as a refund:
 
 - `tokenAddress` is contained in `paymentNetwork.values.tokenAccepted`
-- `to` `===` `refundAddress`
-- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + refund address)))`
-- `maxRateTimespan` `===` `paymentNetwork.values.maxRateTimespan`
+- `to === refundAddress`
+- `paymentReference === last8Bytes(hash(lowercase(requestId + salt + refund address)))`
+- `maxRateTimespan === paymentNetwork.values.maxRateTimespan`
 
 The sum of payment amounts minus the sum of refund amounts is considered the balance.
 

--- a/packages/advanced-logic/specs/payment-network-erc20-fee-proxy-contract-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-erc20-fee-proxy-contract-0.1.0.md
@@ -1,20 +1,13 @@
 # Payment Network - ERC20 with Fee
 
-You may be interested in this document if:
-
-- you want to create your own implementation of the Request protocol
-- you are curious enough to dive and see what is under the hood of the Request protocol
-
-Prerequisite: Having read the advanced logic specification (see [here](./advanced-logic-specs-0.1.0.md)).
-
 ## Description
 
-This extension allows the payments and the refunds to be made in ERC20 tokens on the Ethereum blockchain.
+This extension allows payments and refunds to be made in ERC20 tokens on Ethereum and EVM-compatible blockchains.
 This Payment Network is similar to the [ERC20 Proxy Contract](./payment-network-erc20-proxy-contract-0.1.0.md) extension, with the added feature of allowing a fee to be taken from the payment.
 
-The payment is made through a proxy contract. This proxy contract does the ERC20 token transfer on behalf of the user. The contract ensures a link between an ERC20 transfer and a request through a `paymentReference`.
+The payment is mainly expected through a proxy payment contract, but the request issuer can also declare payments manually. Fees shall not be paid for declarative payments.
 
-This `paymentReference` consists of the last 8 bytes of a salted hash of the requestId: `last8Bytes(hash(lowercase(requestId + salt + address)))`:
+The proxy contract does the ERC20 token transfer on behalf of the user. The contract ensures a link between an ERC20 transfer and a request through a `paymentReference`. This `paymentReference` consists of the last 8 bytes of a salted hash of the requestId: `last8Bytes(hash(lowercase(requestId + salt + address)))`:
 
 The contract also ensures that the `feeAmount` amount of the ERC20 transfer will be forwarded to the `feeAddress`.
 
@@ -27,10 +20,9 @@ The contract also ensures that the `feeAmount` amount of the ERC20 transfer will
 - `hash()` is a keccak256 hash function
 - `last8Bytes()` take the last 8 bytes
 
-As a payment network, this extension allows to deduce a payment `balance` for the request. (see
-[Interpretation](#Interpretation))
+As a payment network, this extension allows to deduce a payment `balance` for the request. (see [Interpretation](#Interpretation))
 
-## Contract
+## Payment Proxy Contract
 
 The contract contains one function called `transferFromWithReferenceAndFee` which takes 6 arguments:
 
@@ -45,11 +37,18 @@ The `TransferWithReferenceAndFee` event is emitted when the tokens are transfere
 
 [See smart contract source](https://github.com/RequestNetwork/requestNetwork/blob/master/packages/smart-contracts/src/contracts/ERC20FeeProxy.sol)
 
-| Network | Contract Address                           |
-| ------- | ------------------------------------------ |
-| Mainnet | 0x370DE27fdb7D1Ff1e1BaA7D11c5820a324Cf623C |
-| Rinkeby | 0xda46309973bffddd5a10ce12c44d2ee266f45a44 |
-| Private | 0x75c35C980C0d37ef46DF04d31A140b65503c0eEd |
+| Network                    | Contract Address                           |
+| -------------------------- | ------------------------------------------ |
+| Mainnet                    | 0x370DE27fdb7D1Ff1e1BaA7D11c5820a324Cf623C |
+| Matic                      | 0x0DfbEe143b42B41eFC5A6F87bFD1fFC78c2f0aC9 |
+| Celo                       | 0x2171a0dc12a9E5b1659feF2BB20E54c84Fa7dB0C |
+| Ethereum Testnet - Rinkeby | 0xda46309973bffddd5a10ce12c44d2ee266f45a44 |
+| Matic Testnet - Mumbai     | 0x131eb294E3803F23dc2882AB795631A12D1d8929 |
+| Private                    | 0x75c35C980C0d37ef46DF04d31A140b65503c0eEd |
+
+## Manual payment declaration
+
+The issuer can declare that he received a payment and give the amount, possibly with a `txHash` for documentation.
 
 ## Properties
 
@@ -61,20 +60,16 @@ The `TransferWithReferenceAndFee` event is emitted when the tokens are transfere
 | **events**                | Array  | List of the actions performed by the extension | **Mandatory** |
 | **values**                | Object |                                                |               |
 | **values.salt**           | String | Salt for the request                           | **Mandatory** |
-| **values.paymentAddress** | String | Ethereum address for the payment               | Optional      |
-| **values.refundAddress**  | String | Ethereum address for the refund                | Optional      |
-| **values.feeAddress**     | String | Ethereum address for the fee payment           | Optional      |
+| **values.paymentAddress** | String | Blockchain address for the payment             | Optional      |
+| **values.refundAddress**  | String | Blockchain address for the refund              | Optional      |
+| **values.feeAddress**     | String | Blockchain address for the fee payment         | Optional      |
 | **values.feeAmount**      | String | The fee amount in the request `currency`       | Optional      |
-
-Note: to use the Rinkeby testnet, create a request with `currency.network` as `rinkeby`.
 
 ---
 
-## Actions
+## Action: Creation
 
-### Creation
-
-#### Parameters
+### Parameters
 
 |                               | Type   | Description                                   | Requirement   |
 | ----------------------------- | ------ | --------------------------------------------- | ------------- |
@@ -83,19 +78,19 @@ Note: to use the Rinkeby testnet, create a request with `currency.network` as `r
 | **version**                   | String | Constant value: "0.1.0"                       | **Mandatory** |
 | **parameters**                | Object |                                               |               |
 | **parameters.salt**           | String | Salt for the request                          | **Mandatory** |
-| **parameters.paymentAddress** | String | Ethereum address for the payment              | Optional      |
-| **parameters.refundAddress**  | String | Ethereum address for the refund               | Optional      |
-| **parameters.feeAddress**     | String | Ethereum address for the fee payment          | Optional      |
+| **parameters.paymentAddress** | String | Blockchain address for the payment            | Optional      |
+| **parameters.refundAddress**  | String | Blockchain address for the refund             | Optional      |
+| **parameters.feeAddress**     | String | Blockchain address for the fee payment        | Optional      |
 | **parameters.feeAmount**      | String | The fee amount in the request `currency`      | Optional      |
 
-#### Conditions
+### Conditions
 
 This action is valid if:
 
 - The `salt` is not empty and long enough (8 bytes of randomness minimum).
 - The `currency.type` is ERC20.
 
-#### Warnings
+### Warnings
 
 This action must trigger the warnings:
 
@@ -106,11 +101,11 @@ This action must trigger the warnings:
 | "feeAmount is given by the payer"       | If `signer` is the payer **and** `feeAddress` is given      |
 | "refundAddress is given by the payee"   | If `signer` is the payee **and** `refundAddress` is given   |
 
-Note: These warnings are necessary to highlight to avoid attempts of fake payments and refunds. For example, a payer could create a request using as the payment address one of his own addresses. A system could interpret a transaction to this address as a payment while the payee did not receive the funds.
+Note: These warnings are necessary to highlight and avoid attempts of fake payments and refunds. For example, a payer could create a request using as the payment address one of his own addresses. A system could interpret a transaction to this address as a payment while the payee did not receive the funds.
 
-#### Results
+### Results
 
-An extension state is created with the following properties:
+The extension state is created with the following properties:
 
 |  Property                 |  Value                                                         |
 | ------------------------- | -------------------------------------------------------------- |
@@ -139,20 +134,18 @@ the 'create' event:
 
 ---
 
-### Updates
+## Action: addPaymentAddress
 
-#### addPaymentAddress
-
-##### Parameters
+### Parameters
 
 |                               | Type   | Description                                   | Requirement   |
 | ----------------------------- | ------ | --------------------------------------------- | ------------- |
 | **id**                        | String | Constant value: "pn-erc20-fee-proxy-contract" | **Mandatory** |
 | **action**                    | String | Constant value: "addPaymentAddress"           | **Mandatory** |
 | **parameters**                | Object |                                               |               |
-| **parameters.paymentAddress** | String | Ethereum address for the payment              | **Mandatory** |
+| **parameters.paymentAddress** | String | Blockchain address for the payment            | **Mandatory** |
 
-##### Conditions
+### Conditions
 
 This action is valid, if:
 
@@ -160,11 +153,11 @@ This action is valid, if:
 - The signer is the `payee`
 - The extension property `paymentAddress` is undefined
 
-##### Warnings
+### warnings
 
 None.
 
-##### Results
+### Results
 
 An extension state is updated with the following properties:
 
@@ -181,18 +174,18 @@ the 'addPaymentAddress' event:
 | **parameters**                |                                     |
 | **parameters.paymentAddress** | `paymentAddress` from parameters    |
 
-#### addRefundAddress
+## Action: addRefundAddress
 
-##### Parameters
+### Parameters
 
 |                              | Type   | Description                                   | Requirement   |
 | ---------------------------- | ------ | --------------------------------------------- | ------------- |
 | **id**                       | String | Constant value: "pn-erc20-fee-proxy-contract" | **Mandatory** |
 | **action**                   | String | Constant value: "addRefundAddress"            | **Mandatory** |
 | **parameters**               | Object |                                               |               |
-| **parameters.refundAddress** | String | Ethereum address for the refund               | **Mandatory** |
+| **parameters.refundAddress** | String | Blockchain address for the refund             | **Mandatory** |
 
-##### Conditions
+### Conditions
 
 This action is valid if:
 
@@ -200,13 +193,13 @@ This action is valid if:
 - The signer is the `payer`
 - The extension property `refundAddress` is undefined
 
-##### Warnings
+### warnings
 
 None.
 
-##### Results
+### Results
 
-An extension state is updated with the following properties:
+The extension state is updated with the following properties:
 
 |  Property                |  Value                                                 |
 | ------------------------ | ------------------------------------------------------ |
@@ -221,19 +214,19 @@ The 'addRefundAddress' event:
 | **parameters**               |                                 |
 | **parameters.refundAddress** | `refundAddress` from parameters |
 
-#### addFee
+## Action: addFee
 
-##### Parameters
+### Parameters
 
 |                           | Type   | Description                                   | Requirement   |
 | ------------------------- | ------ | --------------------------------------------- | ------------- |
 | **id**                    | String | Constant value: "pn-erc20-fee-proxy-contract" | **Mandatory** |
 | **action**                | String | Constant value: "addFeeAddress"               | **Mandatory** |
 | **parameters**            | Object |                                               |               |
-| **parameters.feeAddress** | String | Ethereum address for the fee payment          | **Mandatory** |
+| **parameters.feeAddress** | String | Blockchain address for the fee payment        | **Mandatory** |
 | **parameters.feeAmount**  | String | The fee amount                                | **Mandatory** |
 
-##### Conditions
+### Conditions
 
 This action is valid, if:
 
@@ -242,13 +235,13 @@ This action is valid, if:
 - The extension property `feeAddress` is undefined
 - The extension property `feeAmount` is undefined or represents an integer greater or equal than zero
 
-##### Warnings
+### warnings
 
 None.
 
-##### Results
+### Results
 
-An extension state is updated with the following properties:
+The extension state is updated with the following properties:
 
 |  Property             |  Value                                   |
 | --------------------- | ---------------------------------------- |
@@ -265,6 +258,40 @@ the 'addFee' event:
 | **parameters.feeAddress** | `feeAddress` from parameters    |
 | **parameters.feeAmount**  | `feeAmount` from parameters     |
 
+## Action: declarePayment
+
+### Parameters
+
+|                       | Type   | Description                                          | Requirement   |
+| --------------------- | ------ | ---------------------------------------------------- | ------------- |
+| **id**                | String | Constant value: "pn-erc20-fee-proxy-contract"        | **Mandatory** |
+| **action**            | String | Constant value: "declarePayment"                     | **Mandatory** |
+| **parameters**        | Object |                                                      |               |
+| **parameters.amount** | String | The amount declared as received, in request currency | **Mandatory** |
+| **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
+
+### Conditions
+
+This action is valid, if:
+
+- The extension state with the id "pn-erc20-fee-proxy-contract" exists
+- The signer is the `payee`
+
+### warnings
+
+None.
+
+### Results
+
+An event is added to the extension state events array:
+
+|  Property             |  Value                                |
+| --------------------- | ------------------------------------- |
+| **name**              | Constant value: "declarePayment"      |
+| **parameters**        |                                       |
+| **parameters.amount** | `amount` from parameters              |
+| **parameters.txHash** | `txHash` from parameters or undefined |
+
 ---
 
 ## Interpretation
@@ -273,15 +300,17 @@ The fee proxy contract address is determined by the `request.currency.network` (
 
 Any `TransferWithReferenceAndFee` events emitted from the proxy contract with the following arguments are considered as a payment:
 
-- `tokenAddress` `===` `request.currency.value`
-- `to` `===` `paymentAddress`
-- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + payment address)))`
+- `tokenAddress === request.currency.value`
+- `to === paymentAddress`
+- `paymentReference === last8Bytes(hash(lowercase(requestId + salt + payment address)))`
+
+Any `declarePayment` event is considered a payment.
 
 Any `TransferWithReferenceAndFee` events emitted from the proxy contract with the following arguments are considered as a refund:
 
-- `tokenAddress` `===` `request.currency.value`
-- `to` `===` `refundAddress`
-- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + refund address)))`
+- `tokenAddress === request.currency.value`
+- `to === refundAddress`
+- `paymentReference === last8Bytes(hash(lowercase(requestId + salt + refund address)))`
 
 The sum of payment amounts minus the sum of refund amounts is considered the balance.
 

--- a/packages/advanced-logic/specs/payment-network-eth-fee-proxy-contract-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-eth-fee-proxy-contract-0.1.0.md
@@ -1,22 +1,15 @@
 # Payment Network - Ethereum with Fee
 
-You may be interested in this document if:
-
-- you want to create your own implementation of the Request protocol
-- you are curious enough to dive and see what is under the hood of the Request protocol
-
-Prerequisite: Having read the advanced logic specification (see [here](./advanced-logic-specs-0.1.0.md)).
-
 ## Description
 
-This extension allows the payments and the refunds to be made in Ethers on the Ethereum blockchain.
+This extension allows the payments and the refunds to be made in Ether on the Ethereum blockchain, or in any native token of an EVM chain.
 This Payment Network is similar to the [Ethereum Proxy Contract](./payment-network-eth-proxy-contract-0.1.0.md) extension, with the added feature of allowing a fee to be taken from the payment.
 
-The payment is made through a proxy contract. This proxy contract does the ethers transfers on behalf of the user. The contract ensures a link between the ethers  transfers and a request through a `paymentReference`.
+The payment is primarly made through a proxy contract, and can also be declared manually. Fees shall not be paid for declarative payments.
 
-This `paymentReference` consists of the last 8 bytes of a salted hash of the requestId: `last8Bytes(hash(lowercase(requestId + salt + address)))`:
+This proxy contract does the ethers transfers on behalf of the user. The contract ensures a link between the ethers transfers and a request through a `paymentReference`, consisting of the last 8 bytes of a salted hash of the requestId: `last8Bytes(hash(lowercase(requestId + salt + address)))`:
 
-The contract also ensures that the `feeAmount` amount will be forwarded to the `feeAddress`.
+The contract also ensures that the `feeAmount` amount is forwarded to the `feeAddress`.
 
 - `requestId` is the id of the request
 - `salt` is a random number with at least 8 bytes of randomness. It must be unique to each request
@@ -27,12 +20,11 @@ The contract also ensures that the `feeAmount` amount will be forwarded to the `
 - `hash()` is a keccak256 hash function
 - `last8Bytes()` take the last 8 bytes
 
-As a payment network, this extension allows to deduce a payment `balance` for the request. (see
-[Interpretation](#Interpretation))
+As a payment network, this extension allows to deduce a payment `balance` for the request. (see [Interpretation](#Interpretation))
 
 ## Contract
 
-The contract contains one function called `transferWithReferenceAndFee` which takes 6 arguments:
+The contract contains one function called `transferWithReferenceAndFee` which takes 4 arguments:
 
 - `to` is the destination address for the ethers
 - `paymentReference` is the reference data used to track the transfer (see `paymentReference`)
@@ -55,47 +47,43 @@ The `TransferWithReferenceAndFee` event is emitted when the tokens are transfere
 
 | Property                  | Type   | Description                                    | Requirement   |
 | ------------------------- | ------ | ---------------------------------------------- | ------------- |
-| **id**                    | String | constant value: "pn-eth-fee-proxy-contract"  | **Mandatory** |
+| **id**                    | String | constant value: "pn-eth-fee-proxy-contract"    | **Mandatory** |
 | **type**                  | String | constant value: "paymentNetwork"               | **Mandatory** |
 | **version**               | String | constant value: "0.1.0"                        | **Mandatory** |
 | **events**                | Array  | List of the actions performed by the extension | **Mandatory** |
 | **values**                | Object |                                                |               |
 | **values.salt**           | String | Salt for the request                           | **Mandatory** |
-| **values.paymentAddress** | String | Ethereum address for the payment               | Optional      |
-| **values.refundAddress**  | String | Ethereum address for the refund                | Optional      |
-| **values.feeAddress**     | String | Ethereum address for the fee payment           | Optional      |
-| **values.feeAmount**      | String | The fee amount      | Optional      |
-
-Note: to use the Rinkeby testnet, create a request with `currency.network` as `rinkeby`.
+| **values.paymentAddress** | String | Blockchain address for the payment             | Optional      |
+| **values.refundAddress**  | String | Blockchain address for the refund              | Optional      |
+| **values.feeAddress**     | String | Blockchain address for the fee payment         | Optional      |
+| **values.feeAmount**      | String | The fee amount                                 | Optional      |
 
 ---
 
-## Actions
+## Action: Creation
 
-### Creation
+### Parameters
 
-#### Parameters
-
-|                               | Type   | Description                                   | Requirement   |
-| ----------------------------- | ------ | --------------------------------------------- | ------------- |
+|                               | Type   | Description                                 | Requirement   |
+| ----------------------------- | ------ | ------------------------------------------- | ------------- |
 | **id**                        | String | Constant value: "pn-eth-fee-proxy-contract" | **Mandatory** |
-| **type**                      | String | Constant value: "paymentNetwork"              | **Mandatory** |
-| **version**                   | String | Constant value: "0.1.0"                       | **Mandatory** |
-| **parameters**                | Object |                                               |               |
-| **parameters.salt**           | String | Salt for the request                          | **Mandatory** |
-| **parameters.paymentAddress** | String | Ethereum address for the payment              | Optional      |
-| **parameters.refundAddress**  | String | Ethereum address for the refund               | Optional      |
-| **parameters.feeAddress**     | String | Ethereum address for the fee payment          | Optional      |
-| **parameters.feeAmount**      | String | The fee amount      | Optional      |
+| **type**                      | String | Constant value: "paymentNetwork"            | **Mandatory** |
+| **version**                   | String | Constant value: "0.1.0"                     | **Mandatory** |
+| **parameters**                | Object |                                             |               |
+| **parameters.salt**           | String | Salt for the request                        | **Mandatory** |
+| **parameters.paymentAddress** | String | Blockchain address for the payment          | Optional      |
+| **parameters.refundAddress**  | String | Blockchain address for the refund           | Optional      |
+| **parameters.feeAddress**     | String | Blockchain address for the fee payment      | Optional      |
+| **parameters.feeAmount**      | String | The fee amount                              | Optional      |
 
-#### Conditions
+### Conditions
 
 This action is valid if:
 
 - The `salt` is not empty and long enough (8 bytes of randomness minimum).
 - The `currency.type` is ETH.
 
-#### Warnings
+### Warnings
 
 This action must trigger the warnings:
 
@@ -106,7 +94,7 @@ This action must trigger the warnings:
 | "feeAmount is given by the payer"       | If `signer` is the payer **and** `feeAddress` is given      |
 | "refundAddress is given by the payee"   | If `signer` is the payee **and** `refundAddress` is given   |
 
-Note: These warnings are necessary to highlight to avoid attempts of fake payments and refunds. For example, a payer could create a request using as the payment address one of his own addresses. A system could interpret a transaction to this address as a payment while the payee did not receive the funds.
+Note: These warnings are necessary to highlight and avoid attempts of fake payments and refunds. For example, a payer could create a request using as the payment address one of his own addresses. A system could interpret a transaction to this address as a payment while the payee did not receive the funds.
 
 #### Results
 
@@ -114,7 +102,7 @@ An extension state is created with the following properties:
 
 |  Property                 |  Value                                                         |
 | ------------------------- | -------------------------------------------------------------- |
-| **id**                    | "pn-eth-fee-proxy-contract"                                  |
+| **id**                    | "pn-eth-fee-proxy-contract"                                    |
 | **type**                  | "paymentNetwork"                                               |
 | **version**               | "0.1.0"                                                        |
 | **values**                |                                                                |
@@ -139,20 +127,18 @@ the 'create' event:
 
 ---
 
-### Updates
+## Action: addPaymentAddress
 
-#### addPaymentAddress
+### Parameters
 
-##### Parameters
+|                               | Type   | Description                                 | Requirement   |
+| ----------------------------- | ------ | ------------------------------------------- | ------------- |
+| **id**                        | String | Constant value: "pn-eth-fee-proxy-contract" | **Mandatory** |
+| **action**                    | String | Constant value: "addPaymentAddress"         | **Mandatory** |
+| **parameters**                | Object |                                             |               |
+| **parameters.paymentAddress** | String | Blockchain address for the payment          | **Mandatory** |
 
-|                               | Type   | Description                                   | Requirement   |
-| ----------------------------- | ------ | --------------------------------------------- | ------------- |
-| **id**                        | String | Constant value: "pn-eth-fee-proxy-contract"   | **Mandatory** |
-| **action**                    | String | Constant value: "addPaymentAddress"           | **Mandatory** |
-| **parameters**                | Object |                                               |               |
-| **parameters.paymentAddress** | String | Ethereum address for the payment              | **Mandatory** |
-
-##### Conditions
+### Conditions
 
 This action is valid, if:
 
@@ -160,13 +146,13 @@ This action is valid, if:
 - The signer is the `payee`
 - The extension property `paymentAddress` is undefined
 
-##### Warnings
+### Warnings
 
 None.
 
-##### Results
+### Results
 
-An extension state is updated with the following properties:
+The extension state is updated with the following properties:
 
 |  Property                 |  Value                                               |
 | ------------------------- | ---------------------------------------------------- |
@@ -181,18 +167,18 @@ the 'addPaymentAddress' event:
 | **parameters**                |                                     |
 | **parameters.paymentAddress** | `paymentAddress` from parameters    |
 
-#### addRefundAddress
+## Action: addRefundAddress
 
-##### Parameters
+### Parameters
 
-|                              | Type   | Description                                   | Requirement   |
-| ---------------------------- | ------ | --------------------------------------------- | ------------- |
+|                              | Type   | Description                                 | Requirement   |
+| ---------------------------- | ------ | ------------------------------------------- | ------------- |
 | **id**                       | String | Constant value: "pn-eth-fee-proxy-contract" | **Mandatory** |
-| **action**                   | String | Constant value: "addRefundAddress"            | **Mandatory** |
-| **parameters**               | Object |                                               |               |
-| **parameters.refundAddress** | String | Ethereum address for the refund               | **Mandatory** |
+| **action**                   | String | Constant value: "addRefundAddress"          | **Mandatory** |
+| **parameters**               | Object |                                             |               |
+| **parameters.refundAddress** | String | Blockchain address for the refund           | **Mandatory** |
 
-##### Conditions
+### Conditions
 
 This action is valid if:
 
@@ -200,13 +186,13 @@ This action is valid if:
 - The signer is the `payer`
 - The extension property `refundAddress` is undefined
 
-##### Warnings
+### Warnings
 
 None.
 
-##### Results
+### Results
 
-An extension state is updated with the following properties:
+The extension state is updated with the following properties:
 
 |  Property                |  Value                                                 |
 | ------------------------ | ------------------------------------------------------ |
@@ -221,19 +207,19 @@ The 'addRefundAddress' event:
 | **parameters**               |                                 |
 | **parameters.refundAddress** | `refundAddress` from parameters |
 
-#### addFee
+## Action: addFee
 
-##### Parameters
+### Parameters
 
-|                           | Type   | Description                                   | Requirement   |
-| ------------------------- | ------ | --------------------------------------------- | ------------- |
-| **id**                    | String | Constant value: "pn-eth-fee-proxy-contract"   | **Mandatory** |
-| **action**                | String | Constant value: "addFeeAddress"               | **Mandatory** |
-| **parameters**            | Object |                                               |               |
-| **parameters.feeAddress** | String | Ethereum address for the fee payment          | **Mandatory** |
-| **parameters.feeAmount**  | String | The fee amount                                | **Mandatory** |
+|                           | Type   | Description                                 | Requirement   |
+| ------------------------- | ------ | ------------------------------------------- | ------------- |
+| **id**                    | String | Constant value: "pn-eth-fee-proxy-contract" | **Mandatory** |
+| **action**                | String | Constant value: "addFeeAddress"             | **Mandatory** |
+| **parameters**            | Object |                                             |               |
+| **parameters.feeAddress** | String | Blockchain address for the fee payment      | **Mandatory** |
+| **parameters.feeAmount**  | String | The fee amount                              | **Mandatory** |
 
-##### Conditions
+### Conditions
 
 This action is valid, if:
 
@@ -242,13 +228,13 @@ This action is valid, if:
 - The extension property `feeAddress` is undefined
 - The extension property `feeAmount` is undefined or represents an integer greater or equal than zero
 
-##### Warnings
+### Warnings
 
 None.
 
-##### Results
+### Results
 
-An extension state is updated with the following properties:
+The extension state is updated with the following properties:
 
 |  Property             |  Value                                   |
 | --------------------- | ---------------------------------------- |
@@ -269,19 +255,21 @@ the 'addFee' event:
 
 ## Interpretation
 
-The fee proxy contract address is determined by the `request.currency.network` (see (table)[#Contract] with proxy contract addresses).
+The fee proxy contract address is determined by the `request.currency.network` (see (table)[#Contract] with proxy contract addresses). Only transactions on this network are valid.
 
-Any `TransferWithReferenceAndFee` events emitted from the proxy contract with the following arguments are considered as a payment:
+Any `TransferWithReferenceAndFee` event emitted from the proxy contract with the following arguments is considered a payment:
 
-- `tokenAddress` `===` `request.currency.value`
-- `to` `===` `paymentAddress`
-- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + payment address)))`
+- `tokenAddress === request.currency.value`
+- `to === paymentAddress`
+- `paymentReference === last8Bytes(hash(lowercase(requestId + salt + payment address)))`
 
-Any `TransferWithReferenceAndFee` events emitted from the proxy contract with the following arguments are considered as a refund:
+Any `declarePayment` event is considered a payment.
 
-- `tokenAddress` `===` `request.currency.value`
-- `to` `===` `refundAddress`
-- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + refund address)))`
+Any `TransferWithReferenceAndFee` evens emitted from the proxy contract with the following arguments is considered a refund:
+
+- `tokenAddress === request.currency.value`
+- `to === refundAddress`
+- `paymentReference === last8Bytes(hash(lowercase(requestId + salt + refund address)))`
 
 The sum of payment amounts minus the sum of refund amounts is considered the balance.
 

--- a/packages/advanced-logic/specs/payment-network-eth-input-data-0.2.0.md
+++ b/packages/advanced-logic/specs/payment-network-eth-input-data-0.2.0.md
@@ -1,21 +1,15 @@
 # Payment Network - ETH - input data
 
-You may be interested in this document if:
-
-- you want to create your own implementation of the Request protocol
-- you are curious enough to dive and see what is under the hood of the Request protocol
-
-Prerequisite: Having read the advanced logic specification (see [here](./advanced-logic-specs-0.1.0.md)).
-
 ## Description
 
-This extension allows the payments and the refunds to be made in Ether on the Ethereum blockchain.
+This extension allows the payments and the refunds to be made in Ether on the Ethereum blockchain, or in any native token of an EVM chain.
 A payment reference has to be given when making the transfer to link the payment to the request.
 
-There are two ways to add a payment reference to a transfer:
+There are three ways to match payments for the concerned request (and payment reference):
 
-1. add the reference to the input data of the transfer
-2. call the ethereum proxy smart contract (see [Contract](#Contract))
+1. The payer transfers native tokens add the reference to the input data
+2. The payer calls the ETH proxy smart contract (see [Contract](#Contract))
+3. The issuer declares a payment manually
 
 The payment reference is the last 8 bytes of a salted hash of the requestId: `last8Bytes(hash(lowercase(requestId + salt + address)))`:
 
@@ -25,8 +19,11 @@ The payment reference is the last 8 bytes of a salted hash of the requestId: `la
 - `hash()` is a keccak256 hash function
 - `last8Bytes()` take the last 8 bytes
 
-As a payment network, this extension allows to deduce a payment `balance` for the request. (see
-[Interpretation](#Interpretation))
+As a payment network, this extension allows to deduce a payment `balance` for the request. (see [Interpretation](#Interpretation))
+
+## Manual payment declaration
+
+The issuer can declare that he received a payment and give the amount, possibly with a `txHash` for documentation.
 
 ## Contract
 
@@ -53,19 +50,15 @@ The `TransferWithReference` event is emitted when the Ether is transfered. This 
 | **version**               | String | constant value: "0.2.0"                        | **Mandatory** |
 | **events**                | Array  | List of the actions performed by the extension | **Mandatory** |
 | **values**                | Object |                                                |               |
-| **values.paymentAddress** | String | Ethereum address for the payment               | Optional      |
-| **values.refundAddress**  | String | Ethereum address for the refund                | Optional      |
+| **values.paymentAddress** | String | Blockchain address for the payment             | Optional      |
+| **values.refundAddress**  | String | Blockchain address for the refund              | Optional      |
 | **values.salt**           | String | Salt for the request                           | **Mandatory** |
-
-Note: to use the Rinkeby testnet just set the `currency.network` to "rinkeby"
 
 ---
 
-## Actions
+## Action: Creation
 
-### Creation
-
-#### Parameters
+### Parameters
 
 |                               | Type   | Description                         | Requirement   |
 | ----------------------------- | ------ | ----------------------------------- | ------------- |
@@ -73,11 +66,11 @@ Note: to use the Rinkeby testnet just set the `currency.network` to "rinkeby"
 | **type**                      | String | Constant value: "paymentNetwork"    | **Mandatory** |
 | **version**                   | String | Constant value: "0.2.0"             | **Mandatory** |
 | **parameters**                | Object |                                     |               |
-| **parameters.paymentAddress** | String | Ethereum address for the payment    | Optional      |
-| **parameters.refundAddress**  | String | Ethereum address for the refund     | Optional      |
+| **parameters.paymentAddress** | String | Blockchain address for the payment  | Optional      |
+| **parameters.refundAddress**  | String | Blockchain address for the refund   | Optional      |
 | **parameters.salt**           | String | Salt for the request                | **Mandatory** |
 
-#### Conditions
+### Conditions
 
 This action is valid if:
 
@@ -85,7 +78,7 @@ This action is valid if:
 - The request `currency.network` must be "mainnet", "rinkeby" or an EVM chain
 - The `salt` is not empty and long enough (8 bytes of randomness minimum).
 
-#### Warnings
+### Warnings
 
 This action must trigger the warnings:
 
@@ -94,11 +87,11 @@ This action must trigger the warnings:
 | "paymentAddress is given by the payer"  | If `signer` is the payer **and** `paymentAddress` is given  |
 | "refundAddress is given by the payee"   | If `signer` is the payee **and** `refundAddress` is given   |
 
-Note: These warnings are necessary to highlight to avoid attempts of fake payments and refunds. For example, a payer could create a request using as the payment address one of his own addresses. A system could interpret a transaction to this address as a payment while the payee did not receive the funds.
+Note: These warnings are necessary to highlight and avoid attempts of fake payments and refunds. For example, a payer could create a request using as the payment address one of his own addresses. A system could interpret a transaction to this address as a payment while the payee did not receive the funds.
 
-#### Results
+### Results
 
-A extension state is created with the following properties:
+An extension state is created with the following properties:
 
 |  Property                 |  Value                                                         |
 | ------------------------- | -------------------------------------------------------------- |
@@ -123,20 +116,18 @@ the 'create' event:
 
 ---
 
-### Updates
+## Action: addPaymentAddress
 
-#### addPaymentAddress
-
-##### Parameters
+### Parameters
 
 |                               | Type   | Description                         | Requirement   |
 | ----------------------------- | ------ | ----------------------------------- | ------------- |
 | **id**                        | String | Constant value: "pn-eth-input-data" | **Mandatory** |
 | **action**                    | String | Constant value: "addPaymentAddress" | **Mandatory** |
 | **parameters**                | Object |                                     |               |
-| **parameters.paymentAddress** | String | Ethereum address for the payment    | **Mandatory** |
+| **parameters.paymentAddress** | String | Blockchain address for the payment  | **Mandatory** |
 
-##### Conditions
+### Conditions
 
 This action is valid, if:
 
@@ -144,13 +135,13 @@ This action is valid, if:
 - The signer is the `payee`
 - The extension property `paymentAddress` is undefined
 
-##### Warnings
+### Warnings
 
 None.
 
-##### Results
+### Results
 
-A extension state is updated with the following properties:
+The extension state is updated with the following properties:
 
 |  Property                  |  Value                                               |
 | -------------------------- | ---------------------------------------------------- |
@@ -166,18 +157,18 @@ the 'addPaymentAddress' event:
 | **parameters**                |                                     |
 | **parameters.paymentAddress** | `paymentAddress` from parameters    |
 
-#### addRefundAddress
+## Action: addRefundAddress
 
-##### Parameters
+### Parameters
 
 |                              | Type   | Description                         | Requirement   |
 | ---------------------------- | ------ | ----------------------------------- | ------------- |
 | **id**                       | String | Constant value: "pn-eth-input-data" | **Mandatory** |
 | **action**                   | String | Constant value: "addRefundAddress"  | **Mandatory** |
 | **parameters**               | Object |                                     |               |
-| **parameters.refundAddress** | String | Ethereum address for the refund     | **Mandatory** |
+| **parameters.refundAddress** | String | Blockchain address for the refund   | **Mandatory** |
 
-##### Conditions
+### Conditions
 
 This action is valid if:
 
@@ -185,13 +176,13 @@ This action is valid if:
 - The signer is the `payer`
 - The extension property `refundAddress` is undefined
 
-##### Warnings
+### Warnings
 
 None.
 
-##### Results
+### Results
 
-A extension state is updated with the following properties:
+The extension state is updated with the following properties:
 
 |  Property                |  Value                                                 |
 | ------------------------ | ------------------------------------------------------ |
@@ -207,21 +198,64 @@ The 'addRefundAddress' event:
 | **parameters**               |                                 |
 | **parameters.refundAddress** | `refundAddress` from parameters |
 
+## Action: declarePayment
+
+### Parameters
+
+|                       | Type   | Description                                         | Requirement   |
+| --------------------- | ------ | --------------------------------------------------- | ------------- |
+| **id**                | String | Constant value: "pn-eth-input-data"                 | **Mandatory** |
+| **action**            | String | Constant value: "declarePayment"                    | **Mandatory** |
+| **parameters**        | Object |                                                     |               |
+| **parameters.amount** | String | The amount declared as received                     | **Mandatory** |
+| **parameters.txHash** | String | The transaction hash for documentation and metadata | Optional      |
+
+### Conditions
+
+This action is valid, if:
+
+- The extension state with the id "pn-eth-input-data" exists
+- The signer is the `payee`
+
+### warnings
+
+None.
+
+### Results
+
+An event is added to the extension state events array:
+
+|  Property             |  Value                                |
+| --------------------- | ------------------------------------- |
+| **name**              | Constant value: "declarePayment"      |
+| **parameters**        |                                       |
+| **parameters.amount** | `amount` from parameters              |
+| **parameters.txHash** | `txHash` from parameters or undefined |
+
 ---
 
 ## Interpretation
 
-The proxy contract address is determined by the `request.currency.network` (see (table)[#Contract] with proxy contract addresses).
+The proxy contract address is determined by the `request.currency.network` (see (table)[#Contract] with proxy contract addresses). Only transactions on this network are valid.
 
-The `balance` starts from `0`.
-Any ETH transaction to `paymentAddress` with exactly `last8Bytes(hash(requestId + salt + payment address))` in input data is considered as a payment. The `balance` is increased by the sum of the amounts of the transactions.
-Any `TransferWithReference` events emitted from the proxy contract with the following arguments are considered as a payment:
+The sum of payment amounts minus the sum of refund amounts is considered the balance.
 
-- `to` `===` `paymentAddress`
-- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + payment address)))`
+### Payments
 
-Any ETH transaction to `refundAddress` with exactly `last8Bytes(hash(requestId + salt + refund address))` in input data is considered as a refund. The `balance` is reduced by the sum of the amounts of the transactions.
-Any `TransferWithReference` events emitted from the proxy contract with the following arguments are considered as a refund:
+Any ETH transaction to `paymentAddress` with exactly `last8Bytes(hash(requestId + salt + payment address))` in input data is considered a payment.
 
-- `to` `===` `refundAddress`
-- `paymentReference` `===` `last8Bytes(hash(lowercase(requestId + salt + refund address)))`
+Any `declarePayment` event is considered a payment.
+
+Any `TransferWithReference` events emitted from the proxy contract with the following arguments is considered a payment:
+
+- `to === paymentAddress`
+- `paymentReference === last8Bytes(hash(lowercase(requestId + salt + payment address)))`
+
+### Refunds
+
+Any ETH transaction to `refundAddress` with exactly `last8Bytes(hash(requestId + salt + refund address))` in input data is considered a refund.
+
+Any `TransferWithReference` event emitted from the proxy contract with the following arguments is considered a refund:
+
+- `to === refundAddress`
+- `paymentReference === last8Bytes(hash(lowercase(requestId + salt + refund address)))`


### PR DESCRIPTION
## Description of the changes

Specify that the payee can `declarePayment` for main payment networks:
- ERC20FeeProxy
- AnyToERC20Proxy
- ETHInputData
- ETHFeeProxy

❓ Cross-check: We can keep the same payment network versions for each of them as only the payee can trigger this action.