### PR TITLE
Specs/declare payment revision

### DIFF
--- a/packages/advanced-logic/specs/payment-network-any-to-erc20-proxy-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-any-to-erc20-proxy-0.1.0.md
@@ -292,7 +292,7 @@ the 'addFee' event:
 | **id**                | String | Constant value: "pn-any-to-erc20-proxy"              | **Mandatory** |
 | **action**            | String | Constant value: "declareReceivedPayment"             | **Mandatory** |
 | **parameters**        | Object |                                                      |               |
-| **parameters.amount** | String | The amount declared as received, in request currency | **Mandatory** |
+| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
 | **parameters.note**   | String | Additional information about the payment             | Optional      |
 | **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
 
@@ -328,7 +328,7 @@ An event is added to the extension state events array:
 | **id**                | String | Constant value: "pn-any-to-erc20-proxy"              | **Mandatory** |
 | **action**            | String | Constant value: "declareReceivedRefund"              | **Mandatory** |
 | **parameters**        | Object |                                                      |               |
-| **parameters.amount** | String | The amount declared as received, in request currency | **Mandatory** |
+| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
 | **parameters.note**   | String | Additional information about the payment             | Optional      |
 | **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
 

--- a/packages/advanced-logic/specs/payment-network-erc20-fee-proxy-contract-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-erc20-fee-proxy-contract-0.1.0.md
@@ -267,7 +267,7 @@ the 'addFee' event:
 | **id**                | String | Constant value: "pn-erc20-fee-proxy-contract"        | **Mandatory** |
 | **action**            | String | Constant value: "declareReceivedPayment"             | **Mandatory** |
 | **parameters**        | Object |                                                      |               |
-| **parameters.amount** | String | The amount declared as received, in request currency | **Mandatory** |
+| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
 | **parameters.note**   | String | Additional information about the payment             | Optional      |
 | **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
 
@@ -303,7 +303,7 @@ An event is added to the extension state events array:
 | **id**                | String | Constant value: "pn-erc20-fee-proxy-contract"        | **Mandatory** |
 | **action**            | String | Constant value: "declareReceivedRefund"              | **Mandatory** |
 | **parameters**        | Object |                                                      |               |
-| **parameters.amount** | String | The amount declared as received, in request currency | **Mandatory** |
+| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
 | **parameters.note**   | String | Additional information about the payment             | Optional      |
 | **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
 

--- a/packages/advanced-logic/specs/payment-network-eth-fee-proxy-contract-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-eth-fee-proxy-contract-0.1.0.md
@@ -260,7 +260,7 @@ the 'addFee' event:
 | **id**                | String | Constant value: "pn-eth-fee-proxy-contract"          | **Mandatory** |
 | **action**            | String | Constant value: "declareReceivedPayment"             | **Mandatory** |
 | **parameters**        | Object |                                                      |               |
-| **parameters.amount** | String | The amount declared as received, in request currency | **Mandatory** |
+| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
 | **parameters.note**   | String | Additional information about the payment             | Optional      |
 | **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
 
@@ -296,7 +296,7 @@ An event is added to the extension state events array:
 | **id**                | String | Constant value: "pn-eth-fee-proxy-contract"          | **Mandatory** |
 | **action**            | String | Constant value: "declareReceivedRefund"              | **Mandatory** |
 | **parameters**        | Object |                                                      |               |
-| **parameters.amount** | String | The amount declared as received, in request currency | **Mandatory** |
+| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
 | **parameters.note**   | String | Additional information about the payment             | Optional      |
 | **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
 

--- a/packages/advanced-logic/specs/payment-network-eth-input-data-0.2.0.md
+++ b/packages/advanced-logic/specs/payment-network-eth-input-data-0.2.0.md
@@ -207,7 +207,7 @@ The 'addRefundAddress' event:
 | **id**                | String | Constant value: "pn-eth-input-data"                  | **Mandatory** |
 | **action**            | String | Constant value: "declareReceivedPayment"             | **Mandatory** |
 | **parameters**        | Object |                                                      |               |
-| **parameters.amount** | String | The amount declared as received, in request currency | **Mandatory** |
+| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
 | **parameters.note**   | String | Additional information about the payment             | Optional      |
 | **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
 
@@ -243,7 +243,7 @@ An event is added to the extension state events array:
 | **id**                | String | Constant value: "pn-eth-input-data"                  | **Mandatory** |
 | **action**            | String | Constant value: "declareReceivedRefund"              | **Mandatory** |
 | **parameters**        | Object |                                                      |               |
-| **parameters.amount** | String | The amount declared as received, in request currency | **Mandatory** |
+| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
 | **parameters.note**   | String | Additional information about the payment             | Optional      |
 | **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
 


### PR DESCRIPTION
## Description of the changes
Add some revisions related to the declare payment spec as now declaring payment or refund are done through the Declarative payment network class (PR #620)