### PR TITLE
feat: yarn link:all

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "publish-prerelease": "yarn lerna publish --preid development --skip-git --yes --canary",
     "test": "lerna run test",
     "format": "prettier packages/**/src/**/*.ts -w",
-    "format:check": "prettier packages/**/src/**/*.ts -c"
+    "format:check": "prettier packages/**/src/**/*.ts -c",
+    "link:all": "for d in packages/*; do pushd $d; yarn link; popd; done"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "4.18.0",


### PR DESCRIPTION
## Description of the changes

Adds a new yarn command to make all `requestNetwork` packages available as symlinks in  `~/.config/yarn/link/@requestnetwork/` in order to be able to work with them dynamically in external projects.