### PR TITLE
fix: price calculation

### DIFF
--- a/packages/data-format/src/format/rnf_invoice/utils.ts
+++ b/packages/data-format/src/format/rnf_invoice/utils.ts
@@ -9,7 +9,6 @@ export const getInvoiceTotal = (invoice: Invoice): BigNumber => {
 };
 
 export const getInvoiceLineTotal = (item: InvoiceItem): BigNumber => {
-
   // Support for rnf_version < 0.0.3
   const tax = item.taxPercent
     ? { type: 'percentage', amount: String(item.taxPercent) }

--- a/packages/data-format/src/format/rnf_invoice/utils.ts
+++ b/packages/data-format/src/format/rnf_invoice/utils.ts
@@ -34,6 +34,8 @@ export const getInvoiceLineTotal = (item: InvoiceItem): BigNumber => {
       .mul(Number(taxPercent * preciselyOne).toFixed(0))
       // Remove the decimal offset
       .div(preciselyOne)
+      // Improve the precision
+      .add(50)
       // Remove the percentage multiplier
       .div(100)
       .add(taxFixed)

--- a/packages/data-format/src/format/rnf_invoice/utils.ts
+++ b/packages/data-format/src/format/rnf_invoice/utils.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers';
+import { BigNumber, FixedNumber } from 'ethers';
 import { Invoice, InvoiceItem } from './types';
 
 export const getInvoiceTotal = (invoice: Invoice): BigNumber => {
@@ -12,7 +12,6 @@ export const getInvoiceLineTotal = (item: InvoiceItem): BigNumber => {
   // Every amount in currency is a big number with the good number of decimals for this currency
   // Tax percent is not an amount in currency. To allow a big number multiplication, we convert
   //  it temporarily with preciselyOne (allows 6 decimals, ie 0.123456%)
-  const preciselyOne = 1000000;
 
   // Support for rnf_version < 0.0.3
   const tax = item.taxPercent
@@ -24,20 +23,20 @@ export const getInvoiceLineTotal = (item: InvoiceItem): BigNumber => {
     tax.amount && tax.type === 'fixed' ? BigNumber.from(tax.amount) : BigNumber.from(0);
   const discount = item.discount ? BigNumber.from(item.discount) : BigNumber.from(0);
 
-  return (
-    BigNumber.from(item.unitPrice)
-      // account for floating quantities
-      .mul(Number(item.quantity * preciselyOne).toFixed(0))
-      .div(preciselyOne)
-      .sub(discount)
-      // Artificially offset the decimal to let the multiplication work
-      .mul(Number(taxPercent * preciselyOne).toFixed(0))
-      // Remove the decimal offset
-      .div(preciselyOne)
-      // Improve the precision
-      .add(50)
-      // Remove the percentage multiplier
-      .div(100)
-      .add(taxFixed)
+  return BigNumber.from(
+    // Removes the resulting decimal (.0)
+    Number(
+      FixedNumber.from(item.unitPrice)
+        // accounts for floating quantities
+        .mulUnsafe(FixedNumber.fromString(item.quantity.toString()))
+        .subUnsafe(FixedNumber.from(discount))
+        // accounts for floating taxes
+        .mulUnsafe(FixedNumber.fromString(taxPercent.toString()))
+        // Removes the percentage multiplier
+        .divUnsafe(FixedNumber.from(100))
+        .addUnsafe(FixedNumber.from(taxFixed))
+        .round(0)
+        .toString(),
+    ),
   );
 };

--- a/packages/data-format/src/format/rnf_invoice/utils.ts
+++ b/packages/data-format/src/format/rnf_invoice/utils.ts
@@ -9,9 +9,6 @@ export const getInvoiceTotal = (invoice: Invoice): BigNumber => {
 };
 
 export const getInvoiceLineTotal = (item: InvoiceItem): BigNumber => {
-  // Every amount in currency is a big number with the good number of decimals for this currency
-  // Tax percent is not an amount in currency. To allow a big number multiplication, we convert
-  //  it temporarily with preciselyOne (allows 6 decimals, ie 0.123456%)
 
   // Support for rnf_version < 0.0.3
   const tax = item.taxPercent

--- a/packages/data-format/test/rnf_invoice/utils.test.ts
+++ b/packages/data-format/test/rnf_invoice/utils.test.ts
@@ -174,4 +174,22 @@ describe('getInvoiceTotal', () => {
       }).toString(),
     ).toEqual('1515165');
   });
+
+  it('rounds the total correctly', () => {
+    expect(
+      getInvoiceTotal({
+        ...baseInvoice,
+        invoiceItems: [
+          {
+            ...baseInvoiceItem,
+            unitPrice: '3333',
+            tax: {
+              type: 'percentage',
+              amount: '20',
+            },
+          },
+        ],
+      }).toString(),
+    ).toEqual('4000');
+  });
 });


### PR DESCRIPTION
Fixes edge cases where we lost precision.

e.g. :
`item.unitPrice = 33.33`
`item.quantity = 1`
`item.tax.amount = 20`
`item.discount = 0`

The "true" result is `39.996`. This function returned `39.99`, it now returns `40.00`.
