### PR TITLE
fix(contract): ETH conversion native hashes per chain

### DIFF
--- a/packages/advanced-logic/specs/payment-network-any-to-eth-proxy-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-any-to-eth-proxy-0.1.0.md
@@ -53,7 +53,7 @@ The `TransferWithConversionAndReference` event is emitted when the tokens are tr
 | ------- | ------------------------------------------ |
 | Mainnet | TODO                                       |
 | Rinkeby | 0xCa3353a15fCb5C83a1Ff64BFf055781aC5c4d2F4 |
-| Private | TODO                                       |
+| Private | 0x8273e4B8ED6c78e252a9fCa5563Adfcc75C91b2A |
 
 ## Properties
 

--- a/packages/advanced-logic/specs/payment-network-any-to-eth-proxy-0.1.0.md
+++ b/packages/advanced-logic/specs/payment-network-any-to-eth-proxy-0.1.0.md
@@ -53,7 +53,7 @@ The `TransferWithConversionAndReference` event is emitted when the tokens are tr
 | ------- | ------------------------------------------ |
 | Mainnet | TODO                                       |
 | Rinkeby | 0xCa3353a15fCb5C83a1Ff64BFf055781aC5c4d2F4 |
-| Private | 0x8273e4B8ED6c78e252a9fCa5563Adfcc75C91b2A |
+| Private | TODO                                       |
 
 ## Properties
 

--- a/packages/smart-contracts/scripts/3_deploy_chainlink_contract.ts
+++ b/packages/smart-contracts/scripts/3_deploy_chainlink_contract.ts
@@ -36,7 +36,7 @@ export default async function deploy(args: any, hre: HardhatRuntimeEnvironment) 
 
   const conversionPathInstance = await (
     await hre.ethers.getContractFactory('ChainlinkConversionPath', deployer)
-  ).deploy();
+  ).deploy(ETH_hash);
 
   // all these aggregators are for test purposes
   await conversionPathInstance.updateAggregatorsList(

--- a/packages/smart-contracts/scripts/utils.ts
+++ b/packages/smart-contracts/scripts/utils.ts
@@ -1,3 +1,5 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
 /**
  * List of contract addresses with the same interface as Uniswap V2 Router.
  * Used for SwapToPay and SwapToConvert.
@@ -18,4 +20,23 @@ export const uniswapV2RouterAddresses: Record<string, string> = {
   celo: '0x7D28570135A2B1930F331c507F65039D4937f66c',
   // No swap v2 found
   arbitrumtest: '0x0000000000000000000000000000000000000000',
+};
+
+/**
+ * Executes as many empty transactions as needed for the nonce goes up to a certain target.
+ * Assuming that the deployer is the first signer.
+ */
+export const jumpToNonce = async (args: any, hre: HardhatRuntimeEnvironment, nonce: number) => {
+  const [deployer] = await hre.ethers.getSigners();
+  if (args.simulate) {
+    const currentNonce = await deployer.getTransactionCount();
+    if (currentNonce < nonce) {
+      console.log(`Simulating a jump to nonce ${nonce} (current: ${currentNonce})`);
+    }
+    return;
+  }
+  while ((await deployer.getTransactionCount()) < nonce) {
+    // Atificially increase nonce if needed
+    await deployer.sendTransaction({ to: deployer.address });
+  }
 };

--- a/packages/smart-contracts/src/contracts/ChainlinkConversionPath.sol
+++ b/packages/smart-contracts/src/contracts/ChainlinkConversionPath.sol
@@ -21,7 +21,17 @@ interface AggregatorFraction {
  * @notice ChainlinkConversionPath is a contract computing currency conversion rates based on Chainlink aggretators
  */
 contract ChainlinkConversionPath is WhitelistAdminRole {
-    uint256 constant DECIMALS = 1e18;
+    uint256 constant PRECISION = 1e18;
+    uint256 constant NATIVE_TOKEN_DECIMALS = 18;
+    uint256 constant FIAT_DECIMALS = 8;
+    address public nativeTokenHash;
+
+    /**
+     * @param _nativeTokenHash hash of the native token
+     */
+    constructor(address _nativeTokenHash) {
+        nativeTokenHash = _nativeTokenHash;
+    }
 
     // Mapping of Chainlink aggregators (input currency => output currency => contract address)
     // input & output currencies are the addresses of the ERC20 contracts OR the sha3("currency code")
@@ -103,8 +113,8 @@ contract ChainlinkConversionPath is WhitelistAdminRole {
         )
     {
         // initialize the result with 18 decimals (for more precision)
-        rate = DECIMALS;
-        decimals = DECIMALS;
+        rate = PRECISION;
+        decimals = PRECISION;
         oldestRateTimestamp = block.timestamp;
 
         // For every conversion of the path
@@ -194,11 +204,11 @@ contract ChainlinkConversionPath is WhitelistAdminRole {
      * @return decimals number of decimals
      */
     function getDecimals(address _addr) private view returns (uint256 decimals) {
-        // by default we assume it is FIAT so 8 decimals
-        decimals = 8;
+        // by default we assume it is fiat
+        decimals = FIAT_DECIMALS;
         // if address is the hash of the ETH currency
-        if (_addr == address(0xF5AF88e117747e87fC5929F2ff87221B1447652E)) {
-            decimals = 18;
+        if (_addr == nativeTokenHash) {
+            decimals = NATIVE_TOKEN_DECIMALS;
         } else if (isContract(_addr)) {
             // otherwise, we get the decimals from the erc20 directly
             decimals = ERC20fraction(_addr).decimals();

--- a/packages/smart-contracts/src/contracts/ChainlinkConversionPath.sol
+++ b/packages/smart-contracts/src/contracts/ChainlinkConversionPath.sol
@@ -1,18 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "./legacy_openzeppelin/contracts/access/roles/WhitelistAdminRole.sol";
+import './legacy_openzeppelin/contracts/access/roles/WhitelistAdminRole.sol';
 
 interface ERC20fraction {
-  function decimals() external view returns (uint8);
+    function decimals() external view returns (uint8);
 }
 
 interface AggregatorFraction {
-  function decimals() external view returns (uint8);
-  function latestAnswer() external view returns (int256);
-  function latestTimestamp() external view returns (uint256);
-}
+    function decimals() external view returns (uint8);
 
+    function latestAnswer() external view returns (int256);
+
+    function latestTimestamp() external view returns (uint256);
+}
 
 /**
  * @title ChainlinkConversionPath
@@ -20,207 +21,201 @@ interface AggregatorFraction {
  * @notice ChainlinkConversionPath is a contract computing currency conversion rates based on Chainlink aggretators
  */
 contract ChainlinkConversionPath is WhitelistAdminRole {
-  uint constant DECIMALS = 1e18;
+    uint256 constant DECIMALS = 1e18;
 
-  // Mapping of Chainlink aggregators (input currency => output currency => contract address)
-  // input & output currencies are the addresses of the ERC20 contracts OR the sha3("currency code")
-  mapping(address => mapping(address => address)) public allAggregators;
+    // Mapping of Chainlink aggregators (input currency => output currency => contract address)
+    // input & output currencies are the addresses of the ERC20 contracts OR the sha3("currency code")
+    mapping(address => mapping(address => address)) public allAggregators;
 
-  // declare a new aggregator
-  event AggregatorUpdated(address _input, address _output, address _aggregator);
+    // declare a new aggregator
+    event AggregatorUpdated(address _input, address _output, address _aggregator);
 
-  /**
-    * @notice Update an aggregator
-    * @param _input address representing the input currency
-    * @param _output address representing the output currency
-    * @param _aggregator address of the aggregator contract
-  */
-  function updateAggregator(address _input, address _output, address _aggregator)
-    external
-    onlyWhitelistAdmin
-  {
-    allAggregators[_input][_output] = _aggregator;
-    emit AggregatorUpdated(_input, _output, _aggregator);
-  }
-
-  /**
-    * @notice Update a list of aggregators
-    * @param _inputs list of addresses representing the input currencies
-    * @param _outputs list of addresses representing the output currencies
-    * @param _aggregators list of addresses of the aggregator contracts
-  */
-  function updateAggregatorsList(
-    address[] calldata _inputs,
-    address[] calldata _outputs,
-    address[] calldata _aggregators
-  )
-    external
-    onlyWhitelistAdmin
-  {
-    require(_inputs.length == _outputs.length, "arrays must have the same length");
-    require(_inputs.length == _aggregators.length, "arrays must have the same length");
-
-    // For every conversions of the path
-    for (uint i; i < _inputs.length; i++) {
-      allAggregators[_inputs[i]][_outputs[i]] = _aggregators[i];
-      emit AggregatorUpdated(_inputs[i], _outputs[i], _aggregators[i]);
-    }
-  }
-
-  /**
-  * @notice Computes the conversion of an amount through a list of intermediate conversions
-  * @param _amountIn Amount to convert
-  * @param _path List of addresses representing the currencies for the intermediate conversions
-  * @return result The result after all the conversions
-  * @return oldestRateTimestamp The oldest timestamp of the path
-  */
-  function getConversion(
-    uint256 _amountIn,
-    address[] calldata _path
-  )
-    external
-    view
-    returns (uint256 result, uint256 oldestRateTimestamp)
-  {
-    (uint256 rate, uint256 timestamp, uint256 decimals) = getRate(_path);
-
-    // initialize the result
-    result = (_amountIn * rate) / decimals;
-
-    oldestRateTimestamp = timestamp;
-  }
-
-  /**
-  * @notice Computes the conversion rate from a list of currencies
-  * @param _path List of addresses representing the currencies for the conversions
-  * @return rate The rate
-  * @return oldestRateTimestamp The oldest timestamp of the path
-  * @return decimals of the conversion rate
-  */
-  function getRate(
-    address[] memory _path
-  )
-    public
-    view
-    returns (uint256 rate, uint256 oldestRateTimestamp, uint256 decimals)
-  {
-    // initialize the result with 18 decimals (for more precision)
-    rate = DECIMALS;
-    decimals = DECIMALS;
-    oldestRateTimestamp = block.timestamp;
-
-    // For every conversion of the path
-    for (uint i; i < _path.length - 1; i++) {
-      (
-        AggregatorFraction aggregator,
-        bool reverseAggregator,
-        uint256 decimalsInput,
-        uint256 decimalsOutput
-      ) = getAggregatorAndDecimals(_path[i], _path[i + 1]);
-
-      // store the latest timestamp of the path
-      uint256 currentTimestamp = aggregator.latestTimestamp();
-      if (currentTimestamp < oldestRateTimestamp) {
-        oldestRateTimestamp = currentTimestamp;
-      }
-
-      // get the rate of the current step
-      uint256 currentRate = uint256(aggregator.latestAnswer());
-      // get the number of decimals of the current rate
-      uint256 decimalsAggregator = uint256(aggregator.decimals());
-
-      // mul with the difference of decimals before the current rate computation (for more precision)
-      if (decimalsAggregator > decimalsInput) {
-        rate = rate * (10**(decimalsAggregator-decimalsInput));
-      }
-      if (decimalsAggregator < decimalsOutput) {
-        rate = rate * (10**(decimalsOutput-decimalsAggregator));
-      }
-
-      // Apply the current rate (if path uses an aggregator in the reverse way, div instead of mul)
-      if (reverseAggregator) {
-        rate = rate * (10**decimalsAggregator) / currentRate;
-      } else {
-        rate = rate * currentRate / (10**decimalsAggregator);
-      }
-
-      // div with the difference of decimals AFTER the current rate computation (for more precision)
-      if (decimalsAggregator < decimalsInput) {
-        rate = rate / (10**(decimalsInput-decimalsAggregator));
-      }
-      if (decimalsAggregator > decimalsOutput) {
-        rate = rate / (10**(decimalsAggregator-decimalsOutput));
-      }
-    }
-  }
-
-  /**
-  * @notice Gets aggregators and decimals of two currencies
-  * @param _input input Address
-  * @param _output output Address
-  * @return aggregator to get the rate between the two currencies
-  * @return reverseAggregator true if the aggregator returned give the rate from _output to _input
-  * @return decimalsInput decimals of _input
-  * @return decimalsOutput decimals of _output
-  */
-  function getAggregatorAndDecimals(address _input, address _output)
-    private
-    view
-    returns (AggregatorFraction aggregator, bool reverseAggregator, uint256 decimalsInput, uint256 decimalsOutput)
-  {
-    // Try to get the right aggregator for the conversion
-    aggregator = AggregatorFraction(allAggregators[_input][_output]);
-    reverseAggregator = false;
-
-    // if no aggregator found we try to find an aggregator in the reverse way
-    if (address(aggregator) == address(0x00)) {
-      aggregator = AggregatorFraction(allAggregators[_output][_input]);
-      reverseAggregator = true;
+    /**
+     * @notice Update an aggregator
+     * @param _input address representing the input currency
+     * @param _output address representing the output currency
+     * @param _aggregator address of the aggregator contract
+     */
+    function updateAggregator(
+        address _input,
+        address _output,
+        address _aggregator
+    ) external onlyWhitelistAdmin {
+        allAggregators[_input][_output] = _aggregator;
+        emit AggregatorUpdated(_input, _output, _aggregator);
     }
 
-    require(address(aggregator) != address(0x00), "No aggregator found");
+    /**
+     * @notice Update a list of aggregators
+     * @param _inputs list of addresses representing the input currencies
+     * @param _outputs list of addresses representing the output currencies
+     * @param _aggregators list of addresses of the aggregator contracts
+     */
+    function updateAggregatorsList(
+        address[] calldata _inputs,
+        address[] calldata _outputs,
+        address[] calldata _aggregators
+    ) external onlyWhitelistAdmin {
+        require(_inputs.length == _outputs.length, 'arrays must have the same length');
+        require(_inputs.length == _aggregators.length, 'arrays must have the same length');
 
-    // get the decimals for the two currencies
-    decimalsInput = getDecimals(_input);
-    decimalsOutput = getDecimals(_output);
-  }
-
-  /**
-  * @notice Gets decimals from an address currency
-  * @param _addr address to check
-  * @return decimals number of decimals
-  */
-  function getDecimals(address _addr)
-    private
-    view
-    returns (uint256 decimals)
-  {
-    // by default we assume it is FIAT so 8 decimals
-    decimals = 8;
-    // if address is the hash of the ETH currency
-    if (_addr == address(0xF5AF88e117747e87fC5929F2ff87221B1447652E)) {
-      decimals = 18;
-    } else if (isContract(_addr)) {
-      // otherwise, we get the decimals from the erc20 directly
-      decimals = ERC20fraction(_addr).decimals();
+        // For every conversions of the path
+        for (uint256 i; i < _inputs.length; i++) {
+            allAggregators[_inputs[i]][_outputs[i]] = _aggregators[i];
+            emit AggregatorUpdated(_inputs[i], _outputs[i], _aggregators[i]);
+        }
     }
-  }
 
-  /**
-  * @notice Checks if an address is a contract
-  * @param _addr Address to check
-  * @return true if the address hosts a contract, false otherwise
-  */
-  function isContract(address _addr)
-    private
-    view
-    returns (bool)
-  {
-    uint32 size;
-    // solium-disable security/no-inline-assembly
-    assembly {
-      size := extcodesize(_addr)
+    /**
+     * @notice Computes the conversion of an amount through a list of intermediate conversions
+     * @param _amountIn Amount to convert
+     * @param _path List of addresses representing the currencies for the intermediate conversions
+     * @return result The result after all the conversions
+     * @return oldestRateTimestamp The oldest timestamp of the path
+     */
+    function getConversion(uint256 _amountIn, address[] calldata _path)
+        external
+        view
+        returns (uint256 result, uint256 oldestRateTimestamp)
+    {
+        (uint256 rate, uint256 timestamp, uint256 decimals) = getRate(_path);
+
+        // initialize the result
+        result = (_amountIn * rate) / decimals;
+
+        oldestRateTimestamp = timestamp;
     }
-    return (size > 0);
-  }
+
+    /**
+     * @notice Computes the conversion rate from a list of currencies
+     * @param _path List of addresses representing the currencies for the conversions
+     * @return rate The rate
+     * @return oldestRateTimestamp The oldest timestamp of the path
+     * @return decimals of the conversion rate
+     */
+    function getRate(address[] memory _path)
+        public
+        view
+        returns (
+            uint256 rate,
+            uint256 oldestRateTimestamp,
+            uint256 decimals
+        )
+    {
+        // initialize the result with 18 decimals (for more precision)
+        rate = DECIMALS;
+        decimals = DECIMALS;
+        oldestRateTimestamp = block.timestamp;
+
+        // For every conversion of the path
+        for (uint256 i; i < _path.length - 1; i++) {
+            (
+                AggregatorFraction aggregator,
+                bool reverseAggregator,
+                uint256 decimalsInput,
+                uint256 decimalsOutput
+            ) = getAggregatorAndDecimals(_path[i], _path[i + 1]);
+
+            // store the latest timestamp of the path
+            uint256 currentTimestamp = aggregator.latestTimestamp();
+            if (currentTimestamp < oldestRateTimestamp) {
+                oldestRateTimestamp = currentTimestamp;
+            }
+
+            // get the rate of the current step
+            uint256 currentRate = uint256(aggregator.latestAnswer());
+            // get the number of decimals of the current rate
+            uint256 decimalsAggregator = uint256(aggregator.decimals());
+
+            // mul with the difference of decimals before the current rate computation (for more precision)
+            if (decimalsAggregator > decimalsInput) {
+                rate = rate * (10**(decimalsAggregator - decimalsInput));
+            }
+            if (decimalsAggregator < decimalsOutput) {
+                rate = rate * (10**(decimalsOutput - decimalsAggregator));
+            }
+
+            // Apply the current rate (if path uses an aggregator in the reverse way, div instead of mul)
+            if (reverseAggregator) {
+                rate = (rate * (10**decimalsAggregator)) / currentRate;
+            } else {
+                rate = (rate * currentRate) / (10**decimalsAggregator);
+            }
+
+            // div with the difference of decimals AFTER the current rate computation (for more precision)
+            if (decimalsAggregator < decimalsInput) {
+                rate = rate / (10**(decimalsInput - decimalsAggregator));
+            }
+            if (decimalsAggregator > decimalsOutput) {
+                rate = rate / (10**(decimalsAggregator - decimalsOutput));
+            }
+        }
+    }
+
+    /**
+     * @notice Gets aggregators and decimals of two currencies
+     * @param _input input Address
+     * @param _output output Address
+     * @return aggregator to get the rate between the two currencies
+     * @return reverseAggregator true if the aggregator returned give the rate from _output to _input
+     * @return decimalsInput decimals of _input
+     * @return decimalsOutput decimals of _output
+     */
+    function getAggregatorAndDecimals(address _input, address _output)
+        private
+        view
+        returns (
+            AggregatorFraction aggregator,
+            bool reverseAggregator,
+            uint256 decimalsInput,
+            uint256 decimalsOutput
+        )
+    {
+        // Try to get the right aggregator for the conversion
+        aggregator = AggregatorFraction(allAggregators[_input][_output]);
+        reverseAggregator = false;
+
+        // if no aggregator found we try to find an aggregator in the reverse way
+        if (address(aggregator) == address(0x00)) {
+            aggregator = AggregatorFraction(allAggregators[_output][_input]);
+            reverseAggregator = true;
+        }
+
+        require(address(aggregator) != address(0x00), 'No aggregator found');
+
+        // get the decimals for the two currencies
+        decimalsInput = getDecimals(_input);
+        decimalsOutput = getDecimals(_output);
+    }
+
+    /**
+     * @notice Gets decimals from an address currency
+     * @param _addr address to check
+     * @return decimals number of decimals
+     */
+    function getDecimals(address _addr) private view returns (uint256 decimals) {
+        // by default we assume it is FIAT so 8 decimals
+        decimals = 8;
+        // if address is the hash of the ETH currency
+        if (_addr == address(0xF5AF88e117747e87fC5929F2ff87221B1447652E)) {
+            decimals = 18;
+        } else if (isContract(_addr)) {
+            // otherwise, we get the decimals from the erc20 directly
+            decimals = ERC20fraction(_addr).decimals();
+        }
+    }
+
+    /**
+     * @notice Checks if an address is a contract
+     * @param _addr Address to check
+     * @return true if the address hosts a contract, false otherwise
+     */
+    function isContract(address _addr) private view returns (bool) {
+        uint32 size;
+        // solium-disable security/no-inline-assembly
+        assembly {
+            size := extcodesize(_addr)
+        }
+        return (size > 0);
+    }
 }

--- a/packages/smart-contracts/src/contracts/EthConversionProxy.sol
+++ b/packages/smart-contracts/src/contracts/EthConversionProxy.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import './ChainlinkConversionPath.sol';
 import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
+import './legacy_openzeppelin/contracts/access/roles/WhitelistAdminRole.sol';
 
 /**
  * @title EthConversionProxy
@@ -11,7 +12,7 @@ import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
  *         The inheritance from ReentrancyGuard is required to perform
  *         "transferExactEthWithReferenceAndFee" on the eth-fee-proxy contract
  */
-contract EthConversionProxy is ReentrancyGuard {
+contract EthConversionProxy is ReentrancyGuard, WhitelistAdminRole {
     address public paymentProxy;
     ChainlinkConversionPath public chainlinkConversionPath;
     address public nativeTokenHash;
@@ -119,5 +120,16 @@ contract EthConversionProxy is ReentrancyGuard {
         // Get the amount to pay in the native token
         amountToPay = (_requestAmount * rate) / decimals;
         amountToPayInFees = (_feeAmount * rate) / decimals;
+    }
+
+    /**
+     * @notice Update the conversion path contract address
+     * @param _chainlinkConversionPathAddress address of the conversion path contract
+     */
+    function updateConversionPathAddress(address _chainlinkConversionPathAddress)
+        external
+        onlyWhitelistAdmin
+    {
+        chainlinkConversionPath = ChainlinkConversionPath(_chainlinkConversionPathAddress);
     }
 }

--- a/packages/smart-contracts/src/contracts/EthConversionProxy.sol
+++ b/packages/smart-contracts/src/contracts/EthConversionProxy.sol
@@ -123,7 +123,7 @@ contract EthConversionProxy is ReentrancyGuard, WhitelistAdminRole {
     }
 
     /**
-     * @notice Update the conversion path contract address
+     * @notice Update the conversion path contract used to fetch conversions
      * @param _chainlinkConversionPathAddress address of the conversion path contract
      */
     function updateConversionPathAddress(address _chainlinkConversionPathAddress)
@@ -131,5 +131,16 @@ contract EthConversionProxy is ReentrancyGuard, WhitelistAdminRole {
         onlyWhitelistAdmin
     {
         chainlinkConversionPath = ChainlinkConversionPath(_chainlinkConversionPathAddress);
+    }
+
+    /**
+     * @notice Update the conversion proxy used to process the payment
+     * @param _paymentProxyAddress address of the ETH conversion proxy
+     */
+    function updateConversionProxyAddress(address _paymentProxyAddress)
+        external
+        onlyWhitelistAdmin
+    {
+        paymentProxy = _paymentProxyAddress;
     }
 }

--- a/packages/smart-contracts/src/lib/artifacts/ChainlinkConversionPath/0.2.0.json
+++ b/packages/smart-contracts/src/lib/artifacts/ChainlinkConversionPath/0.2.0.json
@@ -1,0 +1,246 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_nativeTokenHash",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_input",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_output",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_aggregator",
+          "type": "address"
+        }
+      ],
+      "name": "AggregatorUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "WhitelistAdminAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "WhitelistAdminRemoved",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "addWhitelistAdmin",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "allAggregators",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_path",
+          "type": "address[]"
+        }
+      ],
+      "name": "getConversion",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "result",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "oldestRateTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "_path",
+          "type": "address[]"
+        }
+      ],
+      "name": "getRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "rate",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "oldestRateTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "decimals",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "isWhitelistAdmin",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "nativeTokenHash",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceWhitelistAdmin",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_input",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_output",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_aggregator",
+          "type": "address"
+        }
+      ],
+      "name": "updateAggregator",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "_inputs",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_outputs",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_aggregators",
+          "type": "address[]"
+        }
+      ],
+      "name": "updateAggregatorsList",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}

--- a/packages/smart-contracts/src/lib/artifacts/ChainlinkConversionPath/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/ChainlinkConversionPath/index.ts
@@ -1,6 +1,7 @@
 import { ContractArtifact } from '../../ContractArtifact';
 
 import { abi as ABI_0_1_0 } from './0.1.0.json';
+import { abi as ABI_0_2_0 } from './0.2.0.json';
 // @ts-ignore Cannot find module
 import type { ChainlinkConversionPath } from '../../../types/ChainlinkConversionPath';
 
@@ -51,6 +52,15 @@ export const chainlinkConversionPath = new ContractArtifact<ChainlinkConversionP
         },
       },
     },
+    '0.2.0': {
+      abi: ABI_0_2_0,
+      deployment: {
+        private: {
+          address: '0x4e71920b7330515faf5EA0c690f1aD06a85fB60c',
+          creationBlockNumber: 0,
+        },
+      },
+    },
   },
   // Additional deployments of same versions, not worth upgrading the version number but worth using within next versions
   /*
@@ -64,5 +74,5 @@ export const chainlinkConversionPath = new ContractArtifact<ChainlinkConversionP
     },
   },
   */
-  '0.1.0',
+  '0.2.0',
 );

--- a/packages/smart-contracts/src/lib/artifacts/EthConversionProxy/0.2.0.json
+++ b/packages/smart-contracts/src/lib/artifacts/EthConversionProxy/0.2.0.json
@@ -1,0 +1,272 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_paymentProxyAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_chainlinkConversionPathAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_nativeTokenHash",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "currency",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes",
+          "name": "paymentReference",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "feeAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "maxRateTimespan",
+          "type": "uint256"
+        }
+      ],
+      "name": "TransferWithConversionAndReference",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes",
+          "name": "paymentReference",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "feeAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "feeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "TransferWithReferenceAndFee",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "WhitelistAdminAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "WhitelistAdminRemoved",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "addWhitelistAdmin",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "chainlinkConversionPath",
+      "outputs": [
+        {
+          "internalType": "contract ChainlinkConversionPath",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "isWhitelistAdmin",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "nativeTokenHash",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "paymentProxy",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceWhitelistAdmin",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_requestAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_paymentReference",
+          "type": "bytes"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_feeAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_feeAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_maxRateTimespan",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferWithReferenceAndFee",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_chainlinkConversionPathAddress",
+          "type": "address"
+        }
+      ],
+      "name": "updateConversionPathAddress",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_paymentProxyAddress",
+          "type": "address"
+        }
+      ],
+      "name": "updateConversionProxyAddress",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}

--- a/packages/smart-contracts/src/lib/artifacts/EthConversionProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/EthConversionProxy/index.ts
@@ -1,6 +1,7 @@
 import { ContractArtifact } from '../../ContractArtifact';
 
 import { abi as ABI_0_1_0 } from './0.1.0.json';
+import { abi as ABI_0_2_0 } from './0.2.0.json';
 // @ts-ignore Cannot find module
 import type { EthConversionProxy } from '../../../types/EthConversionProxy';
 
@@ -35,6 +36,15 @@ export const ethConversionArtifact = new ContractArtifact<EthConversionProxy>(
         },
       },
     },
+    '0.2.0': {
+      abi: ABI_0_2_0,
+      deployment: {
+        private: {
+          address: '0x8273e4B8ED6c78e252a9fCa5563Adfcc75C91b2A',
+          creationBlockNumber: 0,
+        },
+      },
+    },
   },
-  '0.1.0',
+  '0.2.0',
 );


### PR DESCRIPTION
## Description of the changes

ChainlinkConversionPath v0.2.0
- Configure the native token hash in the constructor of Chainlink conversion path

ETHConversionProxy v0.2.0
- Whitelisted admins can edit the conversion path contract
- Whitelisted admins can edit the proxy contract

Live payment script:
- nonce 10: ChainlinkConversionPath v0.2.0
- nonce 11: ETHConversionProxy v0.2.0