### PR TITLE
feat: Add Velas EVM mainnet deployments

### DIFF
--- a/packages/smart-contracts/hardhat.config.ts
+++ b/packages/smart-contracts/hardhat.config.ts
@@ -71,6 +71,11 @@ export default {
       chainId: 250,
       accounts,
     },
+    velas: {
+      url: process.env.WEB3_PROVIDER_URL || 'https://evmexplorer.velas.com/rpc',
+      chainId: 106,
+      accounts,
+    },
   },
   etherscan: {
     // Can be overridden according to the network (set-explorer-api-key)

--- a/packages/smart-contracts/hardhat.config.ts
+++ b/packages/smart-contracts/hardhat.config.ts
@@ -105,10 +105,6 @@ const setExplorerApiKey = (hre: HardhatRuntimeEnvironment) => {
       hre.config.etherscan.apiKey = process.env.FTMSCAN_API_KEY;
       return;
     }
-    case 'velas': {
-      hre.config.etherscan.apiKey = process.env.VELAS_EVM_EXPLORER_API_KEY;
-      return;
-    }
   }
 };
 

--- a/packages/smart-contracts/hardhat.config.ts
+++ b/packages/smart-contracts/hardhat.config.ts
@@ -105,6 +105,10 @@ const setExplorerApiKey = (hre: HardhatRuntimeEnvironment) => {
       hre.config.etherscan.apiKey = process.env.FTMSCAN_API_KEY;
       return;
     }
+    case 'velas': {
+      hre.config.etherscan.apiKey = process.env.VELAS_EVM_EXPLORER_API_KEY;
+      return;
+    }
   }
 };
 

--- a/packages/smart-contracts/src/lib/artifacts/ERC20FeeProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/ERC20FeeProxy/index.ts
@@ -100,6 +100,10 @@ export const erc20FeeProxyArtifact = new ContractArtifact<ERC20FeeProxy>(
           address: '0x0DfbEe143b42B41eFC5A6F87bFD1fFC78c2f0aC9',
           creationBlockNumber: 20060722,
         },
+        velas: {
+          address: '0x976837eA70b96C458b30dC7DF783667cef580696',
+          creationBlockNumber: 175934,
+        },
       },
     },
   },

--- a/packages/smart-contracts/src/lib/artifacts/EthereumFeeProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/EthereumFeeProxy/index.ts
@@ -25,6 +25,10 @@ export const ethereumFeeProxyArtifact = new ContractArtifact<EthereumFeeProxy>(
           address: '0xC6E23a20C0a1933ACC8E30247B5D1e2215796C1F',
           creationBlockNumber: 20670475,
         },
+        velas: {
+          address: '0xc42b664Ef122E8880F89c6D7C5A234BEd0c6C2d0',
+          creationBlockNumber: 175947,
+        },
       },
     },
   },


### PR DESCRIPTION
## Description of the changes

- Add Velas EVM Mainnet to `hardhat.config.ts` 
- Request Network `ERC20FeeProxy.sol` deployed to Velas EVM Mainnet: [https://evmexplorer.velas.com/tx/0x245be2dabe802fb4a98245bdf900bd12ae990878d5eb45db86cdd03a3bd1745b/internal-transactions](https://evmexplorer.velas.com/tx/0x245be2dabe802fb4a98245bdf900bd12ae990878d5eb45db86cdd03a3bd1745b/internal-transactions)
- Request Network `EthereumFeeProxy.sol` deployed to Velas EVM Mainnet: [https://evmexplorer.velas.com/tx/0x4904c0aad4a8ea4d07dfd7a3f9cf1b0e3bc0ec611001b15c229cb265bc2b242c/internal-transactions](https://evmexplorer.velas.com/tx/0x4904c0aad4a8ea4d07dfd7a3f9cf1b0e3bc0ec611001b15c229cb265bc2b242c/internal-transactions)