### PR TITLE
test(data-access): remove forceExit option

### DIFF
--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -35,7 +35,7 @@
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
-    "test": "jest --forceExit",
+    "test": "jest",
     "test:watch": "yarn test --watch"
   },
   "dependencies": {

--- a/packages/data-access/src/data-access.ts
+++ b/packages/data-access/src/data-access.ts
@@ -169,7 +169,7 @@ export default class DataAccess implements DataAccessTypes.IDataAccess {
   }
 
   public async close(): Promise<void> {
-    this.stopAutoSynchronization();
+    await this.stopAutoSynchronization();
   }
 
   /**
@@ -468,9 +468,9 @@ export default class DataAccess implements DataAccessTypes.IDataAccess {
   /**
    * Stop to synchronize with the storage automatically
    */
-  public stopAutoSynchronization(): void {
+  public async stopAutoSynchronization(): Promise<void> {
     if (this.synchronizationTimer.isStarted) {
-      this.synchronizationTimer.stop();
+      await this.synchronizationTimer.stop();
     }
   }
 

--- a/packages/data-access/src/interval-timer.ts
+++ b/packages/data-access/src/interval-timer.ts
@@ -8,12 +8,12 @@ export default class IntervalTimer {
   // This value is used as we may not want to directly log an error if the interval function fails once
   public intervalFunctionSuccessiveFailureCount = 0;
 
-  private intervalFunction: () => Promise<void>;
-  private intervalTime: number;
+  private readonly intervalFunction: () => Promise<void>;
+  private readonly intervalTime: number;
+  private readonly logger: LogTypes.ILogger;
+  private readonly successiveFailureThreshold: number;
   private timeoutObject: NodeJS.Timeout | null = null;
   private lastRecursion: Promise<void> = Promise.resolve();
-  private logger: LogTypes.ILogger;
-  private successiveFailureThreshold: number;
 
   /**
    * Constructor IntervalTimer
@@ -77,8 +77,7 @@ export default class IntervalTimer {
 
     const createRecursion = () => {
       this.timeoutObject = setTimeout(() => {
-        const recursion = recursiveTimeoutFunction();
-        this.lastRecursion = recursion;
+        this.lastRecursion = recursiveTimeoutFunction();
       }, this.intervalTime);
     };
 
@@ -91,7 +90,7 @@ export default class IntervalTimer {
    */
   public async stop(): Promise<void> {
     if (!this.timeoutObject) {
-      throw Error(`Can't stop IntervalTimer if it has not been started`);
+      return Promise.reject("Can't stop IntervalTimer if it has not been started");
     }
 
     clearTimeout(this.timeoutObject);

--- a/packages/data-access/test/data-access.test.ts
+++ b/packages/data-access/test/data-access.test.ts
@@ -809,7 +809,7 @@ describe('data-access', () => {
     // Should have been called once after 2100ms
     expect(dataAccess.synchronizeNewDataIds).toHaveBeenCalledTimes(2);
 
-    dataAccess.stopAutoSynchronization();
+    await dataAccess.stopAutoSynchronization();
     jest.advanceTimersByTime(1000);
     await flushCallStack();
 
@@ -850,6 +850,6 @@ describe('data-access', () => {
 
     expect(fakeStorageSpied.getData).toHaveBeenNthCalledWith(2, { from: 501, to: 1000 });
 
-    dataAccess.stopAutoSynchronization();
+    await dataAccess.stopAutoSynchronization();
   });
 });

--- a/packages/data-access/test/interval-timer.test.ts
+++ b/packages/data-access/test/interval-timer.test.ts
@@ -62,13 +62,12 @@ describe('interval-timer', () => {
   it('should throw an error if started twice without stop() being called', async () => {
     intervalTimer.start();
     expect(() => intervalTimer.start()).toThrowError('IntervalTimer already started');
-
-    intervalTimer.stop();
+    await intervalTimer.stop();
   });
 
   it('should throw an error if stopped without start() being called', async () => {
-    expect(() => intervalTimer.stop()).toThrowError(
-      `Can't stop IntervalTimer if it has not been started`,
+    await expect(async () => await intervalTimer.stop()).rejects.toEqual(
+      "Can't stop IntervalTimer if it has not been started",
     );
   });
 
@@ -112,14 +111,15 @@ describe('interval-timer', () => {
 
     intervalTimer = new IntervalTimer(callback, 1000, emptyLogger);
     intervalTimer.start();
-
     expect(callback).toHaveBeenCalledTimes(0);
-    jest.advanceTimersByTime(1100);
+
+    // for fake timers to work with native Promise, we have to wrap the timer in a Promise, see:
+    // https://github.com/facebook/jest/issues/7151#issuecomment-622134853
+    await Promise.resolve().then(() => jest.advanceTimersByTime(1100));
     expect(callback).toHaveBeenCalledTimes(1);
 
-    intervalTimer.stop();
-
-    jest.advanceTimersByTime(1000); // 2100
+    await intervalTimer.stop();
+    await Promise.resolve().then(() => jest.advanceTimersByTime(1000)); // 2100
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
@@ -128,19 +128,19 @@ describe('interval-timer', () => {
 
     intervalTimer = new IntervalTimer(callback, 1000, emptyLogger);
     intervalTimer.start();
-
     expect(callback).toHaveBeenCalledTimes(0);
-    jest.advanceTimersByTime(1100);
+
+    // for fake timers to work with native Promise, we have to wrap the timer in a Promise, see:
+    // https://github.com/facebook/jest/issues/7151#issuecomment-622134853
+    await Promise.resolve().then(() => jest.advanceTimersByTime(1100));
     expect(callback).toHaveBeenCalledTimes(1);
 
-    intervalTimer.stop();
-
-    jest.advanceTimersByTime(1000); // 2100
+    await intervalTimer.stop();
+    await Promise.resolve().then(() => jest.advanceTimersByTime(1000)); // 2100
     expect(callback).toHaveBeenCalledTimes(1);
 
     intervalTimer.start();
-
-    jest.advanceTimersByTime(1000); // 3100
+    await Promise.resolve().then(() => jest.advanceTimersByTime(1100));
     expect(callback).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Description of the changes

The `--forceExit` option was added to `data-access` tests in https://github.com/RequestNetwork/requestNetwork/pull/735 because, when using only one worker, Jest does not close its process automatically if there is still open handles.

This PR fixes `data-access` so that the synchronization stop waits for the last recursion to finish.