### PR TITLE
fix: remove -rinkeby from symbol

### DIFF
--- a/packages/currency/src/native.ts
+++ b/packages/currency/src/native.ts
@@ -9,7 +9,7 @@ export const nativeCurrencies = {
       network: 'mainnet',
     },
     {
-      symbol: 'ETH-rinkeby',
+      symbol: 'ETH',
       decimals: 18,
       name: 'Rinkeby Ether',
       network: 'rinkeby',


### PR DESCRIPTION
## Description of the changes
having `-network` in the symbol name cause the `id` to have extra network suffix when calling `CurrencyManager`'s `.from()` method.
It was returning `ETH-rinkeby-rinkeby` for the `id`