### PR TITLE
chore: Dockerfile.dev

### DIFF
--- a/packages/request-node/Dockerfile.dev
+++ b/packages/request-node/Dockerfile.dev
@@ -1,0 +1,16 @@
+FROM node:14-alpine
+
+## Warning! This Docker config is meant to be used for development and debugging, not in prod.
+## This is a simplified Dockerfile for a fast build
+## It expects that the monorepo is compiled (`yarn build:tsc` at the monorepo root)
+## And that the request-node is built with NCC: `npx @vercel/ncc build src/server.ts -o dist/ncc`
+
+WORKDIR /request-node
+COPY dist/ncc .
+
+# Port configuration
+ENV PORT 3000
+EXPOSE 3000
+
+# Run
+CMD ["node", "index.js"]

--- a/packages/request-node/README.md
+++ b/packages/request-node/README.md
@@ -311,6 +311,9 @@ docker-compose up
 
 The environment variables must be defined in the `docker-compose.yml` file in the `environment` section. `$ETHEREUM_NETWORK_ID` and `$WEB3_PROVIDER_URL` must be defined.
 
+#### Docker for unpublished version
+See instructions in [Dockerfile.dev](./Dockerfile.dev)
+
 ### Running fully locally
 
 To run a Request Node locally for tests, make sure you have the necessary IPFS and Ethereum nodes available.


### PR DESCRIPTION
It can be very useful to be able to rapidly build the Request Node with the latest build from all packages. 

I found this to be the best config, as it takes a few seconds to build the whole monorepo (typescript only) and the request-node with [NCC](https://github.com/vercel/ncc)