### PR TITLE
fix: remove empty keywords

### DIFF
--- a/packages/docs/docs/guides/0-getting-started.md
+++ b/packages/docs/docs/guides/0-getting-started.md
@@ -1,6 +1,5 @@
 ---
 title: Get Started with Request
-keywords:
 description: Learn how to integrate Request network and its features.
 ---
 

--- a/packages/docs/docs/guides/3-Portal-API/2-payment-status.md
+++ b/packages/docs/docs/guides/3-Portal-API/2-payment-status.md
@@ -1,7 +1,6 @@
 ---
 title: Payment status with the Portal API
 sidebar_label: Payment status
-keywords:
 description: Learn how to integrate Request network and its features.
 ---
 

--- a/packages/docs/docs/guides/3-Portal-API/5-api-conclusion.md
+++ b/packages/docs/docs/guides/3-Portal-API/5-api-conclusion.md
@@ -1,7 +1,6 @@
 ---
 title: Request through the REST API - wrap-up
 sidebar_label: REST API wrap-up
-keywords:
 description: Learn how to integrate Request network and its features.
 ---
 


### PR DESCRIPTION
## Description of the changes
Build is now failing if `keywords` doesn't contain an array.