### PR TITLE
fix: deployment script with ERC20Conversion v2 and Swap

### DIFF
--- a/packages/smart-contracts/hardhat.config.ts
+++ b/packages/smart-contracts/hardhat.config.ts
@@ -117,6 +117,10 @@ const setExplorerApiKey = (hre: HardhatRuntimeEnvironment) => {
       hre.config.etherscan.apiKey = process.env.FTMSCAN_API_KEY;
       return;
     }
+    case 'arbitrum-one': {
+      hre.config.etherscan.apiKey = process.env.ARBISCAN_API_KEY;
+      return;
+    }
   }
 };
 

--- a/packages/smart-contracts/scripts/3_deploy_chainlink_contract.ts
+++ b/packages/smart-contracts/scripts/3_deploy_chainlink_contract.ts
@@ -70,6 +70,7 @@ export default async function deploy(
       ...args,
       conversionProxyAddress: erc20ConversionAddress,
       swapProxyAddress: localSwapRouterAddress,
+      chainlinkConversionPathAddress: conversionPathInstance.address,
     },
     hre,
   );

--- a/packages/smart-contracts/scripts/conversion-proxy.ts
+++ b/packages/smart-contracts/scripts/conversion-proxy.ts
@@ -1,4 +1,7 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
+// eslint-disable-next-line
+// @ts-ignore Cannot find module
+import { Erc20ConversionProxy } from '../src/types/Erc20ConversionProxy';
 import {
   erc20ConversionProxy as erc20ConversionProxyArtifact,
   ethConversionArtifact,
@@ -6,7 +9,6 @@ import {
 import { deployOne } from './deploy-one';
 import { CurrencyManager } from '@requestnetwork/currency';
 import { RequestLogicTypes } from '@requestnetwork/types';
-import { Erc20ConversionProxy } from 'smart-contracts/src/types';
 
 export async function deployERC20ConversionProxy(
   args: {

--- a/packages/smart-contracts/scripts/conversion-proxy.ts
+++ b/packages/smart-contracts/scripts/conversion-proxy.ts
@@ -3,9 +3,10 @@ import {
   erc20ConversionProxy as erc20ConversionProxyArtifact,
   ethConversionArtifact,
 } from '../src/lib';
-import { DeploymentResult, deployOne } from './deploy-one';
+import { deployOne } from './deploy-one';
 import { CurrencyManager } from '@requestnetwork/currency';
 import { RequestLogicTypes } from '@requestnetwork/types';
+import { Erc20ConversionProxy } from 'smart-contracts/src/types';
 
 export async function deployERC20ConversionProxy(
   args: {
@@ -14,7 +15,7 @@ export async function deployERC20ConversionProxy(
     nonceCondition?: number;
   },
   hre: HardhatRuntimeEnvironment,
-): Promise<DeploymentResult | undefined> {
+) {
   const contractName = 'Erc20ConversionProxy';
 
   if (!args.chainlinkConversionPathAddress) {
@@ -30,7 +31,7 @@ export async function deployERC20ConversionProxy(
     return undefined;
   }
 
-  return deployOne(args, hre, contractName, {
+  return deployOne<Erc20ConversionProxy>(args, hre, contractName, {
     constructorArguments: [args.erc20FeeProxyAddress, args.chainlinkConversionPathAddress],
     artifact: erc20ConversionProxyArtifact,
     nonceCondition: args.nonceCondition,
@@ -42,6 +43,7 @@ export async function deployETHConversionProxy(
   args: {
     chainlinkConversionPathAddress?: string;
     ethFeeProxyAddress?: string;
+    nonceCondition?: number;
   },
   hre: HardhatRuntimeEnvironment,
 ) {
@@ -80,5 +82,6 @@ export async function deployETHConversionProxy(
       nativeTokenHash,
     ],
     artifact: ethConversionArtifact,
+    nonceCondition: args.nonceCondition,
   });
 }

--- a/packages/smart-contracts/scripts/conversion-proxy.ts
+++ b/packages/smart-contracts/scripts/conversion-proxy.ts
@@ -8,7 +8,11 @@ import { CurrencyManager } from '@requestnetwork/currency';
 import { RequestLogicTypes } from '@requestnetwork/types';
 
 export async function deployERC20ConversionProxy(
-  args: { chainlinkConversionPathAddress?: string; erc20FeeProxyAddress?: string },
+  args: {
+    chainlinkConversionPathAddress?: string;
+    erc20FeeProxyAddress?: string;
+    nonceCondition?: number;
+  },
   hre: HardhatRuntimeEnvironment,
 ): Promise<DeploymentResult | undefined> {
   const contractName = 'Erc20ConversionProxy';
@@ -29,6 +33,8 @@ export async function deployERC20ConversionProxy(
   return deployOne(args, hre, contractName, {
     constructorArguments: [args.erc20FeeProxyAddress, args.chainlinkConversionPathAddress],
     artifact: erc20ConversionProxyArtifact,
+    nonceCondition: args.nonceCondition,
+    version: '0.1.1',
   });
 }
 

--- a/packages/smart-contracts/scripts/deploy-one.ts
+++ b/packages/smart-contracts/scripts/deploy-one.ts
@@ -34,6 +34,7 @@ const SKIPPED_DEPLOYMENT: DeploymentResult<unknown> = {
  * @options
  *  - options.verify: set false to prevent verification on live networks
  *  - options.nonceCondition: only proceeds with the deployment if the nonce matches
+ *  - options.version: to deploy or map a version different from the last version
  * @returns a deployment result with address =
  *  - The address if the contract is deployed or attached
  *  - 'simulated' if args.simulate === true (no deployment/)
@@ -48,6 +49,7 @@ export async function deployOne<TContract extends Contract>(
     artifact?: ContractArtifact<Contract>;
     verify?: boolean;
     nonceCondition?: number;
+    version?: string;
   },
 ): Promise<DeploymentResult<TContract>> {
   const [deployer] = await hre.ethers.getSigners();
@@ -56,9 +58,13 @@ export async function deployOne<TContract extends Contract>(
   const constructorArguments = options?.constructorArguments ?? [];
   if (options?.artifact) {
     try {
-      address = options.artifact.getAddress(hre.network.name);
+      address = options.artifact.getAddress(hre.network.name, options.version);
       const action = args.force ? '(forcing deployment)' : '(skipping)';
-      console.log(`Found ${contractName} on ${hre.network.name} at address: ${address} ${action}`);
+      console.log(
+        `Found ${contractName}${options.version ? ` v${options.version}` : ''} on ${
+          hre.network.name
+        } at address: ${address} ${action}`,
+      );
       if (!args.force) {
         return {
           address,

--- a/packages/smart-contracts/scripts/deploy-payments.ts
+++ b/packages/smart-contracts/scripts/deploy-payments.ts
@@ -16,9 +16,11 @@ import { Contract } from 'ethers';
 // eslint-disable-next-line
 // @ts-ignore Cannot find module
 import { ChainlinkConversionPath } from '../src/types/ChainlinkConversionPath';
+// eslint-disable-next-line
+// @ts-ignore Cannot find module
+import { ERC20SwapToConversion } from '../src/types/ERC20SwapToConversion';
 import { CurrencyManager } from '@requestnetwork/currency';
 import { RequestLogicTypes } from '@requestnetwork/types';
-import { ERC20SwapToConversion } from 'smart-contracts/src/types';
 
 /**
  * Script ensuring all payment contracts are deployed and usable on a live chain.

--- a/packages/smart-contracts/scripts/deploy-payments.ts
+++ b/packages/smart-contracts/scripts/deploy-payments.ts
@@ -195,7 +195,7 @@ export async function deployAllPaymentContracts(
       erc20FeeProxyAddress: string,
       erc20SwapConversionInstance: ERC20SwapToConversion,
     ) => {
-      const NONCE_BATCH_5 = 12;
+      const NONCE_BATCH_5 = 13;
       let chainlinkConversionPathAddress = chainlinkInstance?.address;
       if (!chainlinkConversionPathAddress) {
         switchToSimulation();
@@ -294,7 +294,7 @@ export async function deployAllPaymentContracts(
     if (!swapRouterAddress) {
       logDeploymentMsg(
         'ERC20SwapToConversion:',
-        '(swap set to 0x000..000 - can be administrated by deployer)',
+        '(swap and chainlinkPath set to 0x000..000 - can be administrated by deployer)',
       );
       swapRouterAddress = '0x0000000000000000000000000000000000000000';
     }
@@ -303,6 +303,7 @@ export async function deployAllPaymentContracts(
       {
         ...args,
         conversionProxyAddress: '0x0000000000000000000000000000000000000000',
+        chainlinkConversionPathAddress: '0x0000000000000000000000000000000000000000',
         swapProxyAddress: swapRouterAddress,
         nonceCondition: 6,
       },

--- a/packages/smart-contracts/scripts/deploy-payments.ts
+++ b/packages/smart-contracts/scripts/deploy-payments.ts
@@ -117,12 +117,12 @@ export async function deployAllPaymentContracts(
         );
         swapRouterAddress = '0x0000000000000000000000000000000000000000';
       }
-      const swapRouterAddressResult = await deployOne(args, hre, 'ERC20SwapToPay', {
+      const swapToPayResult = await deployOne(args, hre, 'ERC20SwapToPay', {
         constructorArguments: [swapRouterAddress, erc20FeeProxyAddress],
         artifact: erc20SwapToPayArtifact,
         nonceCondition: nonceForBatch2,
       });
-      deploymentResults.push(swapRouterAddressResult);
+      deploymentResults.push(swapToPayResult);
       return deploymentResults;
     };
 

--- a/packages/smart-contracts/scripts/erc20-swap-to-conversion.ts
+++ b/packages/smart-contracts/scripts/erc20-swap-to-conversion.ts
@@ -1,5 +1,7 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { ERC20SwapToConversion } from 'smart-contracts/src/types';
+// eslint-disable-next-line
+// @ts-ignore Cannot find module
+import { ERC20SwapToConversion } from '../src/types/ERC20SwapToConversion';
 import { erc20SwapConversionArtifact } from '../src/lib';
 import { deployOne } from './deploy-one';
 import { uniswapV2RouterAddresses } from './utils';

--- a/packages/smart-contracts/scripts/erc20-swap-to-conversion.ts
+++ b/packages/smart-contracts/scripts/erc20-swap-to-conversion.ts
@@ -6,7 +6,7 @@ import { uniswapV2RouterAddresses } from './utils';
 const contractName = 'ERC20SwapToConversion';
 
 export async function deploySwapConversion(
-  args: { conversionProxyAddress?: string; swapProxyAddress?: string },
+  args: { conversionProxyAddress?: string; swapProxyAddress?: string; nonceCondition?: number },
   hre: HardhatRuntimeEnvironment,
 ) {
   if (!args.conversionProxyAddress) {
@@ -24,6 +24,7 @@ export async function deploySwapConversion(
       args.conversionProxyAddress,
     ],
     artifact: erc20SwapConversionArtifact,
+    nonceCondition: args.nonceCondition,
   });
 
   return deployment;

--- a/packages/smart-contracts/scripts/erc20-swap-to-conversion.ts
+++ b/packages/smart-contracts/scripts/erc20-swap-to-conversion.ts
@@ -1,4 +1,5 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { ERC20SwapToConversion } from 'smart-contracts/src/types';
 import { erc20SwapConversionArtifact } from '../src/lib';
 import { deployOne } from './deploy-one';
 import { uniswapV2RouterAddresses } from './utils';
@@ -18,7 +19,7 @@ export async function deploySwapConversion(
   if (!uniswapV2RouterAddresses[hre.network.name] && !args.swapProxyAddress) {
     console.error(`Missing swap router, cannot deploy ${contractName}.`);
   }
-  const deployment = await deployOne(args, hre, contractName, {
+  const deployment = await deployOne<ERC20SwapToConversion>(args, hre, contractName, {
     constructorArguments: [
       uniswapV2RouterAddresses[hre.network.name] ?? args.swapProxyAddress,
       args.conversionProxyAddress,

--- a/packages/smart-contracts/scripts/erc20-swap-to-conversion.ts
+++ b/packages/smart-contracts/scripts/erc20-swap-to-conversion.ts
@@ -9,7 +9,12 @@ import { uniswapV2RouterAddresses } from './utils';
 const contractName = 'ERC20SwapToConversion';
 
 export async function deploySwapConversion(
-  args: { conversionProxyAddress?: string; swapProxyAddress?: string; nonceCondition?: number },
+  args: {
+    conversionProxyAddress?: string;
+    swapProxyAddress?: string;
+    chainlinkConversionPathAddress: string;
+    nonceCondition?: number;
+  },
   hre: HardhatRuntimeEnvironment,
 ) {
   if (!args.conversionProxyAddress) {
@@ -25,6 +30,7 @@ export async function deploySwapConversion(
     constructorArguments: [
       uniswapV2RouterAddresses[hre.network.name] ?? args.swapProxyAddress,
       args.conversionProxyAddress,
+      args.chainlinkConversionPathAddress,
     ],
     artifact: erc20SwapConversionArtifact,
     nonceCondition: args.nonceCondition,

--- a/packages/smart-contracts/scripts/utils.ts
+++ b/packages/smart-contracts/scripts/utils.ts
@@ -19,7 +19,8 @@ export const uniswapV2RouterAddresses: Record<string, string> = {
   // https://app.ubeswap.org/#/swap
   celo: '0x7D28570135A2B1930F331c507F65039D4937f66c',
   // No swap v2 found
-  arbitrumtest: '0x0000000000000000000000000000000000000000',
+  'arbitrum-rinkeby': '0x0000000000000000000000000000000000000000',
+  'arbitrum-one': '0x0000000000000000000000000000000000000000',
 };
 
 /**

--- a/packages/smart-contracts/src/contracts/ERC20SwapToConversion.sol
+++ b/packages/smart-contracts/src/contracts/ERC20SwapToConversion.sol
@@ -30,10 +30,10 @@ contract ERC20SwapToConversion is Ownable {
   Erc20ConversionProxy public paymentProxy;
   ChainlinkConversionPath public chainlinkConversionPath;
 
-  constructor(address _swapRouterAddress, address _paymentProxyAddress) {
+  constructor(address _swapRouterAddress, address _paymentProxyAddress, address _chainlinkConversionPath) {
     swapRouter = IUniswapV2Router02(_swapRouterAddress);
     paymentProxy = Erc20ConversionProxy(_paymentProxyAddress);
-    chainlinkConversionPath = ChainlinkConversionPath(paymentProxy.chainlinkConversionPath());
+    chainlinkConversionPath = ChainlinkConversionPath(_chainlinkConversionPath);
   }
 
   /**

--- a/packages/smart-contracts/src/contracts/Erc20ConversionProxy.sol
+++ b/packages/smart-contracts/src/contracts/Erc20ConversionProxy.sol
@@ -39,7 +39,7 @@ contract Erc20ConversionProxy is Ownable {
     );
 
     /**
-     * @notice Performs an ERC20 token transfer with a reference computing the payment amount based on the request amount
+     * @notice Transfers ERC20 tokens with a reference with amount based on the request amount in fiat
      * @param _to Transfer recipient of the payement
      * @param _requestAmount Request amount
      * @param _path Conversion path

--- a/packages/smart-contracts/src/contracts/Erc20ConversionProxy.sol
+++ b/packages/smart-contracts/src/contracts/Erc20ConversionProxy.sol
@@ -1,123 +1,138 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "./ChainlinkConversionPath.sol";
-import "./interfaces/ERC20FeeProxy.sol";
-
+import './ChainlinkConversionPath.sol';
+import './interfaces/ERC20FeeProxy.sol';
+import '@openzeppelin/contracts/access/Ownable.sol';
 
 /**
  * @title Erc20ConversionProxy
  * @notice This contract convert from chainlink then swaps ERC20 tokens
  *         before paying a request thanks to a conversion payment proxy
-  */
-contract Erc20ConversionProxy {
-  address public paymentProxy;
-  ChainlinkConversionPath public chainlinkConversionPath;
+ */
+contract Erc20ConversionProxy is Ownable {
+    address public paymentProxy;
+    ChainlinkConversionPath public chainlinkConversionPath;
 
-  constructor(address _paymentProxyAddress, address _chainlinkConversionPathAddress) {
-    paymentProxy = _paymentProxyAddress;
-    chainlinkConversionPath = ChainlinkConversionPath(_chainlinkConversionPathAddress);
-  }
+    constructor(address _paymentProxyAddress, address _chainlinkConversionPathAddress) {
+        paymentProxy = _paymentProxyAddress;
+        chainlinkConversionPath = ChainlinkConversionPath(_chainlinkConversionPathAddress);
+    }
 
-  // Event to declare a conversion with a reference
-  event TransferWithConversionAndReference(
-    uint256 amount,
-    address currency,
-    bytes indexed paymentReference,
-    uint256 feeAmount,
-    uint256 maxRateTimespan
-  );
-  
-  // Event to declare a transfer with a reference
-  event TransferWithReferenceAndFee(
-    address tokenAddress,
-    address to,
-    uint256 amount,
-    bytes indexed paymentReference,
-    uint256 feeAmount,
-    address feeAddress
-  );
-
-  /**
-   * @notice Performs an ERC20 token transfer with a reference computing the payment amount based on the request amount
-   * @param _to Transfer recipient of the payement
-   * @param _requestAmount Request amount
-   * @param _path Conversion path
-   * @param _paymentReference Reference of the payment related
-   * @param _feeAmount The amount of the payment fee
-   * @param _feeAddress The fee recipient
-   * @param _maxToSpend Amount max that we can spend on the behalf of the user
-   * @param _maxRateTimespan Max time span with the oldestrate, ignored if zero
-   */
-  function transferFromWithReferenceAndFee(
-    address _to,
-    uint256 _requestAmount,
-    address[] calldata _path,
-    bytes calldata _paymentReference,
-    uint256 _feeAmount,
-    address _feeAddress,
-    uint256 _maxToSpend,
-    uint256 _maxRateTimespan
-  )
-  external
-  {
-    (uint256 amountToPay, uint256 amountToPayInFees) = getConversions(
-      _path,
-      _requestAmount,
-      _feeAmount,
-      _maxRateTimespan);
-
-    require(
-      amountToPay + amountToPayInFees <= _maxToSpend,
-      "Amount to pay is over the user limit"
+    // Event to declare a conversion with a reference
+    event TransferWithConversionAndReference(
+        uint256 amount,
+        address currency,
+        bytes indexed paymentReference,
+        uint256 feeAmount,
+        uint256 maxRateTimespan
     );
-
-    // Pay the request and fees
-    (bool status, ) = paymentProxy.delegatecall(
-      abi.encodeWithSignature(
-        "transferFromWithReferenceAndFee(address,address,uint256,bytes,uint256,address)",
-        // payment currency
-        _path[_path.length - 1],
-        _to,
-        amountToPay,
-        _paymentReference,
-        amountToPayInFees,
-        _feeAddress
-      )
-    );
-    require(status, "transferFromWithReferenceAndFee failed");
 
     // Event to declare a transfer with a reference
-    emit TransferWithConversionAndReference(
-      _requestAmount,
-      // request currency
-      _path[0],
-      _paymentReference,
-      _feeAmount,
-      _maxRateTimespan
-    );
-  }
-
-  function getConversions(
-    address[] memory _path,
-    uint256 _requestAmount,
-    uint256 _feeAmount,
-    uint256 _maxRateTimespan
-  )
-    internal
-    view
-    returns (uint256 amountToPay, uint256 amountToPayInFees)
-  {
-    (uint256 rate, uint256 oldestTimestampRate, uint256 decimals) = chainlinkConversionPath.getRate(_path);
-
-    // Check rate timespan
-    require(
-      _maxRateTimespan == 0 || block.timestamp - oldestTimestampRate <= _maxRateTimespan,
-      "aggregator rate is outdated"
+    event TransferWithReferenceAndFee(
+        address tokenAddress,
+        address to,
+        uint256 amount,
+        bytes indexed paymentReference,
+        uint256 feeAmount,
+        address feeAddress
     );
 
-    // Get the amount to pay in the crypto currency chosen
-    amountToPay = (_requestAmount * rate) / decimals;
-    amountToPayInFees = (_feeAmount * rate) /decimals;
-  }
+    /**
+     * @notice Performs an ERC20 token transfer with a reference computing the payment amount based on the request amount
+     * @param _to Transfer recipient of the payement
+     * @param _requestAmount Request amount
+     * @param _path Conversion path
+     * @param _paymentReference Reference of the payment related
+     * @param _feeAmount The amount of the payment fee
+     * @param _feeAddress The fee recipient
+     * @param _maxToSpend Amount max that we can spend on the behalf of the user
+     * @param _maxRateTimespan Max time span with the oldestrate, ignored if zero
+     */
+    function transferFromWithReferenceAndFee(
+        address _to,
+        uint256 _requestAmount,
+        address[] calldata _path,
+        bytes calldata _paymentReference,
+        uint256 _feeAmount,
+        address _feeAddress,
+        uint256 _maxToSpend,
+        uint256 _maxRateTimespan
+    ) external {
+        (uint256 amountToPay, uint256 amountToPayInFees) = getConversions(
+            _path,
+            _requestAmount,
+            _feeAmount,
+            _maxRateTimespan
+        );
+
+        require(
+            amountToPay + amountToPayInFees <= _maxToSpend,
+            'Amount to pay is over the user limit'
+        );
+
+        // Pay the request and fees
+        (bool status, ) = paymentProxy.delegatecall(
+            abi.encodeWithSignature(
+                'transferFromWithReferenceAndFee(address,address,uint256,bytes,uint256,address)',
+                // payment currency
+                _path[_path.length - 1],
+                _to,
+                amountToPay,
+                _paymentReference,
+                amountToPayInFees,
+                _feeAddress
+            )
+        );
+        require(status, 'transferFromWithReferenceAndFee failed');
+
+        // Event to declare a transfer with a reference
+        emit TransferWithConversionAndReference(
+            _requestAmount,
+            // request currency
+            _path[0],
+            _paymentReference,
+            _feeAmount,
+            _maxRateTimespan
+        );
+    }
+
+    function getConversions(
+        address[] memory _path,
+        uint256 _requestAmount,
+        uint256 _feeAmount,
+        uint256 _maxRateTimespan
+    ) internal view returns (uint256 amountToPay, uint256 amountToPayInFees) {
+        (uint256 rate, uint256 oldestTimestampRate, uint256 decimals) = chainlinkConversionPath
+            .getRate(_path);
+
+        // Check rate timespan
+        require(
+            _maxRateTimespan == 0 || block.timestamp - oldestTimestampRate <= _maxRateTimespan,
+            'aggregator rate is outdated'
+        );
+
+        // Get the amount to pay in the crypto currency chosen
+        amountToPay = (_requestAmount * rate) / decimals;
+        amountToPayInFees = (_feeAmount * rate) / decimals;
+    }
+
+    /**
+     * @notice Update the conversion path contract used to fetch conversions
+     * @param _chainlinkConversionPathAddress address of the conversion path contract
+     */
+    function updateConversionPathAddress(address _chainlinkConversionPathAddress)
+        external
+        onlyOwner
+    {
+        chainlinkConversionPath = ChainlinkConversionPath(_chainlinkConversionPathAddress);
+    }
+
+    /**
+     * @notice Update the conversion proxy used to process the payment
+     * @param _paymentProxyAddress address of the ETH conversion proxy
+     */
+    function updateConversionProxyAddress(address _paymentProxyAddress) external onlyOwner {
+        paymentProxy = _paymentProxyAddress;
+    }
 }

--- a/packages/smart-contracts/src/lib/artifacts/Erc20ConversionProxy/0.1.1.json
+++ b/packages/smart-contracts/src/lib/artifacts/Erc20ConversionProxy/0.1.1.json
@@ -1,0 +1,252 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_paymentProxyAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_chainlinkConversionPathAddress",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "currency",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes",
+          "name": "paymentReference",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "feeAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "maxRateTimespan",
+          "type": "uint256"
+        }
+      ],
+      "name": "TransferWithConversionAndReference",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "tokenAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes",
+          "name": "paymentReference",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "feeAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "feeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "TransferWithReferenceAndFee",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "chainlinkConversionPath",
+      "outputs": [
+        {
+          "internalType": "contract ChainlinkConversionPath",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "paymentProxy",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_requestAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_paymentReference",
+          "type": "bytes"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_feeAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_feeAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_maxToSpend",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_maxRateTimespan",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFromWithReferenceAndFee",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_chainlinkConversionPathAddress",
+          "type": "address"
+        }
+      ],
+      "name": "updateConversionPathAddress",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_paymentProxyAddress",
+          "type": "address"
+        }
+      ],
+      "name": "updateConversionProxyAddress",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}

--- a/packages/smart-contracts/src/lib/artifacts/Erc20ConversionProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/Erc20ConversionProxy/index.ts
@@ -1,6 +1,7 @@
 import { ContractArtifact } from '../../ContractArtifact';
 
 import { abi as ABI_0_1_0 } from './0.1.0.json';
+import { abi as ABI_0_1_1 } from './0.1.1.json';
 // @ts-ignore Cannot find module
 import type { Erc20ConversionProxy } from '../../../types/Erc20ConversionProxy';
 
@@ -51,18 +52,15 @@ export const erc20ConversionProxy = new ContractArtifact<Erc20ConversionProxy>(
         },
       },
     },
-  },
-  // Additional deployments of same versions, not worth upgrading the version number but worth using within next versions
-  /*
-  '0.1.0-next': {
-    abi: ABI_0_1_0,
-    deployment: {
-      mainnet: {
-        address: '0xf0f49873C50765239F6f9534Ba13c4fe16eD5f2E',
-        creationBlockNumber: 13764028,
+    '0.1.1': {
+      abi: ABI_0_1_1,
+      deployment: {
+        private: {
+          address: '0xdE5491f774F0Cb009ABcEA7326342E105dbb1B2E',
+          creationBlockNumber: 0,
+        },
       },
     },
   },
-  */
   '0.1.0',
 );

--- a/packages/smart-contracts/src/lib/artifacts/Erc20ConversionProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/Erc20ConversionProxy/index.ts
@@ -50,6 +50,14 @@ export const erc20ConversionProxy = new ContractArtifact<Erc20ConversionProxy>(
           address: '0xf0f49873C50765239F6f9534Ba13c4fe16eD5f2E',
           creationBlockNumber: 8403930,
         },
+        /**
+         * FIXME: The contract was deployed on networks below with ABI 0.1.1
+         * The ABI for payments is the same, only administration tasks change.
+         *  */
+        'arbitrum-one': {
+          address: '0xA5186dec7dC1ec85B42A3cd2Dc8289e248530B07',
+          creationBlockNumber: 5321045,
+        },
       },
     },
     '0.1.1': {

--- a/packages/smart-contracts/src/lib/artifacts/Erc20SwapConversion/0.1.0.json
+++ b/packages/smart-contracts/src/lib/artifacts/Erc20SwapConversion/0.1.0.json
@@ -11,9 +11,13 @@
           "internalType": "address",
           "name": "_paymentProxyAddress",
           "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_chainlinkConversionPath",
+          "type": "address"
         }
       ],
-      "payable": false,
       "stateMutability": "nonpayable",
       "type": "constructor"
     },
@@ -37,7 +41,6 @@
       "type": "event"
     },
     {
-      "constant": true,
       "inputs": [],
       "name": "chainlinkConversionPath",
       "outputs": [
@@ -47,27 +50,10 @@
           "type": "address"
         }
       ],
-      "payable": false,
       "stateMutability": "view",
       "type": "function"
     },
     {
-      "constant": true,
-      "inputs": [],
-      "name": "isOwner",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
       "inputs": [],
       "name": "owner",
       "outputs": [
@@ -77,12 +63,10 @@
           "type": "address"
         }
       ],
-      "payable": false,
       "stateMutability": "view",
       "type": "function"
     },
     {
-      "constant": true,
       "inputs": [],
       "name": "paymentProxy",
       "outputs": [
@@ -92,21 +76,17 @@
           "type": "address"
         }
       ],
-      "payable": false,
       "stateMutability": "view",
       "type": "function"
     },
     {
-      "constant": false,
       "inputs": [],
       "name": "renounceOwnership",
       "outputs": [],
-      "payable": false,
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
-      "constant": true,
       "inputs": [],
       "name": "swapRouter",
       "outputs": [
@@ -116,12 +96,10 @@
           "type": "address"
         }
       ],
-      "payable": false,
       "stateMutability": "view",
       "type": "function"
     },
     {
-      "constant": false,
       "inputs": [
         {
           "internalType": "address",
@@ -131,12 +109,10 @@
       ],
       "name": "transferOwnership",
       "outputs": [],
-      "payable": false,
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
-      "constant": false,
       "inputs": [
         {
           "internalType": "address",
@@ -146,12 +122,10 @@
       ],
       "name": "approvePaymentProxyToSpend",
       "outputs": [],
-      "payable": false,
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
-      "constant": false,
       "inputs": [
         {
           "internalType": "address",
@@ -161,12 +135,10 @@
       ],
       "name": "approveRouterToSpend",
       "outputs": [],
-      "payable": false,
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
-      "constant": false,
       "inputs": [
         {
           "internalType": "address",
@@ -221,12 +193,10 @@
       ],
       "name": "swapTransferWithReference",
       "outputs": [],
-      "payable": false,
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
-      "constant": false,
       "inputs": [
         {
           "internalType": "address",
@@ -236,12 +206,10 @@
       ],
       "name": "setPaymentProxy",
       "outputs": [],
-      "payable": false,
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
-      "constant": false,
       "inputs": [
         {
           "internalType": "address",
@@ -251,7 +219,6 @@
       ],
       "name": "setRouter",
       "outputs": [],
-      "payable": false,
       "stateMutability": "nonpayable",
       "type": "function"
     }

--- a/packages/smart-contracts/src/lib/artifacts/Erc20SwapConversion/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/Erc20SwapConversion/index.ts
@@ -14,8 +14,8 @@ export const erc20SwapConversionArtifact = new ContractArtifact<ERC20SwapToConve
           creationBlockNumber: 0,
         },
         rinkeby: {
-          address: '0x38443a9501F20C3bf2BDff14244665F3aEC86bA2',
-          creationBlockNumber: 8884276,
+          address: '0x1d6B06C6f7adFd9314BD4C58a6D306261113a1D4',
+          creationBlockNumber: 9447192,
         },
         bsctest: {
           address: '0x1d6B06C6f7adFd9314BD4C58a6D306261113a1D4',


### PR DESCRIPTION
## Description of the changes
* Erc20ConversionProxy.sol 0.1.1 with setPaymentProxy in order to deploy erc20ConversionProxy before ChainlinkConversionPath on future chains where we only deploy ChainlinkConversionPath 0.2.0 (afterwards)
* deployment script updated to deploy the full suite of contracts