### PR TITLE
feat: add txhash in request-client.js

### DIFF
--- a/packages/request-client.js/src/api/request.ts
+++ b/packages/request-client.js/src/api/request.ts
@@ -554,12 +554,14 @@ export default class Request {
    * @param amount Amount received
    * @param note Note from payee about the received payment
    * @param signerIdentity Identity of the signer. The identity type must be supported by the signature provider.
+   * @param txHash transaction hash
    * @returns The updated request
    */
   public async declareReceivedPayment(
     amount: RequestLogicTypes.Amount,
     note: string,
     signerIdentity: IdentityTypes.IIdentity,
+    txHash?: string,
   ): Promise<Types.IRequestDataWithEvents> {
     const extensionsData: any[] = [];
 
@@ -579,6 +581,7 @@ export default class Request {
       declarativePaymentNetwork.createExtensionsDataForDeclareReceivedPayment({
         amount,
         note,
+        txHash,
       }),
     );
 
@@ -616,12 +619,14 @@ export default class Request {
    * @param amount Amount received
    * @param note Note from payer about the received refund
    * @param signerIdentity Identity of the signer. The identity type must be supported by the signature provider.
+   * @param txHash transaction hash
    * @returns The updated request
    */
   public async declareReceivedRefund(
     amount: RequestLogicTypes.Amount,
     note: string,
     signerIdentity: IdentityTypes.IIdentity,
+    txHash?: string,
   ): Promise<Types.IRequestDataWithEvents> {
     const extensionsData: any[] = [];
 
@@ -641,6 +646,7 @@ export default class Request {
       declarativePaymentNetwork.createExtensionsDataForDeclareReceivedRefund({
         amount,
         note,
+        txHash,
       }),
     );
 

--- a/packages/request-client.js/test/index.test.ts
+++ b/packages/request-client.js/test/index.test.ts
@@ -853,6 +853,29 @@ describe('index', () => {
       expect(requestData.balance!.balance).toEqual('10');
     });
 
+    it('allows to declare a received payment by providing transaction hash', async () => {
+      const requestNetwork = new RequestNetwork({ signatureProvider: fakeSignatureProvider });
+
+      const paymentNetwork: PaymentTypes.IPaymentNetworkCreateParameters = {
+        id: PaymentTypes.PAYMENT_NETWORK_ID.DECLARATIVE,
+        parameters: {},
+      };
+
+      const request = await requestNetwork.createRequest({
+        paymentNetwork,
+        requestInfo: TestData.parametersWithoutExtensionsData,
+        signer: payeeIdentity,
+      });
+      await request.waitForConfirmation();
+
+      mock.resetHistory();
+
+      await request.declareReceivedPayment('10', 'received payment', payeeIdentity, '0x123456789');
+
+      expect(mock.history.get).toHaveLength(4);
+      expect(mock.history.post).toHaveLength(1);
+    });
+
     it('allows to declare a sent refund', async () => {
       const requestNetwork = new RequestNetwork({ signatureProvider: fakeSignatureProvider });
 
@@ -923,6 +946,29 @@ describe('index', () => {
       requestData = await request.declareReceivedRefund('11', 'received refund', delegateIdentity);
       requestData = await new Promise((resolve): any => requestData.on('confirmed', resolve));
       expect(requestData.balance!.balance).toEqual('-11');
+    });
+
+    it('allows to declare a received refund by providing transaction hash', async () => {
+      const requestNetwork = new RequestNetwork({ signatureProvider: fakeSignatureProvider });
+
+      const paymentNetwork: PaymentTypes.IPaymentNetworkCreateParameters = {
+        id: PaymentTypes.PAYMENT_NETWORK_ID.DECLARATIVE,
+        parameters: {},
+      };
+
+      const request = await requestNetwork.createRequest({
+        paymentNetwork,
+        requestInfo: TestData.parametersWithoutExtensionsData,
+        signer: payeeIdentity,
+      });
+      await request.waitForConfirmation();
+
+      mock.resetHistory();
+
+      await request.declareReceivedRefund('10', 'received refund', payerIdentity, '0x123456789');
+
+      expect(mock.history.get).toHaveLength(4);
+      expect(mock.history.post).toHaveLength(1);
     });
 
     it('allows to get the right balance', async () => {


### PR DESCRIPTION
## Description of the changes
Adding `txHash` in `request-client.js` to allow user adding their transaction hash for `declareReceivedPayment` and `declareReceivedRefund` action. This new parameters has been introduced earlier in the `advance-logic` package in this PR #620 