### PR TITLE
fix: tslib dependency in smart-contracts

### DIFF
--- a/packages/smart-contracts/package.json
+++ b/packages/smart-contracts/package.json
@@ -47,6 +47,9 @@
     "test": "yarn hardhat test --network private",
     "test:lib": "yarn jest test/lib"
   },
+  "dependencies": {
+    "tslib": "2.3.1"
+  },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "2.0.2",
     "@nomiclabs/hardhat-etherscan": "2.1.3",
@@ -68,7 +71,6 @@
     "hardhat": "2.4.1",
     "shx": "0.3.2",
     "solhint": "3.3.6",
-    "tslib": "2.3.1",
     "typechain": "5.1.1"
   }
 }


### PR DESCRIPTION
## Description of the changes
- The devDependency was breaking some `smart-contracts` imports like in `payments-subgraph`