### PR TITLE
refactor: payment detectors inheritance

### DIFF
--- a/packages/payment-detection/src/any-to-any-detector.ts
+++ b/packages/payment-detection/src/any-to-any-detector.ts
@@ -1,9 +1,4 @@
-import {
-  AdvancedLogicTypes,
-  ExtensionTypes,
-  PaymentTypes,
-  RequestLogicTypes,
-} from '@requestnetwork/types';
+import { ExtensionTypes, PaymentTypes, RequestLogicTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import { FeeReferenceBasedDetector } from './fee-reference-based-detector';
 
@@ -20,12 +15,11 @@ export abstract class AnyToAnyDetector<
    * @param extensionType Example : ExtensionTypes.ID.ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ETH_PROXY
    */
   public constructor(
-    protected advancedLogic: AdvancedLogicTypes.IAdvancedLogic,
-    protected extension: ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased,
-    protected extensionType: ExtensionTypes.ID,
+    paymentNetworkId: PaymentTypes.PAYMENT_NETWORK_ID,
+    extension: ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased,
     protected currencyManager: ICurrencyManager,
   ) {
-    super(advancedLogic, extension, extensionType);
+    super(paymentNetworkId, extension);
   }
 
   /**

--- a/packages/payment-detection/src/any/any-to-erc20-proxy.ts
+++ b/packages/payment-detection/src/any/any-to-erc20-proxy.ts
@@ -8,7 +8,7 @@ import {
 } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import { ICurrencyManager } from '@requestnetwork/currency';
-import { ERC20FeeProxyPaymentDetector } from '../erc20/fee-proxy-contract';
+import { ERC20FeeProxyPaymentDetectorBase } from '../erc20/fee-proxy-contract';
 import PaymentReferenceCalculator from '../payment-reference-calculator';
 import { AnyToErc20InfoRetriever } from './retrievers/any-to-erc20-proxy';
 import { TheGraphAnyToErc20Retriever } from './retrievers/thegraph';
@@ -26,7 +26,7 @@ const PROXY_CONTRACT_ADDRESS_MAP = {
 /**
  * Handle payment networks with conversion proxy contract extension
  */
-export class AnyToERC20PaymentDetector extends ERC20FeeProxyPaymentDetector<ExtensionTypes.PnAnyToErc20.IAnyToERC20> {
+export class AnyToERC20PaymentDetector extends ERC20FeeProxyPaymentDetectorBase<ExtensionTypes.PnAnyToErc20.IAnyToERC20> {
   /**
    * @param extension The advanced logic payment network extensions
    */
@@ -38,12 +38,11 @@ export class AnyToERC20PaymentDetector extends ERC20FeeProxyPaymentDetector<Exte
     advancedLogic: AdvancedLogicTypes.IAdvancedLogic;
     currencyManager: ICurrencyManager;
   }) {
-    super({
-      advancedLogic,
+    super(
+      PaymentTypes.PAYMENT_NETWORK_ID.ANY_TO_ERC20_PROXY,
+      advancedLogic.extensions.anyToErc20Proxy,
       currencyManager,
-    });
-    this._extensionTypeId = ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY;
-    this.extension = advancedLogic.extensions.anyToErc20Proxy;
+    );
   }
 
   /**

--- a/packages/payment-detection/src/any/any-to-eth-proxy.ts
+++ b/packages/payment-detection/src/any/any-to-eth-proxy.ts
@@ -36,9 +36,8 @@ export class AnyToEthFeeProxyPaymentDetector extends AnyToAnyDetector<PaymentTyp
     currencyManager: ICurrencyManager;
   }) {
     super(
-      advancedLogic,
+      PaymentTypes.PAYMENT_NETWORK_ID.ANY_TO_ETH_PROXY,
       advancedLogic.extensions.anyToEthProxy,
-      ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ETH_PROXY,
       currencyManager,
     );
   }

--- a/packages/payment-detection/src/declarative.ts
+++ b/packages/payment-detection/src/declarative.ts
@@ -7,20 +7,15 @@ import {
 import { BigNumber } from 'ethers';
 
 /**
- * Handle payment networks with declarative requests extension
- *
- * @class PaymentNetworkDeclarative
+ * Handles payment detection for a declarative request, or derived.
  */
-export default class PaymentNetworkDeclarative<
+export abstract class DeclarativePaymentDetectorBase<
   TExtension extends ExtensionTypes.PnAnyDeclarative.IAnyDeclarative = ExtensionTypes.PnAnyDeclarative.IAnyDeclarative
 > implements PaymentTypes.IPaymentNetwork<PaymentTypes.IDeclarativePaymentEventParameters> {
-  protected extension: TExtension;
-  protected _paymentNetworkId: PaymentTypes.PAYMENT_NETWORK_ID;
-
-  public constructor({ advancedLogic }: { advancedLogic: AdvancedLogicTypes.IAdvancedLogic }) {
-    this.extension = advancedLogic.extensions.declarative;
-    this._paymentNetworkId = PaymentTypes.PAYMENT_NETWORK_ID.DECLARATIVE;
-  }
+  public constructor(
+    protected readonly _paymentNetworkId: PaymentTypes.PAYMENT_NETWORK_ID,
+    protected readonly extension: TExtension,
+  ) {}
 
   /**
    * Creates the extensions data for the creation of this extension
@@ -204,5 +199,16 @@ export default class PaymentNetworkDeclarative<
       balance: balance.toString(),
       events,
     };
+  }
+}
+
+/**
+ * Handles payment detection for a declarative request
+ */
+export class DeclarativePaymentDetector<
+  TExtension extends ExtensionTypes.PnAnyDeclarative.IAnyDeclarative = ExtensionTypes.PnAnyDeclarative.IAnyDeclarative
+> extends DeclarativePaymentDetectorBase<TExtension> {
+  constructor({ advancedLogic }: { advancedLogic: AdvancedLogicTypes.IAdvancedLogic }) {
+    super(PaymentTypes.PAYMENT_NETWORK_ID.DECLARATIVE, advancedLogic.extensions.declarative);
   }
 }

--- a/packages/payment-detection/src/erc20/fee-proxy-contract.ts
+++ b/packages/payment-detection/src/erc20/fee-proxy-contract.ts
@@ -15,7 +15,7 @@ import { BigNumber } from 'ethers';
 import { networkSupportsTheGraph } from '../thegraph';
 import TheGraphInfoRetriever from './thegraph-info-retriever';
 import { loadCurrencyFromContract } from './currency';
-import DeclarativePaymentNetwork from '../declarative';
+import { DeclarativePaymentDetectorBase } from '../declarative';
 import { makeGetDeploymentInformation } from '../utils';
 
 /* eslint-disable max-classes-per-file */
@@ -30,32 +30,23 @@ const PROXY_CONTRACT_ADDRESS_MAP = {
 };
 
 /**
- * Handle payment networks with ERC20 fee proxy contract extension
+ * Handle payment networks with ERC20 fee proxy contract extension, or derived
  * FIXME: inherit ReferenceBasedDetector
  */
-export class ERC20FeeProxyPaymentDetector<
-    ExtensionType extends ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased = ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased
+export class ERC20FeeProxyPaymentDetectorBase<
+    TExtension extends ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased = ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased
   >
-  extends DeclarativePaymentNetwork<ExtensionType>
-  implements PaymentTypes.IPaymentNetwork<ExtensionType> {
-  protected _extensionTypeId: ExtensionTypes.ID;
-  protected _currencyManager: ICurrencyManager;
-
+  extends DeclarativePaymentDetectorBase<TExtension>
+  implements PaymentTypes.IPaymentNetwork<TExtension> {
   /**
    * @param extension The advanced logic payment network extensions
    */
-  public constructor({
-    advancedLogic,
-    currencyManager,
-  }: {
-    advancedLogic: AdvancedLogicTypes.IAdvancedLogic;
-    currencyManager: ICurrencyManager;
-  }) {
-    super({ advancedLogic });
-    this._extensionTypeId = ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT;
-    this.extension = advancedLogic.extensions.feeProxyContractErc20;
-    this._paymentNetworkId = PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT;
-    this._currencyManager = currencyManager;
+  public constructor(
+    paymentNetworkId: PaymentTypes.PAYMENT_NETWORK_ID,
+    extension: TExtension,
+    protected _currencyManager: ICurrencyManager,
+  ) {
+    super(paymentNetworkId, extension);
   }
 
   /**
@@ -133,11 +124,11 @@ export class ERC20FeeProxyPaymentDetector<
   public async getBalance(
     request: RequestLogicTypes.IRequest,
   ): Promise<PaymentTypes.IBalanceWithEvents> {
-    const paymentNetwork = request.extensions[this._extensionTypeId];
+    const paymentNetwork = request.extensions[this._paymentNetworkId];
 
     if (!paymentNetwork) {
       return getBalanceErrorObject(
-        `The request does not have the extension : ${this._extensionTypeId}`,
+        `The request does not have the extension : ${this._paymentNetworkId}`,
         PaymentTypes.BALANCE_ERROR_CODE.WRONG_EXTENSION,
       );
     }
@@ -224,7 +215,7 @@ export class ERC20FeeProxyPaymentDetector<
       throw new NetworkNotSupported(`Payment network not supported by ERC20 payment detection`);
     }
 
-    const deploymentInformation = ERC20FeeProxyPaymentDetector.getDeploymentInformation(
+    const deploymentInformation = ERC20FeeProxyPaymentDetectorBase.getDeploymentInformation(
       network,
       paymentNetwork.version,
     );
@@ -328,8 +319,8 @@ export class ERC20FeeProxyPaymentDetector<
   /**
    * Get the detected payment network ID
    */
-  get paymentNetworkId(): ExtensionTypes.ID {
-    return this._extensionTypeId;
+  get paymentNetworkId(): PaymentTypes.PAYMENT_NETWORK_ID {
+    return this._paymentNetworkId;
   }
 
   protected async getCurrency(
@@ -360,4 +351,25 @@ export class ERC20FeeProxyPaymentDetector<
     erc20FeeProxyArtifact,
     PROXY_CONTRACT_ADDRESS_MAP,
   );
+}
+
+/**
+ * Handle payment networks with ERC20 fee proxy contract extension
+ */
+export class ERC20FeeProxyPaymentDetector<
+  TExtension extends ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased = ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased
+> extends ERC20FeeProxyPaymentDetectorBase<TExtension> {
+  constructor({
+    advancedLogic,
+    currencyManager,
+  }: {
+    advancedLogic: AdvancedLogicTypes.IAdvancedLogic;
+    currencyManager: ICurrencyManager;
+  }) {
+    super(
+      PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT,
+      advancedLogic.extensions.feeProxyContractErc20,
+      currencyManager,
+    );
+  }
 }

--- a/packages/payment-detection/src/erc20/proxy-contract.ts
+++ b/packages/payment-detection/src/erc20/proxy-contract.ts
@@ -12,7 +12,7 @@ import PaymentReferenceCalculator from '../payment-reference-calculator';
 import ProxyInfoRetriever from './proxy-info-retriever';
 import TheGraphInfoRetriever from './thegraph-info-retriever';
 import { networkSupportsTheGraph } from '../thegraph';
-import DeclarativePaymentNetwork from '../declarative';
+import { DeclarativePaymentDetectorBase } from '../declarative';
 import { makeGetDeploymentInformation } from '../utils';
 
 /* eslint-disable max-classes-per-file */
@@ -31,18 +31,16 @@ const PROXY_CONTRACT_ADDRESS_MAP = {
 export class ERC20ProxyPaymentDetector<
     ExtensionType extends ExtensionTypes.PnReferenceBased.IReferenceBased = ExtensionTypes.PnReferenceBased.IReferenceBased
   >
-  extends DeclarativePaymentNetwork<ExtensionType>
+  extends DeclarativePaymentDetectorBase<ExtensionType>
   implements PaymentTypes.IPaymentNetwork<ExtensionType> {
-  protected _extensionTypeId: ExtensionTypes.ID;
-
   /**
    * @param extension The advanced logic payment network extensions
    */
   public constructor({ advancedLogic }: { advancedLogic: AdvancedLogicTypes.IAdvancedLogic }) {
-    super({ advancedLogic });
-    this._extensionTypeId = ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT;
-    this.extension = advancedLogic.extensions.proxyContractErc20;
-    this._paymentNetworkId = PaymentTypes.PAYMENT_NETWORK_ID.ERC20_PROXY_CONTRACT;
+    super(
+      PaymentTypes.PAYMENT_NETWORK_ID.ERC20_PROXY_CONTRACT,
+      advancedLogic.extensions.proxyContractErc20,
+    );
   }
 
   /**

--- a/packages/payment-detection/src/eth/fee-proxy-detector.ts
+++ b/packages/payment-detection/src/eth/fee-proxy-detector.ts
@@ -28,9 +28,8 @@ export class EthFeeProxyPaymentDetector extends FeeReferenceBasedDetector<Paymen
    */
   public constructor({ advancedLogic }: { advancedLogic: AdvancedLogicTypes.IAdvancedLogic }) {
     super(
-      advancedLogic,
+      PaymentTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT,
       advancedLogic.extensions.feeProxyContractEth,
-      ExtensionTypes.ID.PAYMENT_NETWORK_ETH_FEE_PROXY_CONTRACT,
     );
   }
 

--- a/packages/payment-detection/src/eth/input-data.ts
+++ b/packages/payment-detection/src/eth/input-data.ts
@@ -38,9 +38,8 @@ export class EthInputDataPaymentDetector extends ReferenceBasedDetector<PaymentT
     explorerApiKeys?: Record<string, string>;
   }) {
     super(
-      advancedLogic,
+      PaymentTypes.PAYMENT_NETWORK_ID.ETH_INPUT_DATA,
       advancedLogic.extensions.ethereumInputData,
-      ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA,
     );
     this.explorerApiKeys = explorerApiKeys || {};
   }

--- a/packages/payment-detection/src/fee-reference-based-detector.ts
+++ b/packages/payment-detection/src/fee-reference-based-detector.ts
@@ -1,9 +1,4 @@
-import {
-  AdvancedLogicTypes,
-  ExtensionTypes,
-  PaymentTypes,
-  RequestLogicTypes,
-} from '@requestnetwork/types';
+import { ExtensionTypes, PaymentTypes, RequestLogicTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import { ReferenceBasedDetector } from './reference-based-detector';
 
@@ -12,19 +7,15 @@ import { ReferenceBasedDetector } from './reference-based-detector';
  */
 export abstract class FeeReferenceBasedDetector<
   TPaymentEventParameters,
-  ExtensionType extends ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased = ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased
-> extends ReferenceBasedDetector<TPaymentEventParameters, ExtensionType> {
+  TExtension extends ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased = ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased
+> extends ReferenceBasedDetector<TPaymentEventParameters, TExtension> {
   /**
    * @param extension The advanced logic payment network extension, reference based
    * @param extensionType Example : ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA
    */
 
-  public constructor(
-    protected advancedLogic: AdvancedLogicTypes.IAdvancedLogic,
-    extension: ExtensionType,
-    protected extensionType: ExtensionTypes.ID,
-  ) {
-    super(advancedLogic, extension, extensionType);
+  public constructor(paymentNetworkId: PaymentTypes.PAYMENT_NETWORK_ID, extension: TExtension) {
+    super(paymentNetworkId, extension);
   }
 
   /**

--- a/packages/payment-detection/src/index.ts
+++ b/packages/payment-detection/src/index.ts
@@ -2,7 +2,7 @@ import PaymentNetworkFactory from './payment-network-factory';
 import PaymentReferenceCalculator from './payment-reference-calculator';
 
 import * as BtcPaymentNetwork from './btc';
-import DeclarativePaymentNetwork from './declarative';
+import { DeclarativePaymentDetector } from './declarative';
 import * as Erc20PaymentNetwork from './erc20';
 import { AnyToERC20PaymentDetector, AnyToEthFeeProxyPaymentDetector } from './any';
 import { EthFeeProxyPaymentDetector, EthInputDataPaymentDetector } from './eth';
@@ -23,7 +23,7 @@ export {
   PaymentNetworkFactory,
   PaymentReferenceCalculator,
   BtcPaymentNetwork,
-  DeclarativePaymentNetwork,
+  DeclarativePaymentDetector,
   Erc20PaymentNetwork,
   EthInputDataPaymentDetector,
   EthFeeProxyPaymentDetector,

--- a/packages/payment-detection/src/near-detector.ts
+++ b/packages/payment-detection/src/near-detector.ts
@@ -27,11 +27,7 @@ export class NearNativeTokenPaymentDetector extends ReferenceBasedDetector<Payme
    * @param extension The advanced logic payment network extension
    */
   public constructor({ advancedLogic }: { advancedLogic: AdvancedLogicTypes.IAdvancedLogic }) {
-    super(
-      advancedLogic,
-      advancedLogic.extensions.nativeToken[0],
-      ExtensionTypes.ID.PAYMENT_NETWORK_NATIVE_TOKEN,
-    );
+    super(PaymentTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN, advancedLogic.extensions.nativeToken[0]);
   }
 
   public static getNearContractName = (

--- a/packages/payment-detection/src/payment-network-factory.ts
+++ b/packages/payment-detection/src/payment-network-factory.ts
@@ -7,7 +7,7 @@ import {
 import { ICurrencyManager } from '@requestnetwork/currency';
 import BTCAddressedBased from './btc/mainnet-address-based';
 import TestnetBTCAddressedBased from './btc/testnet-address-based';
-import Declarative from './declarative';
+import { DeclarativePaymentDetector } from './declarative';
 import { ERC20AddressBasedPaymentDetector } from './erc20/address-based';
 import { ERC20FeeProxyPaymentDetector } from './erc20/fee-proxy-contract';
 import { ERC20ProxyPaymentDetector } from './erc20/proxy-contract';
@@ -48,7 +48,7 @@ const supportedPaymentNetwork: PaymentTypes.ISupportedPaymentNetworkByCurrency =
 
 const anyCurrencyPaymentNetwork: PaymentTypes.IPaymentNetworkModuleByType = {
   [ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY as string]: AnyToERC20PaymentDetector,
-  [ExtensionTypes.ID.PAYMENT_NETWORK_ANY_DECLARATIVE as string]: Declarative,
+  [ExtensionTypes.ID.PAYMENT_NETWORK_ANY_DECLARATIVE as string]: DeclarativePaymentDetector,
   [ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ETH_PROXY as string]: AnyToEthFeeProxyPaymentDetector,
 };
 

--- a/packages/payment-detection/src/reference-based-detector.ts
+++ b/packages/payment-detection/src/reference-based-detector.ts
@@ -1,25 +1,19 @@
-import {
-  AdvancedLogicTypes,
-  ExtensionTypes,
-  PaymentTypes,
-  RequestLogicTypes,
-  TypesUtils,
-} from '@requestnetwork/types';
+import { ExtensionTypes, PaymentTypes, RequestLogicTypes, TypesUtils } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import getBalanceErrorObject from './balance-error';
 import PaymentReferenceCalculator from './payment-reference-calculator';
 
 import { BigNumber } from 'ethers';
-import DeclarativePaymentNetwork from './declarative';
+import { DeclarativePaymentDetectorBase } from './declarative';
 
 /**
  * Abstract class to extend to get the payment balance of reference based requests
  */
 export abstract class ReferenceBasedDetector<
     TPaymentEventParameters,
-    ExtensionType extends ExtensionTypes.PnReferenceBased.IReferenceBased = ExtensionTypes.PnReferenceBased.IReferenceBased
+    TExtension extends ExtensionTypes.PnReferenceBased.IReferenceBased = ExtensionTypes.PnReferenceBased.IReferenceBased
   >
-  extends DeclarativePaymentNetwork<ExtensionType>
+  extends DeclarativePaymentDetectorBase<TExtension>
   implements
     PaymentTypes.IPaymentNetwork<
       TPaymentEventParameters | PaymentTypes.IDeclarativePaymentEventParameters
@@ -29,18 +23,13 @@ export abstract class ReferenceBasedDetector<
    * @param extensionType Example : ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA
    */
 
-  public constructor(
-    protected advancedLogic: AdvancedLogicTypes.IAdvancedLogic,
-    protected extension: ExtensionType,
-    protected extensionType: ExtensionTypes.ID,
-  ) {
-    super({ advancedLogic });
-    if (!TypesUtils.isPaymentNetworkId(extensionType)) {
+  public constructor(paymentNetworkId: PaymentTypes.PAYMENT_NETWORK_ID, extension: TExtension) {
+    super(paymentNetworkId, extension);
+    if (!TypesUtils.isPaymentNetworkId(paymentNetworkId)) {
       throw new Error(
-        `Cannot detect payment for extension type '${extensionType}', it is not a payment network ID.`,
+        `Cannot detect payment for extension type '${paymentNetworkId}', it is not a payment network ID.`,
       );
     }
-    this._paymentNetworkId = extensionType;
   }
 
   /**
@@ -105,14 +94,14 @@ export abstract class ReferenceBasedDetector<
       TPaymentEventParameters | PaymentTypes.IDeclarativePaymentEventParameters
     >
   > {
-    const paymentNetwork = request.extensions[this.extensionType];
+    const paymentNetwork = request.extensions[this._paymentNetworkId];
     const paymentChain = this.getPaymentChain(request.currency, paymentNetwork);
 
     const supportedNetworks = this.extension.supportedNetworks;
     if (!supportedNetworks.includes(paymentChain)) {
       return getBalanceErrorObject(
         `Payment network ${paymentChain} not supported by ${
-          this.extensionType
+          this._paymentNetworkId
         } payment detection. Supported networks: ${supportedNetworks.join(', ')}`,
         PaymentTypes.BALANCE_ERROR_CODE.NETWORK_NOT_SUPPORTED,
       );
@@ -120,7 +109,7 @@ export abstract class ReferenceBasedDetector<
 
     if (!paymentNetwork) {
       return getBalanceErrorObject(
-        `The request does not have the extension: ${this.extensionType}`,
+        `The request does not have the extension: ${this._paymentNetworkId}`,
         PaymentTypes.BALANCE_ERROR_CODE.WRONG_EXTENSION,
       );
     }

--- a/packages/payment-detection/test/declarative.test.ts
+++ b/packages/payment-detection/test/declarative.test.ts
@@ -6,9 +6,9 @@ import {
   RequestLogicTypes,
 } from '@requestnetwork/types';
 
-import Declarative from '../src/declarative';
+import { DeclarativePaymentDetector } from '../src/declarative';
 
-let declarative: Declarative;
+let declarative: DeclarativePaymentDetector;
 
 const mockAdvancedLogic: AdvancedLogicTypes.IAdvancedLogic = {
   applyActionToExtensions(): any {
@@ -64,7 +64,7 @@ const requestMock: RequestLogicTypes.IRequest = {
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 describe('api/declarative', () => {
   beforeEach(() => {
-    declarative = new Declarative({ advancedLogic: mockAdvancedLogic });
+    declarative = new DeclarativePaymentDetector({ advancedLogic: mockAdvancedLogic });
   });
 
   it('can createExtensionsDataForCreation', async () => {
@@ -171,7 +171,7 @@ describe('api/declarative', () => {
             amount: '1000',
             note: 'first payment',
             txHash: 'the-first-hash',
-            network: 'mainnet'
+            network: 'mainnet',
           },
           timestamp: 10,
         },
@@ -181,7 +181,7 @@ describe('api/declarative', () => {
             amount: '500',
             note: 'second payment',
             txHash: 'the-second-hash',
-            network: 'matic'
+            network: 'matic',
           },
           timestamp: 15,
         },
@@ -191,7 +191,7 @@ describe('api/declarative', () => {
             amount: '100',
             note: 'first refund',
             txHash: 'the-first-refund-hash',
-            network: 'mainnet'
+            network: 'mainnet',
           },
           timestamp: 20,
         },
@@ -201,7 +201,7 @@ describe('api/declarative', () => {
             amount: '200',
             note: 'second refund',
             txHash: 'the-second-refund-hash',
-            network: 'matic'
+            network: 'matic',
           },
           timestamp: 25,
         },
@@ -219,7 +219,7 @@ describe('api/declarative', () => {
           parameters: {
             note: 'first payment',
             txHash: 'the-first-hash',
-            network: 'mainnet'
+            network: 'mainnet',
           },
           timestamp: 10,
         },
@@ -229,7 +229,7 @@ describe('api/declarative', () => {
           parameters: {
             note: 'second payment',
             txHash: 'the-second-hash',
-            network: 'matic'
+            network: 'matic',
           },
           timestamp: 15,
         },
@@ -239,7 +239,7 @@ describe('api/declarative', () => {
           parameters: {
             note: 'first refund',
             txHash: 'the-first-refund-hash',
-            network: 'mainnet'
+            network: 'mainnet',
           },
           timestamp: 20,
         },
@@ -249,7 +249,7 @@ describe('api/declarative', () => {
           parameters: {
             note: 'second refund',
             txHash: 'the-second-refund-hash',
-            network: 'matic'
+            network: 'matic',
           },
           timestamp: 25,
         },

--- a/packages/payment-detection/test/payment-network-factory.test.ts
+++ b/packages/payment-detection/test/payment-network-factory.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@requestnetwork/types';
 import { CurrencyManager } from '@requestnetwork/currency';
 import BTCAddressedBased from '../src/btc/mainnet-address-based';
-import Declarative from '../src/declarative';
+import { DeclarativePaymentDetector } from '../src/declarative';
 import { EthInputDataPaymentDetector } from '../src/eth/input-data';
 
 import PaymentNetworkFactory from '../src/payment-network-factory';
@@ -65,7 +65,7 @@ describe('api/payment-network/payment-network-factory', () => {
           paymentNetworkCreationParameters,
           currencyManager,
         }),
-      ).toBeInstanceOf(Declarative);
+      ).toBeInstanceOf(DeclarativePaymentDetector);
     });
 
     it('cannot createPaymentNetwork with extension id not handled', async () => {
@@ -187,7 +187,7 @@ describe('api/payment-network/payment-network-factory', () => {
           request,
           currencyManager,
         }),
-      ).toBeInstanceOf(Declarative);
+      ).toBeInstanceOf(DeclarativePaymentDetector);
     });
 
     it('can pass options down to the paymentNetwork', async () => {

--- a/packages/request-client.js/src/api/request.ts
+++ b/packages/request-client.js/src/api/request.ts
@@ -371,8 +371,7 @@ export default class Request {
     }
 
     // We need to cast the object since IPaymentNetwork doesn't implement createExtensionsDataForDeclareSentPayment
-    const declarativePaymentNetwork: PaymentNetworkDeclarative = this
-      .paymentNetwork as PaymentNetworkDeclarative;
+    const declarativePaymentNetwork = this.paymentNetwork as DeclarativePaymentDetector;
 
     if (!declarativePaymentNetwork.createExtensionsDataForDeclareSentPayment) {
       throw new Error('Cannot declare sent payment without declarative payment network');
@@ -416,8 +415,7 @@ export default class Request {
     }
 
     // We need to cast the object since IPaymentNetwork doesn't implement createExtensionsDataForDeclareSentRefund
-    const declarativePaymentNetwork: PaymentNetworkDeclarative = this
-      .paymentNetwork as PaymentNetworkDeclarative;
+    const declarativePaymentNetwork = this.paymentNetwork as DeclarativePaymentDetector;
 
     if (!declarativePaymentNetwork.createExtensionsDataForDeclareSentRefund) {
       throw new Error('Cannot declare sent refund without declarative payment network');
@@ -468,8 +466,7 @@ export default class Request {
     }
 
     // We need to cast the object since IPaymentNetwork doesn't implement createExtensionsDataForDeclareReceivedPayment
-    const declarativePaymentNetwork: PaymentNetworkDeclarative = this
-      .paymentNetwork as PaymentNetworkDeclarative;
+    const declarativePaymentNetwork = this.paymentNetwork as DeclarativePaymentDetector;
 
     if (!declarativePaymentNetwork.createExtensionsDataForDeclareReceivedPayment) {
       throw new Error('Cannot declare received payment without declarative payment network');
@@ -522,8 +519,7 @@ export default class Request {
     }
 
     // We need to cast the object since IPaymentNetwork doesn't implement createExtensionsDataForDeclareReceivedRefund
-    const declarativePaymentNetwork: PaymentNetworkDeclarative = this
-      .paymentNetwork as PaymentNetworkDeclarative;
+    const declarativePaymentNetwork = this.paymentNetwork as DeclarativePaymentDetector;
 
     if (!declarativePaymentNetwork.createExtensionsDataForDeclareReceivedRefund) {
       throw new Error('Cannot declare received refund without declarative payment network');

--- a/packages/request-client.js/src/api/request.ts
+++ b/packages/request-client.js/src/api/request.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 
-import { DeclarativePaymentNetwork as PaymentNetworkDeclarative } from '@requestnetwork/payment-detection';
+import { DeclarativePaymentDetector } from '@requestnetwork/payment-detection';
 import { IdentityTypes, PaymentTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { ICurrencyManager } from '@requestnetwork/currency';
 import Utils from '@requestnetwork/utils';
@@ -563,15 +563,14 @@ export default class Request {
     delegate: IdentityTypes.IIdentity,
     signerIdentity: IdentityTypes.IIdentity,
   ): Promise<Types.IRequestDataWithEvents> {
-    const extensionsData: any[] = [];
+    const extensionsData: Types.Extension.IAction[] = [];
 
     if (!this.paymentNetwork) {
       throw new Error('Cannot declare delegate without payment network');
     }
 
     // We need to cast the object since IPaymentNetwork doesn't implement createExtensionsDataForDeclareReceivedRefund
-    const declarativePaymentNetwork: PaymentNetworkDeclarative = this
-      .paymentNetwork as PaymentNetworkDeclarative;
+    const declarativePaymentNetwork = this.paymentNetwork as DeclarativePaymentDetector;
 
     if (!declarativePaymentNetwork.createExtensionsDataForAddDelegate) {
       throw new Error('Cannot declare delegate without declarative payment network');


### PR DESCRIPTION
- naming: `DeclarativePaymentDetector` instead of various names
- harmonize usage of  `PaymentTypes.PAYMENT_NETWORK_ID`.
- enforce passing `PaymentTypes.PAYMENT_NETWORK_ID` and the extension as constructor params to avoid forgetting overriding this property in a child class. **This is the main motivation of this PR**. For this to work properly, I sometimes introduced a `-Base` class to keep the current class constructor signature and have a better extensibility