### PR TITLE
chore(payment-detection): disable TheGraph support for fantom

### DIFF
--- a/packages/payment-detection/src/thegraph/index.ts
+++ b/packages/payment-detection/src/thegraph/index.ts
@@ -31,9 +31,9 @@ export const getTheGraphClient = (
 
 // Note: temporary until TheGraph has been thoroughly tested
 export const networkSupportsTheGraph = (network: string): boolean => {
-  return !['mainnet', 'rinkeby', 'private'].includes(network);
+  return !['mainnet', 'rinkeby', 'private', 'fantom'].includes(network);
 };
 
 export const networkSupportsTheGraphForNativePayments = (network: string): boolean => {
-  return !['mainnet', 'private'].includes(network);
+  return !['mainnet', 'private', 'fantom'].includes(network);
 };


### PR DESCRIPTION
## Description of the changes

Our fantom's subgraph has a constant synchronization delay of ~100 to 500 blocks, which causes payment detection to be delayed by 10-15mins. This temporarily disables using TheGraph for payment detection until we fix the subgraph's delay.
