### PR TITLE
ci: adjust jest maxWorkers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/smart-contracts run deploy'
       - run:
           name: 'Test request-client.js'
-          command: 'yarn workspace @requestnetwork/request-client.js run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/request-client.js run test --ci --maxWorkers=1'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -120,7 +120,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/data-access run build'
       - run:
           name: 'Test data-access'
-          command: 'yarn workspace @requestnetwork/data-access run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/data-access run test --ci --maxWorkers=1'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -137,7 +137,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/data-format run build'
       - run:
           name: 'Test data-format'
-          command: 'yarn workspace @requestnetwork/data-format run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/data-format run test --ci --maxWorkers=1'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -154,7 +154,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/transaction-manager run build'
       - run:
           name: 'Test transaction-manager'
-          command: 'yarn workspace @requestnetwork/transaction-manager run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/transaction-manager run test --ci --maxWorkers=1'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -176,7 +176,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/smart-contracts run deploy'
       - run:
           name: 'Test ethereum-storage'
-          command: 'yarn workspace @requestnetwork/ethereum-storage run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/ethereum-storage run test --ci --maxWorkers=1'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -200,7 +200,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/smart-contracts run test'
       - run:
           name: 'Test smart contracts utilities'
-          command: 'yarn workspace @requestnetwork/smart-contracts run test:lib --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/smart-contracts run test:lib --ci --maxWorkers=1'
   test-request-logic:
     docker:
       - *node_image
@@ -213,7 +213,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/request-logic run build'
       - run:
           name: 'Test request-logic'
-          command: 'yarn workspace @requestnetwork/request-logic run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/request-logic run test --ci --maxWorkers=1'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -230,7 +230,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/advanced-logic run build'
       - run:
           name: 'Test advanced-logic'
-          command: 'yarn workspace @requestnetwork/advanced-logic run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/advanced-logic run test --ci --maxWorkers=1'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -252,7 +252,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/smart-contracts run deploy'
       - run:
           name: 'Test request-node'
-          command: 'yarn workspace @requestnetwork/request-node run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/request-node run test --ci'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -266,7 +266,7 @@ jobs:
           at: *working_directory
       - run:
           name: 'Test utils'
-          command: 'yarn workspace @requestnetwork/utils run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/utils run test --ci --maxWorkers=1'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -280,7 +280,7 @@ jobs:
           at: *working_directory
       - run:
           name: 'Test currency'
-          command: 'yarn workspace @requestnetwork/currency run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/currency run test --ci --maxWorkers=1'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -297,7 +297,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/epk-signature run build'
       - run:
           name: 'Test epk-signature'
-          command: 'yarn workspace @requestnetwork/epk-signature run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/epk-signature run test --ci --maxWorkers=1'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -314,7 +314,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/epk-decryption run build'
       - run:
           name: 'Test epk-decryption'
-          command: 'yarn workspace @requestnetwork/epk-decryption run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/epk-decryption run test --ci --maxWorkers=1'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -331,7 +331,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/web3-signature run build'
       - run:
           name: 'Test web3-signature'
-          command: 'yarn workspace @requestnetwork/web3-signature run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/web3-signature run test --ci --maxWorkers=1'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -366,8 +366,11 @@ jobs:
             done
             echo Failed waiting for Node initialization && exit 1
       - run:
-          name: 'Test integration-test'
-          command: 'yarn workspace @requestnetwork/integration-test run test --ci --maxWorkers=2'
+          name: 'Test integration-test (node)'
+          command: 'yarn workspace @requestnetwork/integration-test run test:node --ci --maxWorkers=1'
+      - run:
+          name: 'Test integration-test (layers)'
+          command: 'yarn workspace @requestnetwork/integration-test run test:layers --ci --maxWorkers=1'
   # This test runs the node-client tests against a node backed by TheGraph data access
   test-graph-node:
     docker:
@@ -460,7 +463,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/multi-format run build'
       - run:
           name: 'Test multi-format'
-          command: 'yarn workspace @requestnetwork/multi-format run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/multi-format run test --ci --maxWorkers=1'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -481,7 +484,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/smart-contracts run deploy'
       - run:
           name: 'Test payment-detection'
-          command: 'yarn workspace @requestnetwork/payment-detection run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/payment-detection run test --ci'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -502,7 +505,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/smart-contracts run deploy'
       - run:
           name: 'Test payment-processor'
-          command: 'yarn workspace @requestnetwork/payment-processor run test --ci --maxWorkers=2'
+          command: 'yarn workspace @requestnetwork/payment-processor run test --ci'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -557,8 +560,11 @@ jobs:
             done
             echo Failed waiting for Node initialization && exit 1
       - run:
-          name: 'Test integration-test'
-          command: 'yarn workspace @requestnetwork/integration-test run test:scheduled'
+          name: 'Test integration-test (erc20)'
+          command: 'yarn workspace @requestnetwork/integration-test run test:erc20 --ci --maxWorkers=1'
+      - run:
+          name: 'Test integration-test (btc)'
+          command: 'yarn workspace @requestnetwork/integration-test run test:btc --ci --maxWorkers=1'
 
   # Release a next version package everytime we merge to master
   next-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/smart-contracts run deploy'
       - run:
           name: 'Test request-client.js'
-          command: 'yarn workspace @requestnetwork/request-client.js run test'
+          command: 'yarn workspace @requestnetwork/request-client.js run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -120,7 +120,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/data-access run build'
       - run:
           name: 'Test data-access'
-          command: 'yarn workspace @requestnetwork/data-access run test'
+          command: 'yarn workspace @requestnetwork/data-access run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -137,7 +137,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/data-format run build'
       - run:
           name: 'Test data-format'
-          command: 'yarn workspace @requestnetwork/data-format run test'
+          command: 'yarn workspace @requestnetwork/data-format run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -154,7 +154,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/transaction-manager run build'
       - run:
           name: 'Test transaction-manager'
-          command: 'yarn workspace @requestnetwork/transaction-manager run test'
+          command: 'yarn workspace @requestnetwork/transaction-manager run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -176,7 +176,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/smart-contracts run deploy'
       - run:
           name: 'Test ethereum-storage'
-          command: 'yarn workspace @requestnetwork/ethereum-storage run test'
+          command: 'yarn workspace @requestnetwork/ethereum-storage run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -200,7 +200,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/smart-contracts run test'
       - run:
           name: 'Test smart contracts utilities'
-          command: 'yarn workspace @requestnetwork/smart-contracts run test:lib'
+          command: 'yarn workspace @requestnetwork/smart-contracts run test:lib --ci --maxWorkers=2'
   test-request-logic:
     docker:
       - *node_image
@@ -213,7 +213,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/request-logic run build'
       - run:
           name: 'Test request-logic'
-          command: 'yarn workspace @requestnetwork/request-logic run test'
+          command: 'yarn workspace @requestnetwork/request-logic run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -230,7 +230,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/advanced-logic run build'
       - run:
           name: 'Test advanced-logic'
-          command: 'yarn workspace @requestnetwork/advanced-logic run test'
+          command: 'yarn workspace @requestnetwork/advanced-logic run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -252,7 +252,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/smart-contracts run deploy'
       - run:
           name: 'Test request-node'
-          command: 'yarn workspace @requestnetwork/request-node run test'
+          command: 'yarn workspace @requestnetwork/request-node run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -266,7 +266,7 @@ jobs:
           at: *working_directory
       - run:
           name: 'Test utils'
-          command: 'yarn workspace @requestnetwork/utils run test'
+          command: 'yarn workspace @requestnetwork/utils run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -280,7 +280,7 @@ jobs:
           at: *working_directory
       - run:
           name: 'Test currency'
-          command: 'yarn workspace @requestnetwork/currency run test'
+          command: 'yarn workspace @requestnetwork/currency run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -297,7 +297,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/epk-signature run build'
       - run:
           name: 'Test epk-signature'
-          command: 'yarn workspace @requestnetwork/epk-signature run test'
+          command: 'yarn workspace @requestnetwork/epk-signature run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -314,7 +314,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/epk-decryption run build'
       - run:
           name: 'Test epk-decryption'
-          command: 'yarn workspace @requestnetwork/epk-decryption run test'
+          command: 'yarn workspace @requestnetwork/epk-decryption run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -331,7 +331,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/web3-signature run build'
       - run:
           name: 'Test web3-signature'
-          command: 'yarn workspace @requestnetwork/web3-signature run test'
+          command: 'yarn workspace @requestnetwork/web3-signature run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -367,7 +367,7 @@ jobs:
             echo Failed waiting for Node initialization && exit 1
       - run:
           name: 'Test integration-test'
-          command: 'yarn workspace @requestnetwork/integration-test run test'
+          command: 'yarn workspace @requestnetwork/integration-test run test --ci --maxWorkers=2'
   # This test runs the node-client tests against a node backed by TheGraph data access
   test-graph-node:
     docker:
@@ -460,7 +460,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/multi-format run build'
       - run:
           name: 'Test multi-format'
-          command: 'yarn workspace @requestnetwork/multi-format run test'
+          command: 'yarn workspace @requestnetwork/multi-format run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -481,7 +481,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/smart-contracts run deploy'
       - run:
           name: 'Test payment-detection'
-          command: 'yarn workspace @requestnetwork/payment-detection run test'
+          command: 'yarn workspace @requestnetwork/payment-detection run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -502,7 +502,7 @@ jobs:
           command: 'yarn workspace @requestnetwork/smart-contracts run deploy'
       - run:
           name: 'Test payment-processor'
-          command: 'yarn workspace @requestnetwork/payment-processor run test'
+          command: 'yarn workspace @requestnetwork/payment-processor run test --ci --maxWorkers=2'
       - persist_to_workspace:
           root: *working_directory
           paths:

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -35,7 +35,7 @@
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
-    "test": "jest",
+    "test": "jest --forceExit",
     "test:watch": "yarn test --watch"
   },
   "dependencies": {


### PR DESCRIPTION
## Description of the changes

Adds `--maxWorkers=1` to test commands in CI to prevent Jest from spawning 31 workers on VMs with only 2vCPU, resulting in failing tests, like here: https://app.circleci.com/pipelines/github/RequestNetwork/requestNetwork/5348/workflows/c6e3c200-7b29-4afa-8756-6367e04310fa/jobs/86870/steps

`maxWorkers` should be set to amount of CPUs minus one for Jest's main thread, so `2-1=1` for CircleCI's medium Docker executor that has 2vCPU.

The reason it is spawning 31 workers is that CircleCI hosts have 32 (real) CPUs, making Jest think it is running on a 32 cores machines whereas it is running on a 2vCPU machine.

See: https://support.circleci.com/hc/en-us/articles/360005442714-Your-test-tools-are-smart-and-that-s-a-problem-Learn-about-when-optimization-goes-wrong-