### PR TITLE
fix: typescript lint for test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ yarn-error.log
 
 # compiled output
 /packages/*/dist/
-/packages/*/tsconfig.tsbuildinfo
-/packages/*/tsconfig.build.tsbuildinfo
+tsconfig.tsbuildinfo
+tsconfig.build.tsbuildinfo
 
 # coverage
 /packages/*/coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log
 # compiled output
 /packages/*/dist/
 /packages/*/tsconfig.tsbuildinfo
+/packages/*/tsconfig.build.tsbuildinfo
 
 # coverage
 /packages/*/coverage/

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "lerna run build",
     "clean": "lerna run clean",
-    "build:tsc": "tsc -b packages/advanced-logic packages/currency packages/data-access packages/data-format packages/epk-decryption packages/epk-signature packages/ethereum-storage packages/integration-test packages/multi-format packages/payment-detection packages/prototype-estimator packages/request-client.js packages/request-logic packages/request-node packages/smart-contracts packages/toolbox packages/transaction-manager packages/types packages/usage-examples packages/utils packages/web3-signature",
+    "build:tsc": "tsc -b packages/advanced-logic/tsconfig.build.json packages/currency/tsconfig.build.json packages/data-access/tsconfig.build.json packages/data-format/tsconfig.build.json packages/epk-decryption/tsconfig.build.json packages/epk-signature/tsconfig.build.json packages/ethereum-storage/tsconfig.build.json packages/integration-test/tsconfig.build.json packages/multi-format/tsconfig.build.json packages/payment-detection/tsconfig.build.json packages/prototype-estimator/tsconfig.build.json packages/request-client.js/tsconfig.build.json packages/request-logic/tsconfig.build.json packages/request-node/tsconfig.build.json packages/smart-contracts/tsconfig.build.json packages/toolbox/tsconfig.build.json packages/transaction-manager/tsconfig.build.json packages/types/tsconfig.build.json packages/usage-examples/tsconfig.build.json packages/utils/tsconfig.build.json packages/web3-signature/tsconfig.build.json",
     "lint": "eslint . --fix --quiet",
     "lint:check": "eslint . --quiet",
     "lint-staged": "lint-staged",

--- a/packages/advanced-logic/package.json
+++ b/packages/advanced-logic/package.json
@@ -31,8 +31,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "test": "jest",

--- a/packages/advanced-logic/package.json
+++ b/packages/advanced-logic/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/advanced-logic/tsconfig.build.json
+++ b/packages/advanced-logic/tsconfig.build.json
@@ -5,5 +5,6 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [{ "path": "../currency" }, { "path": "../types" }, { "path": "../utils" }]
 }

--- a/packages/advanced-logic/tsconfig.build.json
+++ b/packages/advanced-logic/tsconfig.build.json
@@ -6,5 +6,9 @@
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
-  "references": [{ "path": "../currency" }, { "path": "../types" }, { "path": "../utils" }]
+  "references": [
+    { "path": "../currency/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/advanced-logic/tsconfig.build.json
+++ b/packages/advanced-logic/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/advanced-logic/tsconfig.json
+++ b/packages/advanced-logic/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src",
     "types": ["node", "jest"]
   },
-  "include": ["./src/**/*"],
   "references": [{ "path": "../currency" }, { "path": "../types" }, { "path": "../utils" }]
 }

--- a/packages/advanced-logic/tsconfig.json
+++ b/packages/advanced-logic/tsconfig.json
@@ -2,6 +2,5 @@
   "extends": "../../tsconfig",
   "compilerOptions": {
     "types": ["node", "jest"]
-  },
-  "references": [{ "path": "../currency" }, { "path": "../types" }, { "path": "../utils" }]
+  }
 }

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -32,8 +32,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "prepare": "yarn run build",

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -32,7 +32,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/currency/tsconfig.build.json
+++ b/packages/currency/tsconfig.build.json
@@ -6,5 +6,8 @@
   },
   "include": ["src/**/*", "./src/aggregators/*.json"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
-  "references": [{ "path": "../types" }, { "path": "../utils" }]
+  "references": [
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/currency/tsconfig.build.json
+++ b/packages/currency/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*", "./src/aggregators/*.json"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/currency/tsconfig.build.json
+++ b/packages/currency/tsconfig.build.json
@@ -5,5 +5,6 @@
     "rootDir": "src"
   },
   "include": ["src/**/*", "./src/aggregators/*.json"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [{ "path": "../types" }, { "path": "../utils" }]
 }

--- a/packages/currency/tsconfig.json
+++ b/packages/currency/tsconfig.json
@@ -2,13 +2,5 @@
   "extends": "../../tsconfig",
   "compilerOptions": {
     "esModuleInterop": true
-  },
-  "references": [
-    {
-      "path": "../types"
-    },
-    {
-      "path": "../utils"
-    }
-  ]
+  }
 }

--- a/packages/currency/tsconfig.json
+++ b/packages/currency/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src",
     "esModuleInterop": true
   },
-  "include": ["./src/**/*", "./src/aggregators/*.json"],
   "references": [
     {
       "path": "../types"

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -31,8 +31,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc -b tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "test": "jest",

--- a/packages/data-access/test/tsconfig.json
+++ b/packages/data-access/test/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../tsconfig",
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "../"
-  },
-  "include": ["../src", "."]
-}

--- a/packages/data-access/test/tsconfig.json
+++ b/packages/data-access/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../"
+  },
+  "include": ["../src", "."]
+}

--- a/packages/data-access/tsconfig.build.json
+++ b/packages/data-access/tsconfig.build.json
@@ -6,5 +6,9 @@
   },
   "include": ["src/**/*", "./src/aggregators/*.json"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
-  "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../multi-format" }]
+  "references": [
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" },
+    { "path": "../multi-format/tsconfig.build.json" }
+  ]
 }

--- a/packages/data-access/tsconfig.build.json
+++ b/packages/data-access/tsconfig.build.json
@@ -2,8 +2,8 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "."
+    "rootDir": "src"
   },
-  "include": ["src/**/*", "src/**/*.json", "scripts", "hardhat.config.ts"],
+  "include": ["src/**/*", "./src/aggregators/*.json"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"]
 }

--- a/packages/data-access/tsconfig.build.json
+++ b/packages/data-access/tsconfig.build.json
@@ -5,5 +5,6 @@
     "rootDir": "src"
   },
   "include": ["src/**/*", "./src/aggregators/*.json"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../multi-format" }]
 }

--- a/packages/data-access/tsconfig.json
+++ b/packages/data-access/tsconfig.json
@@ -1,9 +1,4 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/**/*"],
   "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../multi-format" }]
 }

--- a/packages/data-access/tsconfig.json
+++ b/packages/data-access/tsconfig.json
@@ -1,4 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../multi-format" }]
+  "extends": "../../tsconfig"
 }

--- a/packages/data-format/package.json
+++ b/packages/data-format/package.json
@@ -32,7 +32,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/data-format/package.json
+++ b/packages/data-format/package.json
@@ -32,8 +32,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "test": "jest",

--- a/packages/data-format/tsconfig.build.json
+++ b/packages/data-format/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*", "./src/format/address.json", "./src/format/**/*.json"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/data-format/tsconfig.json
+++ b/packages/data-format/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src",
     "resolveJsonModule": true
-  },
-  "include": ["./src/**/*", "./src/format/address.json", "./src/format/**/*.json"]
+  }
 }

--- a/packages/epk-decryption/package.json
+++ b/packages/epk-decryption/package.json
@@ -32,9 +32,9 @@
   ],
   "scripts": {
     "build": "run-s build:commonjs build:umd",
-    "build:commonjs": "tsc -b",
+    "build:commonjs": "tsc --project tsconfig.build.json",
     "build:umd": "webpack",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "test": "jest",

--- a/packages/epk-decryption/package.json
+++ b/packages/epk-decryption/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "build": "run-s build:commonjs build:umd",
-    "build:commonjs": "tsc --project tsconfig.build.json",
+    "build:commonjs": "tsc -b tsconfig.build.json",
     "build:umd": "webpack",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",

--- a/packages/epk-decryption/tsconfig.build.json
+++ b/packages/epk-decryption/tsconfig.build.json
@@ -5,5 +5,6 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../multi-format" }]
 }

--- a/packages/epk-decryption/tsconfig.build.json
+++ b/packages/epk-decryption/tsconfig.build.json
@@ -6,5 +6,9 @@
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
-  "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../multi-format" }]
+  "references": [
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" },
+    { "path": "../multi-format/tsconfig.build.json" }
+  ]
 }

--- a/packages/epk-decryption/tsconfig.build.json
+++ b/packages/epk-decryption/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/epk-decryption/tsconfig.json
+++ b/packages/epk-decryption/tsconfig.json
@@ -1,9 +1,4 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/**/*"],
   "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../multi-format" }]
 }

--- a/packages/epk-decryption/tsconfig.json
+++ b/packages/epk-decryption/tsconfig.json
@@ -1,4 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../multi-format" }]
+  "extends": "../../tsconfig"
 }

--- a/packages/epk-signature/package.json
+++ b/packages/epk-signature/package.json
@@ -32,9 +32,9 @@
   ],
   "scripts": {
     "build": "run-s build:commonjs build:umd",
-    "build:commonjs": "tsc -b",
+    "build:commonjs": "tsc --project tsconfig.build.json",
     "build:umd": "webpack",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "test": "jest",

--- a/packages/epk-signature/package.json
+++ b/packages/epk-signature/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "build": "run-s build:commonjs build:umd",
-    "build:commonjs": "tsc --project tsconfig.build.json",
+    "build:commonjs": "tsc -b tsconfig.build.json",
     "build:umd": "webpack",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",

--- a/packages/epk-signature/tsconfig.build.json
+++ b/packages/epk-signature/tsconfig.build.json
@@ -6,5 +6,8 @@
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
-  "references": [{ "path": "../types" }, { "path": "../utils" }]
+  "references": [
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/epk-signature/tsconfig.build.json
+++ b/packages/epk-signature/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/epk-signature/tsconfig.build.json
+++ b/packages/epk-signature/tsconfig.build.json
@@ -5,5 +5,6 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [{ "path": "../types" }, { "path": "../utils" }]
 }

--- a/packages/epk-signature/tsconfig.json
+++ b/packages/epk-signature/tsconfig.json
@@ -1,4 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [{ "path": "../types" }, { "path": "../utils" }]
+  "extends": "../../tsconfig"
 }

--- a/packages/epk-signature/tsconfig.json
+++ b/packages/epk-signature/tsconfig.json
@@ -1,9 +1,4 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/**/*"],
   "references": [{ "path": "../types" }, { "path": "../utils" }]
 }

--- a/packages/ethereum-storage/package.json
+++ b/packages/ethereum-storage/package.json
@@ -31,8 +31,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "test": "jest",

--- a/packages/ethereum-storage/package.json
+++ b/packages/ethereum-storage/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/ethereum-storage/tsconfig.build.json
+++ b/packages/ethereum-storage/tsconfig.build.json
@@ -6,5 +6,9 @@
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
-  "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../smart-contracts" }]
+  "references": [
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" },
+    { "path": "../smart-contracts/tsconfig.build.json" }
+  ]
 }

--- a/packages/ethereum-storage/tsconfig.build.json
+++ b/packages/ethereum-storage/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "."
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"]

--- a/packages/ethereum-storage/tsconfig.build.json
+++ b/packages/ethereum-storage/tsconfig.build.json
@@ -5,5 +5,6 @@
     "rootDir": "."
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../smart-contracts" }]
 }

--- a/packages/ethereum-storage/tsconfig.build.json
+++ b/packages/ethereum-storage/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/ethereum-storage/tsconfig.json
+++ b/packages/ethereum-storage/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": ".",
     "resolveJsonModule": true
   },
-  "include": ["./src/**/*"],
   "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../smart-contracts" }]
 }

--- a/packages/ethereum-storage/tsconfig.json
+++ b/packages/ethereum-storage/tsconfig.json
@@ -2,6 +2,5 @@
   "extends": "../../tsconfig",
   "compilerOptions": {
     "resolveJsonModule": true
-  },
-  "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../smart-contracts" }]
+  }
 }

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -26,8 +26,8 @@
     "test"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc -b tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint \"test/**/*.ts\"",
     "test": "run-s test:node test:layers",
     "test:scheduled": "run-s test:erc20 test:btc",

--- a/packages/integration-test/tsconfig.build.json
+++ b/packages/integration-test/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "test"
+  }
+}

--- a/packages/integration-test/tsconfig.build.json
+++ b/packages/integration-test/tsconfig.build.json
@@ -5,17 +5,17 @@
     "rootDir": "test"
   },
   "references": [
-    { "path": "../advanced-logic" },
-    { "path": "../request-client.js" },
-    { "path": "../currency" },
-    { "path": "../data-access" },
-    { "path": "../ethereum-storage" },
-    { "path": "../epk-decryption" },
-    { "path": "../epk-signature" },
-    { "path": "../multi-format" },
-    { "path": "../payment-processor" },
-    { "path": "../request-logic" },
-    { "path": "../transaction-manager" },
-    { "path": "../types" }
+    { "path": "../advanced-logic/tsconfig.build.json" },
+    { "path": "../request-client.js/tsconfig.build.json" },
+    { "path": "../currency/tsconfig.build.json" },
+    { "path": "../data-access/tsconfig.build.json" },
+    { "path": "../ethereum-storage/tsconfig.build.json" },
+    { "path": "../epk-decryption/tsconfig.build.json" },
+    { "path": "../epk-signature/tsconfig.build.json" },
+    { "path": "../multi-format/tsconfig.build.json" },
+    { "path": "../payment-processor/tsconfig.build.json" },
+    { "path": "../request-logic/tsconfig.build.json" },
+    { "path": "../transaction-manager/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" }
   ]
 }

--- a/packages/integration-test/tsconfig.build.json
+++ b/packages/integration-test/tsconfig.build.json
@@ -3,5 +3,19 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "test"
-  }
+  },
+  "references": [
+    { "path": "../advanced-logic" },
+    { "path": "../request-client.js" },
+    { "path": "../currency" },
+    { "path": "../data-access" },
+    { "path": "../ethereum-storage" },
+    { "path": "../epk-decryption" },
+    { "path": "../epk-signature" },
+    { "path": "../multi-format" },
+    { "path": "../payment-processor" },
+    { "path": "../request-logic" },
+    { "path": "../transaction-manager" },
+    { "path": "../types" }
+  ]
 }

--- a/packages/integration-test/tsconfig.json
+++ b/packages/integration-test/tsconfig.json
@@ -1,17 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [
-    { "path": "../advanced-logic" },
-    { "path": "../request-client.js" },
-    { "path": "../currency" },
-    { "path": "../data-access" },
-    { "path": "../ethereum-storage" },
-    { "path": "../epk-decryption" },
-    { "path": "../epk-signature" },
-    { "path": "../multi-format" },
-    { "path": "../payment-processor" },
-    { "path": "../request-logic" },
-    { "path": "../transaction-manager" },
-    { "path": "../types" }
-  ]
+  "extends": "../../tsconfig"
 }

--- a/packages/integration-test/tsconfig.json
+++ b/packages/integration-test/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "test"
-  },
   "references": [
     { "path": "../advanced-logic" },
     { "path": "../request-client.js" },

--- a/packages/multi-format/package.json
+++ b/packages/multi-format/package.json
@@ -31,8 +31,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "prepare": "yarn run build",

--- a/packages/multi-format/package.json
+++ b/packages/multi-format/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/multi-format/tsconfig.build.json
+++ b/packages/multi-format/tsconfig.build.json
@@ -5,5 +5,6 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [{ "path": "../types" }]
 }

--- a/packages/multi-format/tsconfig.build.json
+++ b/packages/multi-format/tsconfig.build.json
@@ -6,5 +6,5 @@
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
-  "references": [{ "path": "../types" }]
+  "references": [{ "path": "../types/tsconfig.build.json" }]
 }

--- a/packages/multi-format/tsconfig.build.json
+++ b/packages/multi-format/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/multi-format/tsconfig.json
+++ b/packages/multi-format/tsconfig.json
@@ -1,4 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [{ "path": "../types" }]
+  "extends": "../../tsconfig"
 }

--- a/packages/multi-format/tsconfig.json
+++ b/packages/multi-format/tsconfig.json
@@ -1,9 +1,4 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/**/*"],
   "references": [{ "path": "../types" }]
 }

--- a/packages/payment-detection/package.json
+++ b/packages/payment-detection/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "prebuild": "yarn codegen",
     "build": "tsc -b tsconfig.build.json",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo **/generated",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "prepare": "yarn run build",

--- a/packages/payment-detection/package.json
+++ b/packages/payment-detection/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "prebuild": "yarn codegen",
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/payment-detection/package.json
+++ b/packages/payment-detection/package.json
@@ -31,8 +31,8 @@
   ],
   "scripts": {
     "prebuild": "yarn codegen",
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo **/generated",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "prepare": "yarn run build",

--- a/packages/payment-detection/tsconfig.build.json
+++ b/packages/payment-detection/tsconfig.build.json
@@ -5,5 +5,12 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [
+    { "path": "../currency" },
+    { "path": "../types" },
+    { "path": "../utils" },
+    { "path": "../smart-contracts" },
+    { "path": "../advanced-logic" }
+  ]
 }

--- a/packages/payment-detection/tsconfig.build.json
+++ b/packages/payment-detection/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/payment-detection/tsconfig.build.json
+++ b/packages/payment-detection/tsconfig.build.json
@@ -7,10 +7,10 @@
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
   "references": [
-    { "path": "../currency" },
-    { "path": "../types" },
-    { "path": "../utils" },
-    { "path": "../smart-contracts" },
-    { "path": "../advanced-logic" }
+    { "path": "../currency/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" },
+    { "path": "../smart-contracts/tsconfig.build.json" },
+    { "path": "../advanced-logic/tsconfig.build.json" }
   ]
 }

--- a/packages/payment-detection/tsconfig.json
+++ b/packages/payment-detection/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/**/*"],
   "references": [
     { "path": "../currency" },
     { "path": "../types" },

--- a/packages/payment-detection/tsconfig.json
+++ b/packages/payment-detection/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [
-    { "path": "../currency" },
-    { "path": "../types" },
-    { "path": "../utils" },
-    { "path": "../smart-contracts" },
-    { "path": "../advanced-logic" }
-  ]
+  "extends": "../../tsconfig"
 }

--- a/packages/payment-processor/package.json
+++ b/packages/payment-processor/package.json
@@ -30,8 +30,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "prepare": "yarn run build",

--- a/packages/payment-processor/package.json
+++ b/packages/payment-processor/package.json
@@ -30,7 +30,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/payment-processor/tsconfig.build.json
+++ b/packages/payment-processor/tsconfig.build.json
@@ -7,9 +7,9 @@
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
   "references": [
-    { "path": "../types" },
-    { "path": "../utils" },
-    { "path": "../payment-detection" },
-    { "path": "../smart-contracts" }
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" },
+    { "path": "../payment-detection/tsconfig.build.json" },
+    { "path": "../smart-contracts/tsconfig.build.json" }
   ]
 }

--- a/packages/payment-processor/tsconfig.build.json
+++ b/packages/payment-processor/tsconfig.build.json
@@ -5,5 +5,11 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [
+    { "path": "../types" },
+    { "path": "../utils" },
+    { "path": "../payment-detection" },
+    { "path": "../smart-contracts" }
+  ]
 }

--- a/packages/payment-processor/tsconfig.build.json
+++ b/packages/payment-processor/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/payment-processor/tsconfig.json
+++ b/packages/payment-processor/tsconfig.json
@@ -1,9 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [
-    { "path": "../types" },
-    { "path": "../utils" },
-    { "path": "../payment-detection" },
-    { "path": "../smart-contracts" }
-  ]
+  "extends": "../../tsconfig"
 }

--- a/packages/payment-processor/tsconfig.json
+++ b/packages/payment-processor/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/**/*"],
   "references": [
     { "path": "../types" },
     { "path": "../utils" },

--- a/packages/prototype-estimator/package.json
+++ b/packages/prototype-estimator/package.json
@@ -21,7 +21,8 @@
   },
   "main": "src/index.ts",
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "ganache-blocktime15": "ganache-cli -l 90000000 -p 8545 --blockTime 15 -m \"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\"",
     "start": "ts-node src/index.ts"
   },

--- a/packages/prototype-estimator/package.json
+++ b/packages/prototype-estimator/package.json
@@ -21,7 +21,7 @@
   },
   "main": "src/index.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "ganache-blocktime15": "ganache-cli -l 90000000 -p 8545 --blockTime 15 -m \"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\"",
     "start": "ts-node src/index.ts"

--- a/packages/prototype-estimator/tsconfig.build.json
+++ b/packages/prototype-estimator/tsconfig.build.json
@@ -7,13 +7,13 @@
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
   "references": [
-    { "path": "../data-access" },
-    { "path": "../epk-signature" },
-    { "path": "../ethereum-storage" },
-    { "path": "../multi-format" },
-    { "path": "../request-logic" },
-    { "path": "../request-client.js" },
-    { "path": "../transaction-manager" },
-    { "path": "../types" }
+    { "path": "../data-access/tsconfig.build.json" },
+    { "path": "../epk-signature/tsconfig.build.json" },
+    { "path": "../ethereum-storage/tsconfig.build.json" },
+    { "path": "../multi-format/tsconfig.build.json" },
+    { "path": "../request-logic/tsconfig.build.json" },
+    { "path": "../request-client.js/tsconfig.build.json" },
+    { "path": "../transaction-manager/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" }
   ]
 }

--- a/packages/prototype-estimator/tsconfig.build.json
+++ b/packages/prototype-estimator/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/prototype-estimator/tsconfig.build.json
+++ b/packages/prototype-estimator/tsconfig.build.json
@@ -5,5 +5,15 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [
+    { "path": "../data-access" },
+    { "path": "../epk-signature" },
+    { "path": "../ethereum-storage" },
+    { "path": "../multi-format" },
+    { "path": "../request-logic" },
+    { "path": "../request-client.js" },
+    { "path": "../transaction-manager" },
+    { "path": "../types" }
+  ]
 }

--- a/packages/prototype-estimator/tsconfig.json
+++ b/packages/prototype-estimator/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/**/*"],
   "references": [
     { "path": "../data-access" },
     { "path": "../epk-signature" },

--- a/packages/prototype-estimator/tsconfig.json
+++ b/packages/prototype-estimator/tsconfig.json
@@ -1,13 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [
-    { "path": "../data-access" },
-    { "path": "../epk-signature" },
-    { "path": "../ethereum-storage" },
-    { "path": "../multi-format" },
-    { "path": "../request-logic" },
-    { "path": "../request-client.js" },
-    { "path": "../transaction-manager" },
-    { "path": "../types" }
-  ]
+  "extends": "../../tsconfig"
 }

--- a/packages/request-client.js/package.json
+++ b/packages/request-client.js/package.json
@@ -32,9 +32,9 @@
   ],
   "scripts": {
     "build": "run-s build:commonjs build:umd",
-    "build:commonjs": "tsc -b",
+    "build:commonjs": "tsc --project tsconfig.build.json",
     "build:umd": "webpack",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "docs": "shx rm -rf ./docs && compodoc -p tsconfig.json --output docs --disablePrivate --gaID UA-105153327-8",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/request-client.js/package.json
+++ b/packages/request-client.js/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "build": "run-s build:commonjs build:umd",
-    "build:commonjs": "tsc --project tsconfig.build.json",
+    "build:commonjs": "tsc -b tsconfig.build.json",
     "build:umd": "webpack",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "docs": "shx rm -rf ./docs && compodoc -p tsconfig.json --output docs --disablePrivate --gaID UA-105153327-8",

--- a/packages/request-client.js/tsconfig.build.json
+++ b/packages/request-client.js/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/request-client.js/tsconfig.build.json
+++ b/packages/request-client.js/tsconfig.build.json
@@ -7,16 +7,16 @@
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
   "references": [
-    { "path": "../advanced-logic" },
-    { "path": "../currency" },
-    { "path": "../data-access" },
-    { "path": "../data-format" },
-    { "path": "../epk-signature" },
-    { "path": "../multi-format" },
-    { "path": "../request-logic" },
-    { "path": "../smart-contracts" },
-    { "path": "../transaction-manager" },
-    { "path": "../payment-detection" },
-    { "path": "../types" }
+    { "path": "../advanced-logic/tsconfig.build.json" },
+    { "path": "../currency/tsconfig.build.json" },
+    { "path": "../data-access/tsconfig.build.json" },
+    { "path": "../data-format/tsconfig.build.json" },
+    { "path": "../epk-signature/tsconfig.build.json" },
+    { "path": "../multi-format/tsconfig.build.json" },
+    { "path": "../request-logic/tsconfig.build.json" },
+    { "path": "../smart-contracts/tsconfig.build.json" },
+    { "path": "../transaction-manager/tsconfig.build.json" },
+    { "path": "../payment-detection/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" }
   ]
 }

--- a/packages/request-client.js/tsconfig.build.json
+++ b/packages/request-client.js/tsconfig.build.json
@@ -5,5 +5,18 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [
+    { "path": "../advanced-logic" },
+    { "path": "../currency" },
+    { "path": "../data-access" },
+    { "path": "../data-format" },
+    { "path": "../epk-signature" },
+    { "path": "../multi-format" },
+    { "path": "../request-logic" },
+    { "path": "../smart-contracts" },
+    { "path": "../transaction-manager" },
+    { "path": "../payment-detection" },
+    { "path": "../types" }
+  ]
 }

--- a/packages/request-client.js/tsconfig.json
+++ b/packages/request-client.js/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [
-    { "path": "../advanced-logic" },
-    { "path": "../currency" },
-    { "path": "../data-access" },
-    { "path": "../data-format" },
-    { "path": "../epk-signature" },
-    { "path": "../multi-format" },
-    { "path": "../request-logic" },
-    { "path": "../smart-contracts" },
-    { "path": "../transaction-manager" },
-    { "path": "../payment-detection" },
-    { "path": "../types" }
-  ]
+  "extends": "../../tsconfig"
 }

--- a/packages/request-client.js/tsconfig.json
+++ b/packages/request-client.js/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/**/*"],
   "references": [
     { "path": "../advanced-logic" },
     { "path": "../currency" },

--- a/packages/request-logic/package.json
+++ b/packages/request-logic/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "example": "ts-node specs/example/example.ts",
     "lint": "eslint . --fix",

--- a/packages/request-logic/package.json
+++ b/packages/request-logic/package.json
@@ -31,8 +31,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "example": "ts-node specs/example/example.ts",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/request-logic/tsconfig.build.json
+++ b/packages/request-logic/tsconfig.build.json
@@ -5,5 +5,11 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [
+    { "path": "../advanced-logic" },
+    { "path": "../multi-format" },
+    { "path": "../types" },
+    { "path": "../utils" }
+  ]
 }

--- a/packages/request-logic/tsconfig.build.json
+++ b/packages/request-logic/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/request-logic/tsconfig.build.json
+++ b/packages/request-logic/tsconfig.build.json
@@ -7,9 +7,9 @@
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
   "references": [
-    { "path": "../advanced-logic" },
-    { "path": "../multi-format" },
-    { "path": "../types" },
-    { "path": "../utils" }
+    { "path": "../advanced-logic/tsconfig.build.json" },
+    { "path": "../multi-format/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" }
   ]
 }

--- a/packages/request-logic/tsconfig.json
+++ b/packages/request-logic/tsconfig.json
@@ -1,9 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [
-    { "path": "../advanced-logic" },
-    { "path": "../multi-format" },
-    { "path": "../types" },
-    { "path": "../utils" }
-  ]
+  "extends": "../../tsconfig"
 }

--- a/packages/request-logic/tsconfig.json
+++ b/packages/request-logic/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/**/*"],
   "references": [
     { "path": "../advanced-logic" },
     { "path": "../multi-format" },

--- a/packages/request-node/package.json
+++ b/packages/request-node/package.json
@@ -29,13 +29,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc --project tsconfig.build.json",
     "build:watch": "tsc -b --watch",
     "test": "jest --runInBand --forceExit",
     "test:watch": "yarn test --watch",
     "start": "ts-node src/server.ts",
     "start:watch": "ts-node-dev src/server.ts",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "init-ipfs": "node init-ipfs.js"

--- a/packages/request-node/package.json
+++ b/packages/request-node/package.json
@@ -29,8 +29,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
-    "build:watch": "tsc -b --watch",
+    "build": "tsc -b tsconfig.build.json",
+    "build:watch": "tsc -b tsconfig.build.json --watch",
     "test": "jest --runInBand --forceExit",
     "test:watch": "yarn test --watch",
     "start": "ts-node src/server.ts",

--- a/packages/request-node/tsconfig.build.json
+++ b/packages/request-node/tsconfig.build.json
@@ -5,5 +5,10 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [
+    { "path": "../data-access" },
+    { "path": "../ethereum-storage" },
+    { "path": "../types" }
+  ]
 }

--- a/packages/request-node/tsconfig.build.json
+++ b/packages/request-node/tsconfig.build.json
@@ -7,8 +7,8 @@
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
   "references": [
-    { "path": "../data-access" },
-    { "path": "../ethereum-storage" },
-    { "path": "../types" }
+    { "path": "../data-access/tsconfig.build.json" },
+    { "path": "../ethereum-storage/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" }
   ]
 }

--- a/packages/request-node/tsconfig.build.json
+++ b/packages/request-node/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/request-node/tsconfig.json
+++ b/packages/request-node/tsconfig.json
@@ -2,10 +2,5 @@
   "extends": "../../tsconfig",
   "compilerOptions": {
     "esModuleInterop": true
-  },
-  "references": [
-    { "path": "../data-access" },
-    { "path": "../ethereum-storage" },
-    { "path": "../types" }
-  ]
+  }
 }

--- a/packages/request-node/tsconfig.json
+++ b/packages/request-node/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src",
     "esModuleInterop": true
   },
-  "include": ["./src/**/*"],
   "references": [
     { "path": "../data-access" },
     { "path": "../ethereum-storage" },

--- a/packages/smart-contracts/package.json
+++ b/packages/smart-contracts/package.json
@@ -32,7 +32,7 @@
     "types"
   ],
   "scripts": {
-    "build:lib": "tsc --project tsconfig.build.json && cp src/types/*.d.ts dist/src/types && cp -r dist/src/types types",
+    "build:lib": "tsc -b tsconfig.build.json && cp src/types/*.d.ts dist/src/types && cp -r dist/src/types types",
     "build:sol": "yarn hardhat compile",
     "build": "yarn build:sol && yarn build:lib",
     "clean:types": "shx rm -rf types && shx rm -rf src/types",

--- a/packages/smart-contracts/package.json
+++ b/packages/smart-contracts/package.json
@@ -32,11 +32,11 @@
     "types"
   ],
   "scripts": {
-    "build:lib": "tsc -b && cp src/types/*.d.ts dist/src/types && cp -r dist/src/types types",
+    "build:lib": "tsc --project tsconfig.build.json && cp src/types/*.d.ts dist/src/types && cp -r dist/src/types types",
     "build:sol": "yarn hardhat compile",
     "build": "yarn build:sol && yarn build:lib",
     "clean:types": "shx rm -rf types && shx rm -rf src/types",
-    "clean:lib": "shx rm -rf dist",
+    "clean:lib": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "clean:hardhat": "shx rm -rf cache && shx rm -rf build",
     "clean": "yarn clean:lib && yarn clean:types && yarn clean:hardhat",
     "lint:lib": "eslint . --fix",

--- a/packages/smart-contracts/tsconfig.build.json
+++ b/packages/smart-contracts/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "scripts", "hardhat.config.ts"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/smart-contracts/tsconfig.build.json
+++ b/packages/smart-contracts/tsconfig.build.json
@@ -5,5 +5,6 @@
     "rootDir": "."
   },
   "include": ["src/**/*", "src/**/*.json", "scripts", "hardhat.config.ts"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [{ "path": "../currency" }, { "path": "../utils" }]
 }

--- a/packages/smart-contracts/tsconfig.build.json
+++ b/packages/smart-contracts/tsconfig.build.json
@@ -6,5 +6,8 @@
   },
   "include": ["src/**/*", "src/**/*.json", "scripts", "hardhat.config.ts"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
-  "references": [{ "path": "../currency" }, { "path": "../utils" }]
+  "references": [
+    { "path": "../currency/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/smart-contracts/tsconfig.json
+++ b/packages/smart-contracts/tsconfig.json
@@ -2,6 +2,5 @@
   "extends": "../../tsconfig",
   "compilerOptions": {
     "resolveJsonModule": true
-  },
-  "references": [{ "path": "../currency" }, { "path": "../utils" }]
+  }
 }

--- a/packages/smart-contracts/tsconfig.json
+++ b/packages/smart-contracts/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": ".",
     "resolveJsonModule": true
   },
-  "include": ["src", "src/**/*.json", "scripts", "hardhat.config.ts"],
   "references": [{ "path": "../currency" }, { "path": "../utils" }]
 }

--- a/packages/toolbox/package.json
+++ b/packages/toolbox/package.json
@@ -31,7 +31,7 @@
     "request-toolbox": "dist/cli.js"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/toolbox/package.json
+++ b/packages/toolbox/package.json
@@ -31,8 +31,8 @@
     "request-toolbox": "dist/cli.js"
   },
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "prepare": "yarn run build",

--- a/packages/toolbox/tsconfig.build.json
+++ b/packages/toolbox/tsconfig.build.json
@@ -7,9 +7,9 @@
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
   "references": [
-    { "path": "../epk-signature" },
-    { "path": "../request-client.js" },
-    { "path": "../smart-contracts" },
-    { "path": "../types" }
+    { "path": "../epk-signature/tsconfig.build.json" },
+    { "path": "../request-client.js/tsconfig.build.json" },
+    { "path": "../smart-contracts/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" }
   ]
 }

--- a/packages/toolbox/tsconfig.build.json
+++ b/packages/toolbox/tsconfig.build.json
@@ -5,5 +5,11 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [
+    { "path": "../epk-signature" },
+    { "path": "../request-client.js" },
+    { "path": "../smart-contracts" },
+    { "path": "../types" }
+  ]
 }

--- a/packages/toolbox/tsconfig.build.json
+++ b/packages/toolbox/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/toolbox/tsconfig.json
+++ b/packages/toolbox/tsconfig.json
@@ -1,12 +1,9 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src",
     "esModuleInterop": true,
     "lib": ["ES2019"]
   },
-  "include": ["./src/**/*"],
   "references": [
     {
       "path": "../epk-signature"

--- a/packages/toolbox/tsconfig.json
+++ b/packages/toolbox/tsconfig.json
@@ -3,19 +3,5 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "lib": ["ES2019"]
-  },
-  "references": [
-    {
-      "path": "../epk-signature"
-    },
-    {
-      "path": "../request-client.js"
-    },
-    {
-      "path": "../smart-contracts"
-    },
-    {
-      "path": "../types"
-    }
-  ]
+  }
 }

--- a/packages/transaction-manager/package.json
+++ b/packages/transaction-manager/package.json
@@ -31,8 +31,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "test": "jest",

--- a/packages/transaction-manager/package.json
+++ b/packages/transaction-manager/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/transaction-manager/tsconfig.build.json
+++ b/packages/transaction-manager/tsconfig.build.json
@@ -5,5 +5,6 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../multi-format" }]
 }

--- a/packages/transaction-manager/tsconfig.build.json
+++ b/packages/transaction-manager/tsconfig.build.json
@@ -6,5 +6,9 @@
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
-  "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../multi-format" }]
+  "references": [
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" },
+    { "path": "../multi-format/tsconfig.build.json" }
+  ]
 }

--- a/packages/transaction-manager/tsconfig.build.json
+++ b/packages/transaction-manager/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/transaction-manager/tsconfig.json
+++ b/packages/transaction-manager/tsconfig.json
@@ -1,9 +1,4 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/**/*"],
   "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../multi-format" }]
 }

--- a/packages/transaction-manager/tsconfig.json
+++ b/packages/transaction-manager/tsconfig.json
@@ -1,4 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [{ "path": "../types" }, { "path": "../utils" }, { "path": "../multi-format" }]
+  "extends": "../../tsconfig"
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,8 +31,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "prepare": "yarn run build"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/types/tsconfig.build.json
+++ b/packages/types/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src",
     "importHelpers": false
-  },
-  "include": ["./src/**/*"]
+  }
 }

--- a/packages/usage-examples/package.json
+++ b/packages/usage-examples/package.json
@@ -20,8 +20,8 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "start": "ts-node src/request-client-js-declarative-request.ts && ts-node src/request-client-js-erc20-request.ts && ts-node src/request-logic-clear-request.ts && ts-node src/request-logic-encrypted-request.ts",

--- a/packages/usage-examples/package.json
+++ b/packages/usage-examples/package.json
@@ -20,7 +20,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/usage-examples/tsconfig.build.json
+++ b/packages/usage-examples/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/usage-examples/tsconfig.build.json
+++ b/packages/usage-examples/tsconfig.build.json
@@ -5,5 +5,18 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [
+    { "path": "../data-access" },
+    { "path": "../epk-decryption" },
+    { "path": "../epk-signature" },
+    { "path": "../multi-format" },
+    { "path": "../payment-processor" },
+    { "path": "../payment-detection" },
+    { "path": "../transaction-manager" },
+    { "path": "../request-logic" },
+    { "path": "../request-client.js" },
+    { "path": "../types" },
+    { "path": "../utils" }
+  ]
 }

--- a/packages/usage-examples/tsconfig.build.json
+++ b/packages/usage-examples/tsconfig.build.json
@@ -7,16 +7,16 @@
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
   "references": [
-    { "path": "../data-access" },
-    { "path": "../epk-decryption" },
-    { "path": "../epk-signature" },
-    { "path": "../multi-format" },
-    { "path": "../payment-processor" },
-    { "path": "../payment-detection" },
-    { "path": "../transaction-manager" },
-    { "path": "../request-logic" },
-    { "path": "../request-client.js" },
-    { "path": "../types" },
-    { "path": "../utils" }
+    { "path": "../data-access/tsconfig.build.json" },
+    { "path": "../epk-decryption/tsconfig.build.json" },
+    { "path": "../epk-signature/tsconfig.build.json" },
+    { "path": "../multi-format/tsconfig.build.json" },
+    { "path": "../payment-processor/tsconfig.build.json" },
+    { "path": "../payment-detection/tsconfig.build.json" },
+    { "path": "../transaction-manager/tsconfig.build.json" },
+    { "path": "../request-logic/tsconfig.build.json" },
+    { "path": "../request-client.js/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" }
   ]
 }

--- a/packages/usage-examples/tsconfig.json
+++ b/packages/usage-examples/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/**/*"],
   "references": [
     { "path": "../data-access" },
     { "path": "../epk-decryption" },

--- a/packages/usage-examples/tsconfig.json
+++ b/packages/usage-examples/tsconfig.json
@@ -1,16 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [
-    { "path": "../data-access" },
-    { "path": "../epk-decryption" },
-    { "path": "../epk-signature" },
-    { "path": "../multi-format" },
-    { "path": "../payment-processor" },
-    { "path": "../payment-detection" },
-    { "path": "../transaction-manager" },
-    { "path": "../request-logic" },
-    { "path": "../request-client.js" },
-    { "path": "../types" },
-    { "path": "../utils" }
-  ]
+  "extends": "../../tsconfig"
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -31,8 +31,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "prepare": "yarn run build",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -5,5 +5,6 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [{ "path": "../types" }]
 }

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -6,5 +6,5 @@
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
-  "references": [{ "path": "../types" }]
+  "references": [{ "path": "../types/tsconfig.build.json" }]
 }

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,4 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [{ "path": "../types" }]
+  "extends": "../../tsconfig"
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,9 +1,4 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/**/*"],
   "references": [{ "path": "../types" }]
 }

--- a/packages/web3-signature/package.json
+++ b/packages/web3-signature/package.json
@@ -32,9 +32,9 @@
   ],
   "scripts": {
     "build": "run-s build:commonjs build:umd",
-    "build:commonjs": "tsc -b",
+    "build:commonjs": "tsc --project tsconfig.build.json",
     "build:umd": "webpack",
-    "clean": "shx rm -rf dist tsconfig.tsbuildinfo",
+    "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "test": "jest",

--- a/packages/web3-signature/package.json
+++ b/packages/web3-signature/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "build": "run-s build:commonjs build:umd",
-    "build:commonjs": "tsc --project tsconfig.build.json",
+    "build:commonjs": "tsc -b tsconfig.build.json",
     "build:umd": "webpack",
     "clean": "shx rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "eslint . --fix",

--- a/packages/web3-signature/tsconfig.build.json
+++ b/packages/web3-signature/tsconfig.build.json
@@ -6,5 +6,8 @@
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"],
-  "references": [{ "path": "../types" }, { "path": "../utils" }]
+  "references": [
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/web3-signature/tsconfig.build.json
+++ b/packages/web3-signature/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/web3-signature/tsconfig.build.json
+++ b/packages/web3-signature/tsconfig.build.json
@@ -5,5 +5,6 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "references": [{ "path": "../types" }, { "path": "../utils" }]
 }

--- a/packages/web3-signature/tsconfig.json
+++ b/packages/web3-signature/tsconfig.json
@@ -1,4 +1,3 @@
 {
-  "extends": "../../tsconfig",
-  "references": [{ "path": "../types" }, { "path": "../utils" }]
+  "extends": "../../tsconfig"
 }

--- a/packages/web3-signature/tsconfig.json
+++ b/packages/web3-signature/tsconfig.json
@@ -1,9 +1,4 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["./src/**/*"],
   "references": [{ "path": "../types" }, { "path": "../utils" }]
 }


### PR DESCRIPTION
## Context

Test files in our packages do not benefit from TS linting. This is because our `tsconfig.json` are including `src` files only, so test files are excluded from compilation and thus they are not linted.

## Description of the changes

This PR changes the way packages are built. In each package, TSC will use a `tsconfig.build.json` to compile the files. The standard `tsconfig.json` will not containe any `include`, `exclude`, `rootDir`, or `rootDirs` configuration. This way test files can be correctly linted by the IDE.