### PR TITLE
fix(http-data-access): do not throw in setTimeout

### DIFF
--- a/packages/request-client.js/src/http-data-access.ts
+++ b/packages/request-client.js/src/http-data-access.ts
@@ -115,13 +115,13 @@ export default class HttpDataAccess implements DataAccessTypes.IDataAccess {
         result.emit('confirmed', confirmedData);
       })
       .catch((e) => {
+        let error: Error = e;
         if (e.response.status === 404) {
-          throw new Error(
+          error = new Error(
             `Transaction confirmation not receive after ${this.httpConfig.getConfirmationMaxRetry} retries`,
           );
-        } else {
-          throw new Error(e.message);
         }
+        result.emit('error', error);
       });
 
     return result;

--- a/packages/request-client.js/test/http-data-access.test.ts
+++ b/packages/request-client.js/test/http-data-access.test.ts
@@ -1,0 +1,37 @@
+import HttpDataAccess from '../src/http-data-access';
+import AxiosMockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+let mockAxios: MockAdapter;
+
+beforeAll(() => {
+  mockAxios = new AxiosMockAdapter(axios);
+  mockAxios.onPost('/persistTransaction').reply(200, { result: {} });
+  mockAxios.onGet('/getConfirmedTransaction').reply(200, { result: {} });
+});
+
+afterAll(() => {
+  mockAxios.restore();
+  jest.restoreAllMocks();
+});
+
+describe('HttpDataAccess', () => {
+  describe('persistTransaction()', () => {
+    it('should emmit error', (done) => {
+      mockAxios.onGet('/getConfirmedTransaction').reply(404, { result: {} });
+      const httpDataAccess = new HttpDataAccess({
+        httpConfig: {
+          getConfirmationDeferDelay: 0,
+          getConfirmationMaxRetry: 0,
+        },
+      });
+      void httpDataAccess.persistTransaction({}, '', []).then((returnPersistTransaction) => {
+        returnPersistTransaction.on('error', (e) => {
+          expect(e.message).toBe('Transaction confirmation not receive after 0 retries');
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Context

Request confirmation checking-loop can be deferred with a parameter `getConfirmationDeferDelay`.
This has been done by wrapping the checking-loop in a `setTimeout` block.

## Issue

The checking-loop can throw an `Error`. But as this error is thrown in a `setTimeout` block, it is thrown in the main event loop and cannot get caught by surroundings `try {} catch() {}` from the users' code that is consuming our library.

## Description of the changes

Use a promise to sleep for `getConfirmationDeferDelay` ms. Do not throw but emit an `error` event in the `EventEmitter` instead.