### PR TITLE
fix: add txHash and network to extensions events

### DIFF
--- a/packages/advanced-logic/src/extensions/payment-network/declarative.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/declarative.ts
@@ -254,6 +254,8 @@ export default class DeclarativePaymentNetwork<
       parameters: {
         amount: extensionAction.parameters.amount,
         note: extensionAction.parameters.note,
+        txHash: extensionAction.parameters.txHash,
+        network: extensionAction.parameters.network,
       },
       timestamp,
       from: actionSigner,
@@ -298,6 +300,8 @@ export default class DeclarativePaymentNetwork<
       parameters: {
         amount: extensionAction.parameters.amount,
         note: extensionAction.parameters.note,
+        txHash: extensionAction.parameters.txHash,
+        network: extensionAction.parameters.network,
       },
       timestamp,
       from: actionSigner,
@@ -342,6 +346,8 @@ export default class DeclarativePaymentNetwork<
       parameters: {
         amount: extensionAction.parameters.amount,
         note: extensionAction.parameters.note,
+        txHash: extensionAction.parameters.txHash,
+        network: extensionAction.parameters.network,
       },
       timestamp,
       from: actionSigner,
@@ -386,6 +392,8 @@ export default class DeclarativePaymentNetwork<
       parameters: {
         amount: extensionAction.parameters.amount,
         note: extensionAction.parameters.note,
+        txHash: extensionAction.parameters.txHash,
+        network: extensionAction.parameters.network,
       },
       timestamp,
       from: actionSigner,


### PR DESCRIPTION
## Description of the changes
`txHash` and `network` needs to be injected to `request.extensions[paymentNetworkId].events[i].parameters` in order to make it available on `balance.events[i].parameters`