### PR TITLE
fix: arbitrum-testnet-naming

### DIFF
--- a/packages/smart-contracts/src/lib/artifacts/ChainlinkConversionPath/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/ChainlinkConversionPath/index.ts
@@ -46,7 +46,7 @@ export const chainlinkConversionPath = new ContractArtifact<ChainlinkConversionP
           address: '0xEEc4790306C43DC00cebbE4D0c36Fadf8634B533',
           creationBlockNumber: 10141032,
         },
-        'arbitrum-testnet': {
+        'arbitrum-rinkeby': {
           address: '0xEEc4790306C43DC00cebbE4D0c36Fadf8634B533',
           creationBlockNumber: 8403926,
         },

--- a/packages/smart-contracts/src/lib/artifacts/ERC20FeeProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/ERC20FeeProxy/index.ts
@@ -100,7 +100,7 @@ export const erc20FeeProxyArtifact = new ContractArtifact<ERC20FeeProxy>(
           address: '0x0DfbEe143b42B41eFC5A6F87bFD1fFC78c2f0aC9',
           creationBlockNumber: 20060722,
         },
-        'arbitrum-testnet': {
+        'arbitrum-rinkeby': {
           address: '0x0DfbEe143b42B41eFC5A6F87bFD1fFC78c2f0aC9',
           creationBlockNumber: 8403921,
         },

--- a/packages/smart-contracts/src/lib/artifacts/Erc20ConversionProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/Erc20ConversionProxy/index.ts
@@ -45,7 +45,7 @@ export const erc20ConversionProxy = new ContractArtifact<Erc20ConversionProxy>(
           address: '0xf0f49873C50765239F6f9534Ba13c4fe16eD5f2E',
           creationBlockNumber: 10141033,
         },
-        'arbitrum-testnet': {
+        'arbitrum-rinkeby': {
           address: '0xf0f49873C50765239F6f9534Ba13c4fe16eD5f2E',
           creationBlockNumber: 8403930,
         },

--- a/packages/smart-contracts/src/lib/artifacts/EthereumFeeProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/EthereumFeeProxy/index.ts
@@ -33,7 +33,7 @@ export const ethereumFeeProxyArtifact = new ContractArtifact<EthereumFeeProxy>(
           address: '0xC6E23a20C0a1933ACC8E30247B5D1e2215796C1F',
           creationBlockNumber: 13764157,
         },
-        'arbitrum-testnet': {
+        'arbitrum-rinkeby': {
           address: '0xC6E23a20C0a1933ACC8E30247B5D1e2215796C1F',
           creationBlockNumber: 8403946,
         },

--- a/packages/smart-contracts/src/lib/artifacts/EthereumProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/EthereumProxy/index.ts
@@ -78,7 +78,7 @@ export const ethereumProxyArtifact = new ContractArtifact<EthereumProxy>(
           address: '0x27c60BE17e853c47A9F1d280B05365f483c2dFAF',
           creationBlockNumber: 10141029,
         },
-        'arbitrum-testnet': {
+        'arbitrum-rinkeby': {
           address: '0x27c60BE17e853c47A9F1d280B05365f483c2dFAF',
           creationBlockNumber: 8403917,
         },


### PR DESCRIPTION
Change name from arbitrum-testnet to arbitrum-rinkeby for subgraph compatibility