### PR TITLE
chore: add txHash in create*Action argument

### DIFF
--- a/packages/payment-detection/src/declarative.ts
+++ b/packages/payment-detection/src/declarative.ts
@@ -75,6 +75,7 @@ export default class PaymentNetworkDeclarative
     return this.extension.createDeclareSentPaymentAction({
       amount: parameters.amount,
       note: parameters.note,
+      txHash: parameters.txHash,
     });
   }
 
@@ -90,6 +91,7 @@ export default class PaymentNetworkDeclarative
     return this.extension.createDeclareSentRefundAction({
       amount: parameters.amount,
       note: parameters.note,
+      txHash: parameters.txHash,
     });
   }
 
@@ -105,6 +107,7 @@ export default class PaymentNetworkDeclarative
     return this.extension.createDeclareReceivedPaymentAction({
       amount: parameters.amount,
       note: parameters.note,
+      txHash: parameters.txHash,
     });
   }
 
@@ -120,6 +123,7 @@ export default class PaymentNetworkDeclarative
     return this.extension.createDeclareReceivedRefundAction({
       amount: parameters.amount,
       note: parameters.note,
+      txHash: parameters.txHash,
     });
   }
 


### PR DESCRIPTION
## Description of the changes
Need to include `txHash` to `create*Action` argument

Question for @vrolland or @yomarion:
Why we don't just add the `parameters` directly to the `create*Action` argument directly as it's the same type?