### PR TITLE
fix: extension version not based on data

### DIFF
--- a/packages/advanced-logic/src/extensions/abstract-extension.ts
+++ b/packages/advanced-logic/src/extensions/abstract-extension.ts
@@ -102,12 +102,16 @@ export default abstract class AbstractExtension<TCreationParameters> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _timestamp: number,
   ): ExtensionTypes.IState {
+    if (!extensionAction.version) {
+      throw Error('version is required at creation');
+    }
+
     return {
       events: [],
       id: extensionAction.id,
       type: this.extensionType,
       values: {},
-      version: this.currentVersion,
+      version: extensionAction.version,
     };
   }
 

--- a/packages/advanced-logic/src/extensions/content-data.ts
+++ b/packages/advanced-logic/src/extensions/content-data.ts
@@ -63,7 +63,6 @@ export default class ContentDataExtension<
         ...genericCreationAction.values,
         content: extensionAction.parameters.content,
       },
-      version: this.currentVersion,
     };
   }
 }

--- a/packages/advanced-logic/src/extensions/payment-network/address-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/address-based.ts
@@ -138,7 +138,6 @@ export default abstract class AddressBasedPaymentNetwork<
         paymentAddress,
         refundAddress,
       },
-      version: this.currentVersion,
     };
   }
 
@@ -253,7 +252,7 @@ export default abstract class AddressBasedPaymentNetwork<
 }
 
 export class InvalidPaymentAddressError extends Error {
-  constructor(address?: string, addressReference: string = 'paymentAddress') {
+  constructor(address?: string, addressReference = 'paymentAddress') {
     const formattedAddress = address ? ` '${address}'` : '';
     super(`${addressReference}${formattedAddress} is not a valid address`);
   }
@@ -261,7 +260,7 @@ export class InvalidPaymentAddressError extends Error {
 
 export class UnsupportedNetworkError extends Error {
   constructor(unsupportedNetworkName: string, supportedNetworks?: string[]) {
-    const supportedNetworkDetails = !!supportedNetworks
+    const supportedNetworkDetails = supportedNetworks
       ? ` (only ${supportedNetworks.join(', ')})`
       : '';
     super(

--- a/packages/advanced-logic/src/extensions/payment-network/declarative.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/declarative.ts
@@ -181,7 +181,10 @@ export default class DeclarativePaymentNetwork<
     extensionAction: ExtensionTypes.IAction,
     timestamp: number,
   ): ExtensionTypes.IState {
+    const genericCreationAction = super.applyCreation(extensionAction, timestamp);
+
     return {
+      ...genericCreationAction,
       events: [
         {
           name: 'create',
@@ -194,8 +197,6 @@ export default class DeclarativePaymentNetwork<
           timestamp,
         },
       ],
-      id: extensionAction.id,
-      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
       values: {
         paymentInfo: extensionAction.parameters.paymentInfo,
         receivedPaymentAmount: '0',
@@ -206,7 +207,6 @@ export default class DeclarativePaymentNetwork<
         payeeDelegate: extensionAction.parameters.payeeDelegate,
         payerDelegate: extensionAction.parameters.payerDelegate,
       },
-      version: CURRENT_VERSION,
     };
   }
 

--- a/packages/advanced-logic/src/extensions/payment-network/reference-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/reference-based.ts
@@ -82,13 +82,10 @@ export default abstract class ReferenceBasedPaymentNetwork<
           timestamp,
         },
       ],
-      id: this.extensionId,
-      type: this.extensionType,
       values: {
         ...basicCreationAction.values,
         salt: extensionAction.parameters.salt,
       },
-      version: this.currentVersion,
     };
   }
 }

--- a/packages/advanced-logic/test/extensions/content-data.test.ts
+++ b/packages/advanced-logic/test/extensions/content-data.test.ts
@@ -80,6 +80,29 @@ describe('content-data', () => {
         );
       }).toThrowError('The extension should be created before receiving any other action');
     });
+
+    it('keeps the version used at creation', () => {
+      const newState = contentData.applyActionToExtension(
+        {},
+        { ...TestData.createContentDataExtensionData, version: 'ABCD' },
+        TestData.requestCreatedNoExtension,
+        TestData.otherIdRaw.identity,
+        TestData.arbitraryTimestamp,
+      );
+      expect(newState[contentData.extensionId].version).toBe('ABCD');
+    });
+
+    it('requires a version at creation', () => {
+      expect(() => {
+        contentData.applyActionToExtension(
+          {},
+          { ...TestData.createContentDataExtensionData, version: '' },
+          TestData.requestCreatedNoExtension,
+          TestData.otherIdRaw.identity,
+          TestData.arbitraryTimestamp,
+        );
+      }).toThrowError('version is required at creation');
+    });
   });
 
   describe('createCreationAction', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/any-to-erc20-proxy.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/any-to-erc20-proxy.test.ts
@@ -485,6 +485,28 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
           `refundAddress '${DataConversionERC20FeeAddData.invalidAddress}' is not a valid address`,
         );
       });
+      it('keeps the version used at creation', () => {
+        const newState = anyToErc20Proxy.applyActionToExtension(
+          {},
+          { ...DataConversionERC20FeeCreate.actionCreationFull, version: 'ABCD' },
+          DataConversionERC20FeeCreate.requestStateNoExtensions,
+          TestData.otherIdRaw.identity,
+          TestData.arbitraryTimestamp,
+        );
+        expect(newState[anyToErc20Proxy.extensionId].version).toBe('ABCD');
+      });
+
+      it('requires a version at creation', () => {
+        expect(() => {
+          anyToErc20Proxy.applyActionToExtension(
+            {},
+            { ...DataConversionERC20FeeCreate.actionCreationFull, version: '' },
+            DataConversionERC20FeeCreate.requestStateNoExtensions,
+            TestData.otherIdRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError('version is required at creation');
+      });
     });
 
     describe('applyActionToExtension/addPaymentAddress', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/bitcoin/mainnet-address-based.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/bitcoin/mainnet-address-based.test.ts
@@ -211,6 +211,29 @@ describe('extensions/payment-network/bitcoin/mainnet-address-based', () => {
           `refundAddress '${DataBTCAddPaymentAddress.refundTestnetBTCAddress}' is not a valid address`,
         );
       });
+
+      it('keeps the version used at creation', () => {
+        const newState = mainnetBitcoinAddressBasedPN.applyActionToExtension(
+          {},
+          { ...DataBTCCreate.actionCreationWithPaymentAndRefund, version: 'ABCD' },
+          DataBTCCreate.requestStateNoExtensions,
+          TestData.otherIdRaw.identity,
+          TestData.arbitraryTimestamp,
+        );
+        expect(newState[mainnetBitcoinAddressBasedPN.extensionId].version).toBe('ABCD');
+      });
+
+      it('requires a version at creation', () => {
+        expect(() => {
+          mainnetBitcoinAddressBasedPN.applyActionToExtension(
+            {},
+            { ...DataBTCCreate.actionCreationWithPaymentAndRefund, version: '' },
+            DataBTCCreate.requestStateNoExtensions,
+            TestData.otherIdRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError('version is required at creation');
+      });
     });
 
     describe('applyActionToExtension/addPaymentAddress', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/bitcoin/testnet-address-based.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/bitcoin/testnet-address-based.test.ts
@@ -202,6 +202,29 @@ describe('extensions/payment-network/bitcoin/testnet-address-based', () => {
           `refundAddress '${DataBTCAddPaymentAddress.refundBTCAddress}' is not a valid address`,
         );
       });
+
+      it('keeps the version used at creation', () => {
+        const newState = testnetBitcoinAddressBasedPN.applyActionToExtension(
+          {},
+          { ...DataBTCCreate.actionCreationWithPaymentAndRefund, version: 'ABCD' },
+          DataBTCCreate.requestStateNoExtensions,
+          TestData.otherIdRaw.identity,
+          TestData.arbitraryTimestamp,
+        );
+        expect(newState[testnetBitcoinAddressBasedPN.extensionId].version).toBe('ABCD');
+      });
+
+      it('requires a version at creation', () => {
+        expect(() => {
+          testnetBitcoinAddressBasedPN.applyActionToExtension(
+            {},
+            { ...DataBTCCreate.actionCreationWithPaymentAndRefund, version: '' },
+            DataBTCCreate.requestStateNoExtensions,
+            TestData.otherIdRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError('version is required at creation');
+      });
     });
 
     describe('applyActionToExtension/addPaymentAddress', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/declarative.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/declarative.test.ts
@@ -184,6 +184,29 @@ describe('extensions/payment-network/any/declarative', () => {
       });
     });
 
+    it('keeps the version used at creation', () => {
+      const newState = pnAnyDeclarative.applyActionToExtension(
+        {},
+        { ...TestDataDeclarative.actionCreationWithPaymentAndRefund, version: 'ABCD' },
+        TestDataDeclarative.requestStateNoExtensions,
+        TestData.otherIdRaw.identity,
+        TestData.arbitraryTimestamp,
+      );
+      expect(newState[pnAnyDeclarative.extensionId].version).toBe('ABCD');
+    });
+
+    it('requires a version at creation', () => {
+      expect(() => {
+        pnAnyDeclarative.applyActionToExtension(
+          {},
+          { ...TestDataDeclarative.actionCreationWithPaymentAndRefund, version: '' },
+          TestDataDeclarative.requestStateNoExtensions,
+          TestData.otherIdRaw.identity,
+          TestData.arbitraryTimestamp,
+        );
+      }).toThrowError('version is required at creation');
+    });
+
     describe('applyActionToExtension/addPaymentInstruction', () => {
       it('can applyActionToExtensions of addPaymentInstruction', () => {
         // 'new extension state wrong'

--- a/packages/advanced-logic/test/extensions/payment-network/erc20/address-based.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/erc20/address-based.test.ts
@@ -214,6 +214,29 @@ describe('extensions/payment-network/erc20/mainnet-address-based', () => {
           `refundAddress '${DataERC20AddPaymentAddress.invalidAddress}' is not a valid address`,
         );
       });
+
+      it('keeps the version used at creation', () => {
+        const newState = erc20AddressBasedPaymentNetwork.applyActionToExtension(
+          {},
+          { ...DataERC20Create.actionCreationWithPaymentAndRefund, version: 'ABCD' },
+          DataERC20Create.requestStateNoExtensions,
+          TestData.otherIdRaw.identity,
+          TestData.arbitraryTimestamp,
+        );
+        expect(newState[erc20AddressBasedPaymentNetwork.extensionId].version).toBe('ABCD');
+      });
+
+      it('requires a version at creation', () => {
+        expect(() => {
+          erc20AddressBasedPaymentNetwork.applyActionToExtension(
+            {},
+            { ...DataERC20Create.actionCreationWithPaymentAndRefund, version: '' },
+            DataERC20Create.requestStateNoExtensions,
+            TestData.otherIdRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError('version is required at creation');
+      });
     });
 
     describe('applyActionToExtension/addPaymentAddress', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/erc20/fee-proxy-contract.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/erc20/fee-proxy-contract.test.ts
@@ -321,6 +321,29 @@ describe('extensions/payment-network/erc20/fee-proxy-contract', () => {
           `refundAddress '${DataERC20FeeAddData.invalidAddress}' is not a valid address`,
         );
       });
+
+      it('keeps the version used at creation', () => {
+        const newState = erc20FeeProxyContract.applyActionToExtension(
+          {},
+          { ...DataERC20FeeCreate.actionCreationFull, version: 'ABCD' },
+          DataERC20FeeCreate.requestStateNoExtensions,
+          TestData.otherIdRaw.identity,
+          TestData.arbitraryTimestamp,
+        );
+        expect(newState[erc20FeeProxyContract.extensionId].version).toBe('ABCD');
+      });
+
+      it('requires a version at creation', () => {
+        expect(() => {
+          erc20FeeProxyContract.applyActionToExtension(
+            {},
+            { ...DataERC20FeeCreate.actionCreationFull, version: '' },
+            DataERC20FeeCreate.requestStateNoExtensions,
+            TestData.otherIdRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError('version is required at creation');
+      });
     });
 
     describe('applyActionToExtension/addPaymentAddress', () => {
@@ -494,105 +517,105 @@ describe('extensions/payment-network/erc20/fee-proxy-contract', () => {
         }).toThrowError('refundAddress is not a valid address');
       });
     });
-  });
 
-  describe('applyActionToExtension/addFee', () => {
-    it('can applyActionToExtensions of addFee', () => {
-      // 'new extension state wrong'
-      expect(
-        erc20FeeProxyContract.applyActionToExtension(
-          DataERC20FeeCreate.requestStateCreatedEmpty.extensions,
-          DataERC20FeeAddData.actionAddFee,
-          DataERC20FeeCreate.requestStateCreatedEmpty,
-          TestData.payeeRaw.identity,
-          TestData.arbitraryTimestamp,
-        ),
-      ).toEqual(DataERC20FeeAddData.extensionStateWithFeeAfterCreation);
-    });
+    describe('applyActionToExtension/addFee', () => {
+      it('can applyActionToExtensions of addFee', () => {
+        // 'new extension state wrong'
+        expect(
+          erc20FeeProxyContract.applyActionToExtension(
+            DataERC20FeeCreate.requestStateCreatedEmpty.extensions,
+            DataERC20FeeAddData.actionAddFee,
+            DataERC20FeeCreate.requestStateCreatedEmpty,
+            TestData.payeeRaw.identity,
+            TestData.arbitraryTimestamp,
+          ),
+        ).toEqual(DataERC20FeeAddData.extensionStateWithFeeAfterCreation);
+      });
 
-    it('cannot applyActionToExtensions of addFee without a previous state', () => {
-      // 'must throw'
-      expect(() => {
-        erc20FeeProxyContract.applyActionToExtension(
-          DataERC20FeeCreate.requestStateNoExtensions.extensions,
-          DataERC20FeeAddData.actionAddFee,
-          DataERC20FeeCreate.requestStateNoExtensions,
-          TestData.payeeRaw.identity,
-          TestData.arbitraryTimestamp,
-        );
-      }).toThrowError(`The extension should be created before receiving any other action`);
-    });
+      it('cannot applyActionToExtensions of addFee without a previous state', () => {
+        // 'must throw'
+        expect(() => {
+          erc20FeeProxyContract.applyActionToExtension(
+            DataERC20FeeCreate.requestStateNoExtensions.extensions,
+            DataERC20FeeAddData.actionAddFee,
+            DataERC20FeeCreate.requestStateNoExtensions,
+            TestData.payeeRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError(`The extension should be created before receiving any other action`);
+      });
 
-    it('cannot applyActionToExtensions of addFee without a payee', () => {
-      const previousState = Utils.deepCopy(DataERC20FeeCreate.requestStateCreatedEmpty);
-      previousState.payee = undefined;
-      // 'must throw'
-      expect(() => {
-        erc20FeeProxyContract.applyActionToExtension(
-          previousState.extensions,
-          DataERC20FeeAddData.actionAddFee,
-          previousState,
-          TestData.payeeRaw.identity,
-          TestData.arbitraryTimestamp,
-        );
-      }).toThrowError(`The request must have a payee`);
-    });
+      it('cannot applyActionToExtensions of addFee without a payee', () => {
+        const previousState = Utils.deepCopy(DataERC20FeeCreate.requestStateCreatedEmpty);
+        previousState.payee = undefined;
+        // 'must throw'
+        expect(() => {
+          erc20FeeProxyContract.applyActionToExtension(
+            previousState.extensions,
+            DataERC20FeeAddData.actionAddFee,
+            previousState,
+            TestData.payeeRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError(`The request must have a payee`);
+      });
 
-    it('cannot applyActionToExtensions of addFee signed by someone else than the payee', () => {
-      const previousState = Utils.deepCopy(DataERC20FeeCreate.requestStateCreatedEmpty);
-      // 'must throw'
-      expect(() => {
-        erc20FeeProxyContract.applyActionToExtension(
-          previousState.extensions,
-          DataERC20FeeAddData.actionAddFee,
-          previousState,
-          TestData.payerRaw.identity,
-          TestData.arbitraryTimestamp,
-        );
-      }).toThrowError(`The signer must be the payee`);
-    });
+      it('cannot applyActionToExtensions of addFee signed by someone else than the payee', () => {
+        const previousState = Utils.deepCopy(DataERC20FeeCreate.requestStateCreatedEmpty);
+        // 'must throw'
+        expect(() => {
+          erc20FeeProxyContract.applyActionToExtension(
+            previousState.extensions,
+            DataERC20FeeAddData.actionAddFee,
+            previousState,
+            TestData.payerRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError(`The signer must be the payee`);
+      });
 
-    it('cannot applyActionToExtensions of addFee with fee data already given', () => {
-      // 'must throw'
-      expect(() => {
-        erc20FeeProxyContract.applyActionToExtension(
-          DataERC20FeeCreate.requestFullStateCreated.extensions,
-          DataERC20FeeAddData.actionAddFee,
-          DataERC20FeeCreate.requestFullStateCreated,
-          TestData.payeeRaw.identity,
-          TestData.arbitraryTimestamp,
-        );
-      }).toThrowError(`Fee address already given`);
-    });
+      it('cannot applyActionToExtensions of addFee with fee data already given', () => {
+        // 'must throw'
+        expect(() => {
+          erc20FeeProxyContract.applyActionToExtension(
+            DataERC20FeeCreate.requestFullStateCreated.extensions,
+            DataERC20FeeAddData.actionAddFee,
+            DataERC20FeeCreate.requestFullStateCreated,
+            TestData.payeeRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError(`Fee address already given`);
+      });
 
-    it('cannot applyActionToExtensions of addFee with fee address not valid', () => {
-      const testnetPaymentAddress = Utils.deepCopy(DataERC20FeeAddData.actionAddFee);
-      testnetPaymentAddress.parameters.feeAddress = DataERC20FeeAddData.invalidAddress;
-      // 'must throw'
-      expect(() => {
-        erc20FeeProxyContract.applyActionToExtension(
-          DataERC20FeeCreate.requestStateCreatedEmpty.extensions,
-          testnetPaymentAddress,
-          DataERC20FeeCreate.requestStateCreatedEmpty,
-          TestData.payerRaw.identity,
-          TestData.arbitraryTimestamp,
-        );
-      }).toThrowError('feeAddress is not a valid address');
-    });
+      it('cannot applyActionToExtensions of addFee with fee address not valid', () => {
+        const testnetPaymentAddress = Utils.deepCopy(DataERC20FeeAddData.actionAddFee);
+        testnetPaymentAddress.parameters.feeAddress = DataERC20FeeAddData.invalidAddress;
+        // 'must throw'
+        expect(() => {
+          erc20FeeProxyContract.applyActionToExtension(
+            DataERC20FeeCreate.requestStateCreatedEmpty.extensions,
+            testnetPaymentAddress,
+            DataERC20FeeCreate.requestStateCreatedEmpty,
+            TestData.payerRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError('feeAddress is not a valid address');
+      });
 
-    it('cannot applyActionToExtensions of addFee with fee amount not valid', () => {
-      const testnetPaymentAddress = Utils.deepCopy(DataERC20FeeAddData.actionAddFee);
-      testnetPaymentAddress.parameters.feeAmount = DataERC20FeeAddData.invalidAddress;
-      // 'must throw'
-      expect(() => {
-        erc20FeeProxyContract.applyActionToExtension(
-          DataERC20FeeCreate.requestStateCreatedEmpty.extensions,
-          testnetPaymentAddress,
-          DataERC20FeeCreate.requestStateCreatedEmpty,
-          TestData.payerRaw.identity,
-          TestData.arbitraryTimestamp,
-        );
-      }).toThrowError('feeAmount is not a valid amount');
+      it('cannot applyActionToExtensions of addFee with fee amount not valid', () => {
+        const testnetPaymentAddress = Utils.deepCopy(DataERC20FeeAddData.actionAddFee);
+        testnetPaymentAddress.parameters.feeAmount = DataERC20FeeAddData.invalidAddress;
+        // 'must throw'
+        expect(() => {
+          erc20FeeProxyContract.applyActionToExtension(
+            DataERC20FeeCreate.requestStateCreatedEmpty.extensions,
+            testnetPaymentAddress,
+            DataERC20FeeCreate.requestStateCreatedEmpty,
+            TestData.payerRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError('feeAmount is not a valid amount');
+      });
     });
   });
 });

--- a/packages/advanced-logic/test/extensions/payment-network/erc20/proxy-contract.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/erc20/proxy-contract.test.ts
@@ -239,6 +239,29 @@ describe('extensions/payment-network/erc20/proxy-contract', () => {
           `refundAddress '${DataERC20AddPaymentAddress.invalidAddress}' is not a valid address`,
         );
       });
+
+      it('keeps the version used at creation', () => {
+        const newState = erc20ProxyContract.applyActionToExtension(
+          {},
+          { ...DataERC20Create.actionCreationWithPaymentAndRefund, version: 'ABCD' },
+          DataERC20Create.requestStateNoExtensions,
+          TestData.otherIdRaw.identity,
+          TestData.arbitraryTimestamp,
+        );
+        expect(newState[erc20ProxyContract.extensionId].version).toBe('ABCD');
+      });
+
+      it('requires a version at creation', () => {
+        expect(() => {
+          erc20ProxyContract.applyActionToExtension(
+            {},
+            { ...DataERC20Create.actionCreationWithPaymentAndRefund, version: '' },
+            DataERC20Create.requestStateNoExtensions,
+            TestData.otherIdRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError('version is required at creation');
+      });
     });
 
     describe('applyActionToExtension/addPaymentAddress', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/ethereum/fee-proxy-contract.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/ethereum/fee-proxy-contract.test.ts
@@ -321,6 +321,29 @@ describe('extensions/payment-network/ethereum/fee-proxy-contract', () => {
           `refundAddress '${DataEthFeeAddData.invalidAddress}' is not a valid address`,
         );
       });
+
+      it('keeps the version used at creation', () => {
+        const newState = ethFeeProxyContract.applyActionToExtension(
+          {},
+          { ...DataEthFeeCreate.actionCreationFull, version: 'ABCD' },
+          DataEthFeeCreate.requestStateNoExtensions,
+          TestData.otherIdRaw.identity,
+          TestData.arbitraryTimestamp,
+        );
+        expect(newState[ethFeeProxyContract.extensionId].version).toBe('ABCD');
+      });
+
+      it('requires a version at creation', () => {
+        expect(() => {
+          ethFeeProxyContract.applyActionToExtension(
+            {},
+            { ...DataEthFeeCreate.actionCreationFull, version: '' },
+            DataEthFeeCreate.requestStateNoExtensions,
+            TestData.otherIdRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError('version is required at creation');
+      });
     });
 
     describe('applyActionToExtension/addPaymentAddress', () => {
@@ -494,105 +517,105 @@ describe('extensions/payment-network/ethereum/fee-proxy-contract', () => {
         }).toThrowError('refundAddress is not a valid address');
       });
     });
-  });
 
-  describe('applyActionToExtension/addFee', () => {
-    it('can applyActionToExtensions of addFee', () => {
-      // 'new extension state wrong'
-      expect(
-        ethFeeProxyContract.applyActionToExtension(
-          DataEthFeeCreate.requestStateCreatedEmpty.extensions,
-          DataEthFeeAddData.actionAddFee,
-          DataEthFeeCreate.requestStateCreatedEmpty,
-          TestData.payeeRaw.identity,
-          TestData.arbitraryTimestamp,
-        ),
-      ).toEqual(DataEthFeeAddData.extensionStateWithFeeAfterCreation);
-    });
+    describe('applyActionToExtension/addFee', () => {
+      it('can applyActionToExtensions of addFee', () => {
+        // 'new extension state wrong'
+        expect(
+          ethFeeProxyContract.applyActionToExtension(
+            DataEthFeeCreate.requestStateCreatedEmpty.extensions,
+            DataEthFeeAddData.actionAddFee,
+            DataEthFeeCreate.requestStateCreatedEmpty,
+            TestData.payeeRaw.identity,
+            TestData.arbitraryTimestamp,
+          ),
+        ).toEqual(DataEthFeeAddData.extensionStateWithFeeAfterCreation);
+      });
 
-    it('cannot applyActionToExtensions of addFee without a previous state', () => {
-      // 'must throw'
-      expect(() => {
-        ethFeeProxyContract.applyActionToExtension(
-          DataEthFeeCreate.requestStateNoExtensions.extensions,
-          DataEthFeeAddData.actionAddFee,
-          DataEthFeeCreate.requestStateNoExtensions,
-          TestData.payeeRaw.identity,
-          TestData.arbitraryTimestamp,
-        );
-      }).toThrowError(`The extension should be created before receiving any other action`);
-    });
+      it('cannot applyActionToExtensions of addFee without a previous state', () => {
+        // 'must throw'
+        expect(() => {
+          ethFeeProxyContract.applyActionToExtension(
+            DataEthFeeCreate.requestStateNoExtensions.extensions,
+            DataEthFeeAddData.actionAddFee,
+            DataEthFeeCreate.requestStateNoExtensions,
+            TestData.payeeRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError(`The extension should be created before receiving any other action`);
+      });
 
-    it('cannot applyActionToExtensions of addFee without a payee', () => {
-      const previousState = Utils.deepCopy(DataEthFeeCreate.requestStateCreatedEmpty);
-      previousState.payee = undefined;
-      // 'must throw'
-      expect(() => {
-        ethFeeProxyContract.applyActionToExtension(
-          previousState.extensions,
-          DataEthFeeAddData.actionAddFee,
-          previousState,
-          TestData.payeeRaw.identity,
-          TestData.arbitraryTimestamp,
-        );
-      }).toThrowError(`The request must have a payee`);
-    });
+      it('cannot applyActionToExtensions of addFee without a payee', () => {
+        const previousState = Utils.deepCopy(DataEthFeeCreate.requestStateCreatedEmpty);
+        previousState.payee = undefined;
+        // 'must throw'
+        expect(() => {
+          ethFeeProxyContract.applyActionToExtension(
+            previousState.extensions,
+            DataEthFeeAddData.actionAddFee,
+            previousState,
+            TestData.payeeRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError(`The request must have a payee`);
+      });
 
-    it('cannot applyActionToExtensions of addFee signed by someone else than the payee', () => {
-      const previousState = Utils.deepCopy(DataEthFeeCreate.requestStateCreatedEmpty);
-      // 'must throw'
-      expect(() => {
-        ethFeeProxyContract.applyActionToExtension(
-          previousState.extensions,
-          DataEthFeeAddData.actionAddFee,
-          previousState,
-          TestData.payerRaw.identity,
-          TestData.arbitraryTimestamp,
-        );
-      }).toThrowError(`The signer must be the payee`);
-    });
+      it('cannot applyActionToExtensions of addFee signed by someone else than the payee', () => {
+        const previousState = Utils.deepCopy(DataEthFeeCreate.requestStateCreatedEmpty);
+        // 'must throw'
+        expect(() => {
+          ethFeeProxyContract.applyActionToExtension(
+            previousState.extensions,
+            DataEthFeeAddData.actionAddFee,
+            previousState,
+            TestData.payerRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError(`The signer must be the payee`);
+      });
 
-    it('cannot applyActionToExtensions of addFee with fee data already given', () => {
-      // 'must throw'
-      expect(() => {
-        ethFeeProxyContract.applyActionToExtension(
-          DataEthFeeCreate.requestFullStateCreated.extensions,
-          DataEthFeeAddData.actionAddFee,
-          DataEthFeeCreate.requestFullStateCreated,
-          TestData.payeeRaw.identity,
-          TestData.arbitraryTimestamp,
-        );
-      }).toThrowError(`Fee address already given`);
-    });
+      it('cannot applyActionToExtensions of addFee with fee data already given', () => {
+        // 'must throw'
+        expect(() => {
+          ethFeeProxyContract.applyActionToExtension(
+            DataEthFeeCreate.requestFullStateCreated.extensions,
+            DataEthFeeAddData.actionAddFee,
+            DataEthFeeCreate.requestFullStateCreated,
+            TestData.payeeRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError(`Fee address already given`);
+      });
 
-    it('cannot applyActionToExtensions of addFee with fee address not valid', () => {
-      const testnetPaymentAddress = Utils.deepCopy(DataEthFeeAddData.actionAddFee);
-      testnetPaymentAddress.parameters.feeAddress = DataEthFeeAddData.invalidAddress;
-      // 'must throw'
-      expect(() => {
-        ethFeeProxyContract.applyActionToExtension(
-          DataEthFeeCreate.requestStateCreatedEmpty.extensions,
-          testnetPaymentAddress,
-          DataEthFeeCreate.requestStateCreatedEmpty,
-          TestData.payerRaw.identity,
-          TestData.arbitraryTimestamp,
-        );
-      }).toThrowError('feeAddress is not a valid address');
-    });
+      it('cannot applyActionToExtensions of addFee with fee address not valid', () => {
+        const testnetPaymentAddress = Utils.deepCopy(DataEthFeeAddData.actionAddFee);
+        testnetPaymentAddress.parameters.feeAddress = DataEthFeeAddData.invalidAddress;
+        // 'must throw'
+        expect(() => {
+          ethFeeProxyContract.applyActionToExtension(
+            DataEthFeeCreate.requestStateCreatedEmpty.extensions,
+            testnetPaymentAddress,
+            DataEthFeeCreate.requestStateCreatedEmpty,
+            TestData.payerRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError('feeAddress is not a valid address');
+      });
 
-    it('cannot applyActionToExtensions of addFee with fee amount not valid', () => {
-      const testnetPaymentAddress = Utils.deepCopy(DataEthFeeAddData.actionAddFee);
-      testnetPaymentAddress.parameters.feeAmount = DataEthFeeAddData.invalidAddress;
-      // 'must throw'
-      expect(() => {
-        ethFeeProxyContract.applyActionToExtension(
-          DataEthFeeCreate.requestStateCreatedEmpty.extensions,
-          testnetPaymentAddress,
-          DataEthFeeCreate.requestStateCreatedEmpty,
-          TestData.payerRaw.identity,
-          TestData.arbitraryTimestamp,
-        );
-      }).toThrowError('feeAmount is not a valid amount');
+      it('cannot applyActionToExtensions of addFee with fee amount not valid', () => {
+        const testnetPaymentAddress = Utils.deepCopy(DataEthFeeAddData.actionAddFee);
+        testnetPaymentAddress.parameters.feeAmount = DataEthFeeAddData.invalidAddress;
+        // 'must throw'
+        expect(() => {
+          ethFeeProxyContract.applyActionToExtension(
+            DataEthFeeCreate.requestStateCreatedEmpty.extensions,
+            testnetPaymentAddress,
+            DataEthFeeCreate.requestStateCreatedEmpty,
+            TestData.payerRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError('feeAmount is not a valid amount');
+      });
     });
   });
 });

--- a/packages/advanced-logic/test/extensions/payment-network/ethereum/input-data.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/ethereum/input-data.test.ts
@@ -239,6 +239,29 @@ describe('extensions/payment-network/ethereum/input-data', () => {
           `refundAddress '${DataEthAddPaymentAddress.invalidAddress}' is not a valid address`,
         );
       });
+
+      it('keeps the version used at creation', () => {
+        const newState = ethereumInputDataPaymentNetwork.applyActionToExtension(
+          {},
+          { ...DataEthCreate.actionCreationWithPaymentAndRefund, version: 'ABCD' },
+          DataEthCreate.requestStateNoExtensions,
+          TestData.otherIdRaw.identity,
+          TestData.arbitraryTimestamp,
+        );
+        expect(newState[ethereumInputDataPaymentNetwork.extensionId].version).toBe('ABCD');
+      });
+
+      it('requires a version at creation', () => {
+        expect(() => {
+          ethereumInputDataPaymentNetwork.applyActionToExtension(
+            {},
+            { ...DataEthCreate.actionCreationWithPaymentAndRefund, version: '' },
+            DataEthCreate.requestStateNoExtensions,
+            TestData.otherIdRaw.identity,
+            TestData.arbitraryTimestamp,
+          );
+        }).toThrowError('version is required at creation');
+      });
     });
 
     describe('applyActionToExtension/addPaymentAddress', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
@@ -398,5 +398,38 @@ describe('extensions/payment-network/native-token', () => {
         `Cannot apply action for network ${mainnetTestCase.wrongCurrency.network} on state with payment network: ${mainnetTestCase.currency.network}`,
       );
     });
+
+    it('keeps the version used at creation', () => {
+      const advancedLogic = new AdvancedLogic();
+      const requestState = {
+        ...requestStateNoExtensions,
+        currency: mainnetTestCase.currency,
+      };
+      const newState = advancedLogic.applyActionToExtensions(
+        {},
+        { ...actionCreationWithNativeTokenPayment, version: 'ABCD' },
+        requestState,
+        payeeRaw.identity,
+        arbitraryTimestamp,
+      );
+      expect(newState[mainnetTestCase.paymentNetwork.extensionId].version).toBe('ABCD');
+    });
+
+    it('requires a version at creation', () => {
+      expect(() => {
+        const advancedLogic = new AdvancedLogic();
+        const requestState = {
+          ...requestStateNoExtensions,
+          currency: mainnetTestCase.currency,
+        };
+        advancedLogic.applyActionToExtensions(
+          {},
+          { ...actionCreationWithNativeTokenPayment, version: '' },
+          requestState,
+          payeeRaw.identity,
+          arbitraryTimestamp,
+        );
+      }).toThrowError('version is required at creation');
+    });
   });
 });

--- a/packages/advanced-logic/test/utils/payment-network/erc20/fee-proxy-contract-create-data-generator.ts
+++ b/packages/advanced-logic/test/utils/payment-network/erc20/fee-proxy-contract-create-data-generator.ts
@@ -84,7 +84,7 @@ export const extensionFullState = {
       refundAddress,
       salt,
     },
-    version: '0.2.0',
+    version: '0.1.0',
   },
 };
 export const extensionStateCreatedEmpty = {


### PR DESCRIPTION

⚠️  Please review carefully and challenge that the bug is indeed a bug!


## Context
The Payment Processor should use the contract matching the version of the PN.

## Previous issues
A bug fix in Payment Processor was done earlier https://github.com/RequestNetwork/requestNetwork/pull/556

## Description of the bug
This new bug, not related to the previous, is that the extension version is not based on the stored data, but defaults to the `CURRENT_VERSION` of the extension. 


## Description of the changes
- rely on the abstract extension for `id`, `type` and `version`
- throw if there was no `version` at creation
- tests: test each payment network individually, since regression could have important impacts
