### PR TITLE
fix(request-node): eth_feeHistory missing parameters

### DIFF
--- a/packages/request-node/src/thegraph/TheGraphStorage.ts
+++ b/packages/request-node/src/thegraph/TheGraphStorage.ts
@@ -47,7 +47,7 @@ export class TheGraphStorage {
   async initialize(): Promise<void> {
     await this.ipfsStorage.initialize();
     try {
-      await this.provider.send('eth_feeHistory', []);
+      await this.provider.send('eth_feeHistory', ['0x1', 'latest', []]);
     } catch (e) {
       this.logger.warn(
         'This RPC provider does not support the "eth_feeHistory" method: switching to legacy gas price',

--- a/packages/request-node/src/thegraph/TheGraphStorage.ts
+++ b/packages/request-node/src/thegraph/TheGraphStorage.ts
@@ -47,7 +47,7 @@ export class TheGraphStorage {
   async initialize(): Promise<void> {
     await this.ipfsStorage.initialize();
     try {
-      await this.provider.send('eth_feeHistory', ['0x1', 'latest', []]);
+      await this.provider.send('eth_feeHistory', [1, 'latest', []]);
     } catch (e) {
       this.logger.warn(
         'This RPC provider does not support the "eth_feeHistory" method: switching to legacy gas price',


### PR DESCRIPTION
## Description of the changes

Call to `eth_feeHistory` was always failing due to missing parameters.