### PR TITLE
fix: include env files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,12 @@
 # -----------------------
 
 # local environment variables
-/.env*
+.env
+.env.*
 
 # logs
-/lerna-debug.log
-/yarn-error.log
+lerna-debug.log
+yarn-error.log
 
 # dependencies
 /node_modules/


### PR DESCRIPTION
## Description of the changes

Fix mistake included in https://github.com/RequestNetwork/requestNetwork/commit/9504089c3edfb77b9084429d871a42b5f52b57b3 (https://github.com/RequestNetwork/requestNetwork/pull/732): rollback to ignoring `.env` files from our `packages` directories.