### PR TITLE
Revert "ci: use ram disk"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  working_directory: &working_directory /mnt/ramdisk/repo
+  working_directory: &working_directory ~/repo
   attach_workspace: &attach_workspace
   image_name: &image_name 'circleci/python:3.7'
   node_image: &node_image


### PR DESCRIPTION
Reverts RequestNetwork/requestNetwork#737 because `next-release` fails with an OOM error since then.