### PR TITLE
feat: add network as declarative params

### DIFF
--- a/packages/advanced-logic/specs/payment-network-any-to-erc20-proxy-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-any-to-erc20-proxy-0.1.0.md
@@ -30,7 +30,7 @@ As a payment network, this extension allows to deduce a payment `balance` for th
 
 ## Manual payment declaration
 
-The issuer can declare that he received a payment and give the amount, possibly with a `txHash` for documentation.
+The issuer can declare that he received a payment and give the amount, possibly with a `txHash` and `network` for documentation.
 
 ## Contract
 
@@ -287,14 +287,15 @@ the 'addFee' event:
 
 ### Parameters
 
-|                       | Type   | Description                                          | Requirement   |
-| --------------------- | ------ | ---------------------------------------------------- | ------------- |
-| **id**                | String | Constant value: "pn-any-to-erc20-proxy"              | **Mandatory** |
-| **action**            | String | Constant value: "declareReceivedPayment"             | **Mandatory** |
-| **parameters**        | Object |                                                      |               |
-| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
-| **parameters.note**   | String | Additional information about the payment             | Optional      |
-| **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
+|                        | Type   | Description                                                   | Requirement   |
+| ---------------------- | ------ | ------------------------------------------------------------- | ------------- |
+| **id**                 | String | Constant value: "pn-any-to-erc20-proxy"                       | **Mandatory** |
+| **action**             | String | Constant value: "declareReceivedPayment"                      | **Mandatory** |
+| **parameters**         | Object |                                                               |               |
+| **parameters.amount**  | Amount | The amount declared as received, in request currency          | **Mandatory** |
+| **parameters.note**    | String | Additional information about the payment                      | Optional      |
+| **parameters.txHash**  | String | The transaction hash for documentation and metadata           | Optional      |
+| **parameters.network** | String | The network of the transaction for documentation and metadata | Optional      |
 
 ### Conditions
 
@@ -311,26 +312,29 @@ None.
 
 An event is added to the extension state events array:
 
-|  Property             |  Value                                   |
-| --------------------- | -----------------------------------------|
-| **name**              | Constant value: "declareReceivedPayment" |
-| **parameters**        |                                          |
-| **parameters.amount** | `amount` from parameters                 |
-| **parameters.note**   | `note` from parameters                   |
-| **parameters.txHash** | `txHash` from parameters or undefined    |
+|  Property              |  Value                                   |
+| ---------------------- | -----------------------------------------|
+| **name**               | Constant value: "declareReceivedPayment" |
+| **parameters**         |                                          |
+| **parameters.amount**  | `amount` from parameters                 |
+| **parameters.note**    | `note` from parameters                   |
+| **parameters.txHash**  | `txHash` from parameters or undefined    |
+| **parameters.network** | `network` from parameters or undefined   |
 
 ## Action: declareReceivedRefund
 
 ### Parameters
 
-|                       | Type   | Description                                          | Requirement   |
-| --------------------- | ------ | ---------------------------------------------------- | ------------- |
-| **id**                | String | Constant value: "pn-any-to-erc20-proxy"              | **Mandatory** |
-| **action**            | String | Constant value: "declareReceivedRefund"              | **Mandatory** |
-| **parameters**        | Object |                                                      |               |
-| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
-| **parameters.note**   | String | Additional information about the payment             | Optional      |
-| **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
+|                        | Type   | Description                                                   | Requirement   |
+| ---------------------- | ------ | ------------------------------------------------------------- | ------------- |
+| **id**                 | String | Constant value: "pn-any-to-erc20-proxy"                       | **Mandatory** |
+| **action**             | String | Constant value: "declareReceivedRefund"                       | **Mandatory** |
+| **parameters**         | Object |                                                               |               |
+| **parameters.amount**  | Amount | The amount declared as received, in request currency          | **Mandatory** |
+| **parameters.note**    | String | Additional information about the payment                      | Optional      |
+| **parameters.txHash**  | String | The transaction hash for documentation and metadata           | Optional      |
+| **parameters.network** | String | The network of the transaction for documentation and metadata | Optional      |
+
 
 ### Conditions
 
@@ -347,13 +351,14 @@ None.
 
 An event is added to the extension state events array:
 
-|  Property             |  Value                                   |
-| --------------------- | -----------------------------------------|
-| **name**              | Constant value: "declareReceivedRefund"  |
-| **parameters**        |                                          |
-| **parameters.amount** | `amount` from parameters                 |
-| **parameters.note**   | `note` from parameters                   |
-| **parameters.txHash** | `txHash` from parameters or undefined    |
+|  Property              |  Value                                   |
+| ---------------------- | -----------------------------------------|
+| **name**               | Constant value: "declareReceivedRefund"  |
+| **parameters**         |                                          |
+| **parameters.amount**  | `amount` from parameters                 |
+| **parameters.note**    | `note` from parameters                   |
+| **parameters.txHash**  | `txHash` from parameters or undefined    |
+| **parameters.network** | `network` from parameters or undefined   |
 
 ---
 

--- a/packages/advanced-logic/specs/payment-network-erc20-fee-proxy-contract-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-erc20-fee-proxy-contract-0.1.0.md
@@ -48,7 +48,7 @@ The `TransferWithReferenceAndFee` event is emitted when the tokens are transfere
 
 ## Manual payment declaration
 
-The issuer can declare that he received a payment and give the amount, possibly with a `txHash` for documentation.
+The issuer can declare that he received a payment and give the amount, possibly with a `txHash` and `network` for documentation.
 
 ## Properties
 
@@ -262,14 +262,15 @@ the 'addFee' event:
 
 ### Parameters
 
-|                       | Type   | Description                                          | Requirement   |
-| --------------------- | ------ | ---------------------------------------------------- | ------------- |
-| **id**                | String | Constant value: "pn-erc20-fee-proxy-contract"        | **Mandatory** |
-| **action**            | String | Constant value: "declareReceivedPayment"             | **Mandatory** |
-| **parameters**        | Object |                                                      |               |
-| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
-| **parameters.note**   | String | Additional information about the payment             | Optional      |
-| **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
+|                        |  Type   | Description                                                  | Requirement   |
+| ---------------------- | ------ | ------------------------------------------------------------- | ------------- |
+| **id**                 | String | Constant value: "pn-erc20-fee-proxy-contract"                 | **Mandatory** |
+| **action**             | String | Constant value: "declareReceivedPayment"                      | **Mandatory** |
+| **parameters**         | Object |                                                               |               |
+| **parameters.amount**  | Amount | The amount declared as received, in request currency          | **Mandatory** |
+| **parameters.note**    | String | Additional information about the payment                      | Optional      |
+| **parameters.txHash**  | String | The transaction hash for documentation and metadata           | Optional      |
+| **parameters.network** | String | The network of the transaction for documentation and metadata | Optional      |
 
 ### Conditions
 
@@ -298,14 +299,15 @@ An event is added to the extension state events array:
 
 ### Parameters
 
-|                       | Type   | Description                                          | Requirement   |
-| --------------------- | ------ | ---------------------------------------------------- | ------------- |
-| **id**                | String | Constant value: "pn-erc20-fee-proxy-contract"        | **Mandatory** |
-| **action**            | String | Constant value: "declareReceivedRefund"              | **Mandatory** |
-| **parameters**        | Object |                                                      |               |
-| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
-| **parameters.note**   | String | Additional information about the payment             | Optional      |
-| **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
+|                        | Type   | Description                                                   | Requirement   |
+| ---------------------- | ------ | ------------------------------------------------------------- | ------------- |
+| **id**                 | String | Constant value: "pn-erc20-fee-proxy-contract"                 | **Mandatory** |
+| **action**             | String | Constant value: "declareReceivedRefund"                       | **Mandatory** |
+| **parameters**         | Object |                                                               |               |
+| **parameters.amount**  | Amount | The amount declared as received, in request currency          | **Mandatory** |
+| **parameters.note**    | String | Additional information about the payment                      | Optional      |
+| **parameters.txHash**  | String | The transaction hash for documentation and metadata           | Optional      |
+| **parameters.network** | String | The network of the transaction for documentation and metadata | Optional      |
 
 ### Conditions
 
@@ -322,13 +324,14 @@ None.
 
 An event is added to the extension state events array:
 
-|  Property             |  Value                                   |
-| --------------------- | -----------------------------------------|
-| **name**              | Constant value: "declareReceivedRefund"  |
-| **parameters**        |                                          |
-| **parameters.amount** | `amount` from parameters                 |
-| **parameters.note**   | `note` from parameters                   |
-| **parameters.txHash** | `txHash` from parameters or undefined    |
+|  Property              |  Value                                   |
+| ---------------------- | -----------------------------------------|
+| **name**               | Constant value: "declareReceivedRefund"  |
+| **parameters**         |                                          |
+| **parameters.amount**  | `amount` from parameters                 |
+| **parameters.note**    | `note` from parameters                   |
+| **parameters.txHash**  | `txHash` from parameters or undefined    |
+| **parameters.network** | `network` from parameters or undefined   |
 
 ---
 

--- a/packages/advanced-logic/specs/payment-network-eth-fee-proxy-contract-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-eth-fee-proxy-contract-0.1.0.md
@@ -255,14 +255,15 @@ the 'addFee' event:
 
 ### Parameters
 
-|                       | Type   | Description                                          | Requirement   |
-| --------------------- | ------ | ---------------------------------------------------- | ------------- |
-| **id**                | String | Constant value: "pn-eth-fee-proxy-contract"          | **Mandatory** |
-| **action**            | String | Constant value: "declareReceivedPayment"             | **Mandatory** |
-| **parameters**        | Object |                                                      |               |
-| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
-| **parameters.note**   | String | Additional information about the payment             | Optional      |
-| **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
+|                        | Type   | Description                                                   | Requirement   |
+| ---------------------- | ------ | ------------------------------------------------------------- | ------------- |
+| **id**                 | String | Constant value: "pn-eth-fee-proxy-contract"                   | **Mandatory** |
+| **action**             | String | Constant value: "declareReceivedPayment"                      | **Mandatory** |
+| **parameters**         | Object |                                                               |               |
+| **parameters.amount**  | Amount | The amount declared as received, in request currency          | **Mandatory** |
+| **parameters.note**    | String | Additional information about the payment                      | Optional      |
+| **parameters.txHash**  | String | The transaction hash for documentation and metadata           | Optional      |
+| **parameters.network** | String | The network of the transaction for documentation and metadata | Optional      |
 
 ### Conditions
 
@@ -279,26 +280,28 @@ None.
 
 An event is added to the extension state events array:
 
-|  Property             |  Value                                   |
-| --------------------- | -----------------------------------------|
-| **name**              | Constant value: "declareReceivedPayment" |
-| **parameters**        |                                          |
-| **parameters.amount** | `amount` from parameters                 |
-| **parameters.note**   | `note` from parameters                   |
-| **parameters.txHash** | `txHash` from parameters or undefined    |
+|  Property              |  Value                                   |
+| ---------------------- | -----------------------------------------|
+| **name**               | Constant value: "declareReceivedPayment" |
+| **parameters**         |                                          |
+| **parameters.amount**  | `amount` from parameters                 |
+| **parameters.note**    | `note` from parameters                   |
+| **parameters.txHash**  | `txHash` from parameters or undefined    |
+| **parameters.network** | `network` from parameters or undefined   |
 
 ## Action: declareReceivedRefund
 
 ### Parameters
 
-|                       | Type   | Description                                          | Requirement   |
-| --------------------- | ------ | ---------------------------------------------------- | ------------- |
-| **id**                | String | Constant value: "pn-eth-fee-proxy-contract"          | **Mandatory** |
-| **action**            | String | Constant value: "declareReceivedRefund"              | **Mandatory** |
-| **parameters**        | Object |                                                      |               |
-| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
-| **parameters.note**   | String | Additional information about the payment             | Optional      |
-| **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
+|                        | Type   | Description                                                   | Requirement   |
+| ---------------------- | ------ | ------------------------------------------------------------- | ------------- |
+| **id**                 | String | Constant value: "pn-eth-fee-proxy-contract"                   | **Mandatory** |
+| **action**             | String | Constant value: "declareReceivedRefund"                       | **Mandatory** |
+| **parameters**         | Object |                                                               |               |
+| **parameters.amount**  | Amount | The amount declared as received, in request currency          | **Mandatory** |
+| **parameters.note**    | String | Additional information about the payment                      | Optional      |
+| **parameters.txHash**  | String | The transaction hash for documentation and metadata           | Optional      |
+| **parameters.network** | String | The network of the transaction for documentation and metadata | Optional      |
 
 ### Conditions
 
@@ -315,13 +318,14 @@ None.
 
 An event is added to the extension state events array:
 
-|  Property             |  Value                                   |
-| --------------------- | -----------------------------------------|
-| **name**              | Constant value: "declareReceivedRefund"  |
-| **parameters**        |                                          |
-| **parameters.amount** | `amount` from parameters                 |
-| **parameters.note**   | `note` from parameters                   |
-| **parameters.txHash** | `txHash` from parameters or undefined    |
+|  Property              |  Value                                   |
+| ---------------------- | -----------------------------------------|
+| **name**               | Constant value: "declareReceivedRefund"  |
+| **parameters**         |                                          |
+| **parameters.amount**  | `amount` from parameters                 |
+| **parameters.note**    | `note` from parameters                   |
+| **parameters.txHash**  | `txHash` from parameters or undefined    |
+| **parameters.network** | `network` from parameters or undefined   |
 
 ---
 

--- a/packages/advanced-logic/specs/payment-network-eth-input-data-0.2.0.md
+++ b/packages/advanced-logic/specs/payment-network-eth-input-data-0.2.0.md
@@ -23,7 +23,7 @@ As a payment network, this extension allows to deduce a payment `balance` for th
 
 ## Manual payment declaration
 
-The issuer can declare that he received a payment and give the amount, possibly with a `txHash` for documentation.
+The issuer can declare that he received a payment and give the amount, possibly with a `txHash` and `network` for documentation.
 
 ## Contract
 
@@ -202,14 +202,15 @@ The 'addRefundAddress' event:
 
 ### Parameters
 
-|                       | Type   | Description                                          | Requirement   |
-| --------------------- | ------ | ---------------------------------------------------- | ------------- |
-| **id**                | String | Constant value: "pn-eth-input-data"                  | **Mandatory** |
-| **action**            | String | Constant value: "declareReceivedPayment"             | **Mandatory** |
-| **parameters**        | Object |                                                      |               |
-| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
-| **parameters.note**   | String | Additional information about the payment             | Optional      |
-| **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
+|                        | Type   | Description                                                   | Requirement   |
+| ---------------------- | ------ | ------------------------------------------------------------- | ------------- |
+| **id**                 | String | Constant value: "pn-eth-input-data"                           | **Mandatory** |
+| **action**             | String | Constant value: "declareReceivedPayment"                      | **Mandatory** |
+| **parameters**         | Object |                                                               |               |
+| **parameters.amount**  | Amount | The amount declared as received, in request currency          | **Mandatory** |
+| **parameters.note**    | String | Additional information about the payment                      | Optional      |
+| **parameters.txHash**  | String | The transaction hash for documentation and metadata           | Optional      |
+| **parameters.network** | String | The network of the transaction for documentation and metadata | Optional      |
 
 ### Conditions
 
@@ -226,26 +227,28 @@ None.
 
 An event is added to the extension state events array:
 
-|  Property             |  Value                                   |
-| --------------------- | -----------------------------------------|
-| **name**              | Constant value: "declareReceivedPayment" |
-| **parameters**        |                                          |
-| **parameters.amount** | `amount` from parameters                 |
-| **parameters.note**   | `note` from parameters                   |
-| **parameters.txHash** | `txHash` from parameters or undefined    |
+|  Property              |  Value                                   |
+| ---------------------- | -----------------------------------------|
+| **name**               | Constant value: "declareReceivedPayment" |
+| **parameters**         |                                          |
+| **parameters.amount**  | `amount` from parameters                 |
+| **parameters.note**    | `note` from parameters                   |
+| **parameters.txHash**  | `txHash` from parameters or undefined    |
+| **parameters.network** | `network` from parameters or undefined   |
 
 ## Action: declareReceivedRefund
 
 ### Parameters
 
-|                       | Type   | Description                                          | Requirement   |
-| --------------------- | ------ | ---------------------------------------------------- | ------------- |
-| **id**                | String | Constant value: "pn-eth-input-data"                  | **Mandatory** |
-| **action**            | String | Constant value: "declareReceivedRefund"              | **Mandatory** |
-| **parameters**        | Object |                                                      |               |
-| **parameters.amount** | Amount | The amount declared as received, in request currency | **Mandatory** |
-| **parameters.note**   | String | Additional information about the payment             | Optional      |
-| **parameters.txHash** | String | The transaction hash for documentation and metadata  | Optional      |
+|                        | Type   | Description                                                   | Requirement   |
+| ---------------------- | ------ | ------------------------------------------------------------- | ------------- |
+| **id**                 | String | Constant value: "pn-eth-input-data"                           | **Mandatory** |
+| **action**             | String | Constant value: "declareReceivedRefund"                       | **Mandatory** |
+| **parameters**         | Object |                                                               |               |
+| **parameters.amount**  | Amount | The amount declared as received, in request currency          | **Mandatory** |
+| **parameters.note**    | String | Additional information about the payment                      | Optional      |
+| **parameters.txHash**  | String | The transaction hash for documentation and metadata           | Optional      |
+| **parameters.network** | String | The network of the transaction for documentation and metadata | Optional      |
 
 ### Conditions
 
@@ -262,13 +265,14 @@ None.
 
 An event is added to the extension state events array:
 
-|  Property             |  Value                                   |
-| --------------------- | -----------------------------------------|
-| **name**              | Constant value: "declareReceivedRefund"  |
-| **parameters**        |                                          |
-| **parameters.amount** | `amount` from parameters                 |
-| **parameters.note**   | `note` from parameters                   |
-| **parameters.txHash** | `txHash` from parameters or undefined    |
+|  Property              |  Value                                   |
+| ---------------------- | -----------------------------------------|
+| **name**               | Constant value: "declareReceivedRefund"  |
+| **parameters**         |                                          |
+| **parameters.amount**  | `amount` from parameters                 |
+| **parameters.note**    | `note` from parameters                   |
+| **parameters.txHash**  | `txHash` from parameters or undefined    |
+| **parameters.network** | `network` from parameters or undefined   |
 
 ---
 

--- a/packages/advanced-logic/src/extensions/payment-network/declarative.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/declarative.ts
@@ -50,6 +50,7 @@ export default class DeclarativePaymentNetwork<
         amount: parameters.amount.toString(),
         note: parameters.note,
         txHash: parameters.txHash,
+        network: parameters.network,
       },
     };
   }
@@ -71,6 +72,7 @@ export default class DeclarativePaymentNetwork<
         amount: parameters.amount.toString(),
         note: parameters.note,
         txHash: parameters.txHash,
+        network: parameters.network,
       },
     };
   }
@@ -92,6 +94,7 @@ export default class DeclarativePaymentNetwork<
         amount: parameters.amount.toString(),
         note: parameters.note,
         txHash: parameters.txHash,
+        network: parameters.network,
       },
     };
   }
@@ -113,6 +116,7 @@ export default class DeclarativePaymentNetwork<
         amount: parameters.amount.toString(),
         note: parameters.note,
         txHash: parameters.txHash,
+        network: parameters.network,
       },
     };
   }

--- a/packages/payment-detection/src/declarative.ts
+++ b/packages/payment-detection/src/declarative.ts
@@ -79,6 +79,7 @@ export default class PaymentNetworkDeclarative<
       amount: parameters.amount,
       note: parameters.note,
       txHash: parameters.txHash,
+      network: parameters.network,
     });
   }
 
@@ -95,6 +96,7 @@ export default class PaymentNetworkDeclarative<
       amount: parameters.amount,
       note: parameters.note,
       txHash: parameters.txHash,
+      network: parameters.network,
     });
   }
 
@@ -111,6 +113,7 @@ export default class PaymentNetworkDeclarative<
       amount: parameters.amount,
       note: parameters.note,
       txHash: parameters.txHash,
+      network: parameters.network,
     });
   }
 
@@ -127,6 +130,7 @@ export default class PaymentNetworkDeclarative<
       amount: parameters.amount,
       note: parameters.note,
       txHash: parameters.txHash,
+      network: parameters.network,
     });
   }
 
@@ -171,6 +175,7 @@ export default class PaymentNetworkDeclarative<
           name: PaymentTypes.EVENTS_NAMES.PAYMENT,
           parameters: {
             txHash: parameters.txHash,
+            network: parameters.network,
             note: parameters.note,
             from: data.from,
           },
@@ -186,6 +191,7 @@ export default class PaymentNetworkDeclarative<
           name: PaymentTypes.EVENTS_NAMES.REFUND,
           parameters: {
             txHash: parameters.txHash,
+            network: parameters.network,
             note: parameters.note,
             from: data.from,
           },

--- a/packages/payment-detection/test/declarative.test.ts
+++ b/packages/payment-detection/test/declarative.test.ts
@@ -170,7 +170,8 @@ describe('api/declarative', () => {
           parameters: {
             amount: '1000',
             note: 'first payment',
-            txHash: 'the-first-hash'
+            txHash: 'the-first-hash',
+            network: 'mainnet'
           },
           timestamp: 10,
         },
@@ -179,7 +180,8 @@ describe('api/declarative', () => {
           parameters: {
             amount: '500',
             note: 'second payment',
-            txHash: 'the-second-hash'
+            txHash: 'the-second-hash',
+            network: 'matic'
           },
           timestamp: 15,
         },
@@ -188,7 +190,8 @@ describe('api/declarative', () => {
           parameters: {
             amount: '100',
             note: 'first refund',
-            txHash: 'the-first-refund-hash'
+            txHash: 'the-first-refund-hash',
+            network: 'mainnet'
           },
           timestamp: 20,
         },
@@ -197,7 +200,8 @@ describe('api/declarative', () => {
           parameters: {
             amount: '200',
             note: 'second refund',
-            txHash: 'the-second-refund-hash'
+            txHash: 'the-second-refund-hash',
+            network: 'matic'
           },
           timestamp: 25,
         },
@@ -214,7 +218,8 @@ describe('api/declarative', () => {
           name: PaymentTypes.EVENTS_NAMES.PAYMENT,
           parameters: {
             note: 'first payment',
-            txHash: 'the-first-hash'
+            txHash: 'the-first-hash',
+            network: 'mainnet'
           },
           timestamp: 10,
         },
@@ -223,7 +228,8 @@ describe('api/declarative', () => {
           name: PaymentTypes.EVENTS_NAMES.PAYMENT,
           parameters: {
             note: 'second payment',
-            txHash: 'the-second-hash'
+            txHash: 'the-second-hash',
+            network: 'matic'
           },
           timestamp: 15,
         },
@@ -232,7 +238,8 @@ describe('api/declarative', () => {
           name: PaymentTypes.EVENTS_NAMES.REFUND,
           parameters: {
             note: 'first refund',
-            txHash: 'the-first-refund-hash'
+            txHash: 'the-first-refund-hash',
+            network: 'mainnet'
           },
           timestamp: 20,
         },
@@ -241,7 +248,8 @@ describe('api/declarative', () => {
           name: PaymentTypes.EVENTS_NAMES.REFUND,
           parameters: {
             note: 'second refund',
-            txHash: 'the-second-refund-hash'
+            txHash: 'the-second-refund-hash',
+            network: 'matic'
           },
           timestamp: 25,
         },

--- a/packages/request-client.js/src/api/request.ts
+++ b/packages/request-client.js/src/api/request.ts
@@ -451,6 +451,7 @@ export default class Request {
    * @param note Note from payee about the received payment
    * @param signerIdentity Identity of the signer. The identity type must be supported by the signature provider.
    * @param txHash transaction hash
+   * @param network network of the transaction
    * @returns The updated request
    */
   public async declareReceivedPayment(
@@ -458,6 +459,7 @@ export default class Request {
     note: string,
     signerIdentity: IdentityTypes.IIdentity,
     txHash?: string,
+    network?: string,
   ): Promise<Types.IRequestDataWithEvents> {
     const extensionsData: any[] = [];
 
@@ -478,6 +480,7 @@ export default class Request {
         amount,
         note,
         txHash,
+        network,
       }),
     );
 
@@ -502,6 +505,7 @@ export default class Request {
    * @param note Note from payer about the received refund
    * @param signerIdentity Identity of the signer. The identity type must be supported by the signature provider.
    * @param txHash transaction hash
+   * @param network network of the transaction
    * @returns The updated request
    */
   public async declareReceivedRefund(
@@ -509,6 +513,7 @@ export default class Request {
     note: string,
     signerIdentity: IdentityTypes.IIdentity,
     txHash?: string,
+    network?: string,
   ): Promise<Types.IRequestDataWithEvents> {
     const extensionsData: any[] = [];
 
@@ -529,6 +534,7 @@ export default class Request {
         amount,
         note,
         txHash,
+        network,
       }),
     );
 

--- a/packages/request-client.js/test/index.test.ts
+++ b/packages/request-client.js/test/index.test.ts
@@ -880,7 +880,7 @@ describe('index', () => {
       expect(requestData.balance!.balance).toEqual('10');
     });
 
-    it('allows to declare a received payment by providing transaction hash', async () => {
+    it('allows to declare a received payment by providing transaction hash and network', async () => {
       const requestNetwork = new RequestNetwork({
         httpConfig,
         signatureProvider: TestData.fakeSignatureProvider,
@@ -905,6 +905,7 @@ describe('index', () => {
         'received payment',
         TestData.payee.identity,
         '0x123456789',
+        'mainnet'
       );
       await new Promise((r) => requestDataWithEvents.on('confirmed', r));
 

--- a/packages/types/src/extensions/pn-any-declarative-types.ts
+++ b/packages/types/src/extensions/pn-any-declarative-types.ts
@@ -38,6 +38,7 @@ export interface ISentParameters {
   amount: RequestLogicTypes.Amount;
   note: string;
   txHash?: string;
+  network?: string;
 }
 
 /** Parameters of declareReceivedPayment and declareReceivedRefund action */
@@ -45,6 +46,7 @@ export interface IReceivedParameters {
   amount: RequestLogicTypes.Amount;
   note: string;
   txHash?: string;
+  network?: string;
 }
 
 /** Parameters of addPaymentInstruction action */

--- a/packages/types/src/payment-types.ts
+++ b/packages/types/src/payment-types.ts
@@ -185,6 +185,7 @@ export type BTCBalanceWithEvents = IBalanceWithEvents<IBTCPaymentEventParameters
 /** Parameters for events of Declarative payments */
 export interface IDeclarativePaymentEventParameters {
   txHash?: string;
+  network?: string;
   note?: string;
   from?: IIdentity;
 }


### PR DESCRIPTION
## Description of the changes
Adding `network` as parameters. As discussed with @benjlevesque , `txHash` is not enough as the manual payment can be made in a different network than the expected payment method (e.g a request is expected to be paid in USDT but the payment is made in Polygon)