### PR TITLE
feat: ether to smart wallet payment

### DIFF
--- a/packages/smart-contracts/src/contracts/EthereumFeeProxy.sol
+++ b/packages/smart-contracts/src/contracts/EthereumFeeProxy.sol
@@ -1,78 +1,75 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 
 /**
  * @title EthereumFeeProxy
  * @notice This contract performs an Ethereum transfer with a Fee sent to a third address and stores a reference
  */
-contract EthereumFeeProxy is ReentrancyGuard{
-  // Event to declare a transfer with a reference
-  event TransferWithReferenceAndFee(
-    address to,
-    uint256 amount,
-    bytes indexed paymentReference,
-    uint256 feeAmount,
-    address feeAddress
-  );
-
-  // Fallback function returns funds to the sender
-  receive() external payable {
-    revert("not payable receive");
-  }
-
-
-  /**
-  * @notice Performs an Ethereum transfer with a reference
-  * @param _to Transfer recipient
-  * @param _paymentReference Reference of the payment related
-  * @param _feeAmount The amount of the payment fee (part of the msg.value)
-  * @param _feeAddress The fee recipient
-  */
-  function transferWithReferenceAndFee(
-    address payable _to,
-    bytes calldata _paymentReference,
-    uint256 _feeAmount,
-    address payable _feeAddress
-  )
-    external
-    payable
-  {
-    transferExactEthWithReferenceAndFee(
-      _to,
-      msg.value - _feeAmount,
-      _paymentReference,
-      _feeAmount,
-      _feeAddress
+contract EthereumFeeProxy is ReentrancyGuard {
+    // Event to declare a transfer with a reference
+    event TransferWithReferenceAndFee(
+        address to,
+        uint256 amount,
+        bytes indexed paymentReference,
+        uint256 feeAmount,
+        address feeAddress
     );
-  }
 
+    // Fallback function returns funds to the sender
+    receive() external payable {
+        revert('not payable receive');
+    }
 
-  /**
-  * @notice Performs an Ethereum transfer with a reference with an exact amount of eth
-  * @param _to Transfer recipient
-  * @param _amount Amount to transfer
-  * @param _paymentReference Reference of the payment related
-  * @param _feeAmount The amount of the payment fee (part of the msg.value)
-  * @param _feeAddress The fee recipient
-  */
-  function transferExactEthWithReferenceAndFee(
-    address payable _to,
-    uint256 _amount,
-    bytes calldata _paymentReference,
-    uint256 _feeAmount,
-    address payable _feeAddress
-  )
-    nonReentrant
-    public
-    payable
-  {
-    _to.transfer(_amount);
-    _feeAddress.transfer(_feeAmount);
-    // transfer the remaining ethers to the sender
-    payable(msg.sender).transfer(msg.value - _amount - _feeAmount);
+    /**
+     * @notice Performs an Ethereum transfer with a reference
+     * @param _to Transfer recipient
+     * @param _paymentReference Reference of the payment related
+     * @param _feeAmount The amount of the payment fee (part of the msg.value)
+     * @param _feeAddress The fee recipient
+     */
+    function transferWithReferenceAndFee(
+        address payable _to,
+        bytes calldata _paymentReference,
+        uint256 _feeAmount,
+        address payable _feeAddress
+    ) external payable {
+        transferExactEthWithReferenceAndFee(
+            _to,
+            msg.value - _feeAmount,
+            _paymentReference,
+            _feeAmount,
+            _feeAddress
+        );
+    }
 
-    emit TransferWithReferenceAndFee(_to, _amount, _paymentReference, _feeAmount, _feeAddress);
-  }
+    /**
+     * @notice Performs an Ethereum transfer with a reference with an exact amount of eth
+     * @param _to Transfer recipient
+     * @param _amount Amount to transfer
+     * @param _paymentReference Reference of the payment related
+     * @param _feeAmount The amount of the payment fee (part of the msg.value)
+     * @param _feeAddress The fee recipient
+     */
+    function transferExactEthWithReferenceAndFee(
+        address payable _to,
+        uint256 _amount,
+        bytes calldata _paymentReference,
+        uint256 _feeAmount,
+        address payable _feeAddress
+    ) public payable nonReentrant {
+        (bool sendSuccess, ) = _to.call{value: _amount}('');
+        require(sendSuccess, 'Could not pay the recipient');
+
+        _feeAddress.transfer(_feeAmount);
+
+        // transfer the remaining ethers to the sender
+        (bool sendBackSuccess, ) = payable(msg.sender).call{
+            value: msg.value - _amount - _feeAmount
+        }('');
+        require(sendBackSuccess, 'Could not send remaining funds to the payer');
+
+        emit TransferWithReferenceAndFee(_to, _amount, _paymentReference, _feeAmount, _feeAddress);
+    }
 }

--- a/packages/smart-contracts/src/contracts/EthereumProxy.sol
+++ b/packages/smart-contracts/src/contracts/EthereumProxy.sol
@@ -1,30 +1,30 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-
 /**
  * @title EthereumProxy
  * @notice This contract performs an Ethereum transfer and stores a reference
  */
 contract EthereumProxy {
-  // Event to declare a transfer with a reference
-  event TransferWithReference(address to, uint256 amount, bytes indexed paymentReference);
+    // Event to declare a transfer with a reference
+    event TransferWithReference(address to, uint256 amount, bytes indexed paymentReference);
 
-  // Fallback function returns funds to the sender
-  receive() external payable {
-    revert("not payable receive");
-  }
+    // Fallback function returns funds to the sender
+    receive() external payable {
+        revert('not payable receive');
+    }
 
-  /**
-  * @notice Performs an Ethereum transfer with a reference
-  * @param _to Transfer recipient
-  * @param _paymentReference Reference of the payment related
-  */
-  function transferWithReference(address payable _to, bytes calldata _paymentReference)
-    external
-    payable
-  {
-    _to.transfer(msg.value);
-    emit TransferWithReference(_to, msg.value, _paymentReference);
-  }
+    /**
+     * @notice Performs an Ethereum transfer with a reference
+     * @param _to Transfer recipient
+     * @param _paymentReference Reference of the payment related
+     */
+    function transferWithReference(address payable _to, bytes calldata _paymentReference)
+        external
+        payable
+    {
+        (bool success, ) = _to.call{value: msg.value}('');
+        require(success, 'Could not pay the recipient');
+        emit TransferWithReference(_to, msg.value, _paymentReference);
+    }
 }

--- a/packages/smart-contracts/src/contracts/test/EtherFallbackPayment.sol
+++ b/packages/smart-contracts/src/contracts/test/EtherFallbackPayment.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.7.0 <0.9.0;
+
+/// @title EtherPaymentFallback - A contract that has a fallback to accept ether payments
+/// @author Richard Meissner - <richard@gnosis.pm>
+contract EtherPaymentFallback {
+    event SafeReceived(address indexed sender, uint256 value);
+
+    /// @dev Fallback function accepts Ether transactions.
+    receive() external payable {
+        emit SafeReceived(msg.sender, msg.value);
+    }
+
+    constructor() {}
+}

--- a/packages/smart-contracts/src/contracts/test/GnosisProxy.sol
+++ b/packages/smart-contracts/src/contracts/test/GnosisProxy.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.0;
 
 contract GnosisSafeProxy {
-    // singleton always needs to be first declared variable, to ensure that it is at the same location in the contracts to which calls are delegated.
-    // To reduce deployment costs this variable is internal and needs to be retrieved via `getStorageAt`
     address internal singleton;
 
     /// @dev Constructor function sets address of singleton contract.

--- a/packages/smart-contracts/src/contracts/test/GnosisProxy.sol
+++ b/packages/smart-contracts/src/contracts/test/GnosisProxy.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GnosisSafeProxy {
+    // singleton always needs to be first declared variable, to ensure that it is at the same location in the contracts to which calls are delegated.
+    // To reduce deployment costs this variable is internal and needs to be retrieved via `getStorageAt`
+    address internal singleton;
+
+    /// @dev Constructor function sets address of singleton contract.
+    /// @param _singleton Singleton address.
+    constructor(address _singleton) {
+        require(_singleton != address(0), 'Invalid singleton address provided');
+        singleton = _singleton;
+    }
+
+    /// @dev Fallback function forwards all transactions and returns all received return data.
+    fallback() external payable {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            let _singleton := and(sload(0), 0xffffffffffffffffffffffffffffffffffffffff)
+            // 0xa619486e == keccak("masterCopy()"). The value is right padded to 32-bytes with 0s
+            if eq(
+                calldataload(0),
+                0xa619486e00000000000000000000000000000000000000000000000000000000
+            ) {
+                mstore(0, _singleton)
+                return(0, 0x20)
+            }
+            calldatacopy(0, 0, calldatasize())
+            let success := delegatecall(gas(), _singleton, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            if eq(success, 0) {
+                revert(0, returndatasize())
+            }
+            return(0, returndatasize())
+        }
+    }
+}

--- a/packages/smart-contracts/test/contracts/EthereumFeeProxy.test.ts
+++ b/packages/smart-contracts/test/contracts/EthereumFeeProxy.test.ts
@@ -2,7 +2,13 @@ import { ethers, network } from 'hardhat';
 import { BigNumber, Signer } from 'ethers';
 import { expect, use } from 'chai';
 import { solidity } from 'ethereum-waffle';
-import { EthereumFeeProxy } from '../../src/types';
+import {
+  EthereumFeeProxy,
+  EtherPaymentFallback,
+  EtherPaymentFallback__factory,
+  GnosisSafeProxy,
+  GnosisSafeProxy__factory,
+} from '../../src/types';
 import { ethereumFeeProxyArtifact } from '../../src/lib/';
 import { HttpNetworkConfig } from 'hardhat/types';
 
@@ -12,6 +18,8 @@ describe('contract: EthereumFeeProxy', () => {
   let to: string;
   let signer: Signer;
   let ethFeeProxy: EthereumFeeProxy;
+  let gnosisSafeProxy: GnosisSafeProxy;
+  let etherPaymentFallback: EtherPaymentFallback;
   const referenceExample = '0xaaaa';
   const amount = BigNumber.from('10000000000000000');
   const feeAmount = BigNumber.from('2000000000000000');
@@ -23,6 +31,10 @@ describe('contract: EthereumFeeProxy', () => {
     [, to] = (await ethers.getSigners()).map((s) => s.address);
     [signer] = await ethers.getSigners();
     ethFeeProxy = ethereumFeeProxyArtifact.connect(network.name, signer);
+    etherPaymentFallback = await new EtherPaymentFallback__factory(signer).deploy();
+    gnosisSafeProxy = await new GnosisSafeProxy__factory(signer).deploy(
+      etherPaymentFallback.address,
+    );
   });
 
   it('allows to pays with a reference', async () => {
@@ -98,5 +110,71 @@ describe('contract: EthereumFeeProxy', () => {
         value: feeAmount,
       }),
     ).to.be.revertedWith('revert');
+  });
+
+  it('allows to pay with a reference to a gnosis safe', async () => {
+    const gnosisSafeProxyOldBalance = await provider.getBalance(gnosisSafeProxy.address);
+
+    await expect(
+      ethFeeProxy.transferWithReferenceAndFee(
+        gnosisSafeProxy.address,
+        referenceExample,
+        feeAmount,
+        feeAddress,
+        {
+          value: amount.add(feeAmount),
+        },
+      ),
+    )
+      .to.emit(ethFeeProxy, 'TransferWithReferenceAndFee')
+      .withArgs(
+        gnosisSafeProxy.address,
+        amount.toString(),
+        ethers.utils.keccak256(referenceExample),
+        feeAmount.toString(),
+        feeAddress,
+      );
+
+    const gnosisSafeProxyNewBalance = await provider.getBalance(gnosisSafeProxy.address);
+    expect(gnosisSafeProxyNewBalance.toString()).to.equals(
+      gnosisSafeProxyOldBalance.add(amount).toString(),
+    );
+  });
+
+  it('allows to pays exact eth with a reference with extra msg.value to a gnosisSafe', async () => {
+    const gnosisSafeOldBalance = await provider.getBalance(gnosisSafeProxy.address);
+    const feeAddressOldBalance = await provider.getBalance(feeAddress);
+
+    await expect(
+      ethFeeProxy.transferExactEthWithReferenceAndFee(
+        gnosisSafeProxy.address,
+        amount,
+        referenceExample,
+        feeAmount,
+        feeAddress,
+        {
+          value: amount.add(feeAmount).add('10000'),
+        },
+      ),
+    )
+      .to.emit(ethFeeProxy, 'TransferWithReferenceAndFee')
+      .withArgs(
+        gnosisSafeProxy.address,
+        amount.toString(),
+        ethers.utils.keccak256(referenceExample),
+        feeAmount.toString(),
+        feeAddress,
+      );
+
+    const gnosisSafeNewBalance = await provider.getBalance(gnosisSafeProxy.address);
+    const feeAddressNewBalance = await provider.getBalance(feeAddress);
+    const contractBalance = await provider.getBalance(ethFeeProxy.address);
+
+    // Check balance changes
+    expect(gnosisSafeNewBalance.toString()).to.equals(gnosisSafeOldBalance.add(amount).toString());
+    expect(feeAddressNewBalance.toString()).to.equals(
+      feeAddressOldBalance.add(feeAmount).toString(),
+    );
+    expect(contractBalance.toString()).to.equals('0');
   });
 });

--- a/packages/smart-contracts/test/contracts/EthereumProxy.test.ts
+++ b/packages/smart-contracts/test/contracts/EthereumProxy.test.ts
@@ -2,7 +2,13 @@ import { ethers, network } from 'hardhat';
 import { Signer } from 'ethers';
 import { expect, use } from 'chai';
 import { solidity } from 'ethereum-waffle';
-import { EthereumProxy } from '../../src/types';
+import {
+  EthereumProxy,
+  EtherPaymentFallback,
+  EtherPaymentFallback__factory,
+  GnosisSafeProxy,
+  GnosisSafeProxy__factory,
+} from '../../src/types';
 import { ethereumProxyArtifact } from '../../src/lib/';
 import { HttpNetworkConfig } from 'hardhat/types';
 
@@ -13,6 +19,8 @@ describe('contract: EthereumProxy', () => {
   let to: string;
   let signer: Signer;
   let ethProxy: EthereumProxy;
+  let gnosisSafeProxy: GnosisSafeProxy;
+  let etherPaymentFallback: EtherPaymentFallback;
   const referenceExample = '0xaaaa';
   const DEFAULT_GAS_PRICE = ethers.BigNumber.from('100000000000');
   const amount = ethers.BigNumber.from('10000000000000000');
@@ -23,6 +31,10 @@ describe('contract: EthereumProxy', () => {
     [from, to] = (await ethers.getSigners()).map((s) => s.address);
     [signer] = await ethers.getSigners();
     ethProxy = ethereumProxyArtifact.connect(network.name, signer);
+    etherPaymentFallback = await new EtherPaymentFallback__factory(signer).deploy();
+    gnosisSafeProxy = await new GnosisSafeProxy__factory(signer).deploy(
+      etherPaymentFallback.address,
+    );
   });
 
   it('allows to store a reference', async () => {
@@ -53,5 +65,27 @@ describe('contract: EthereumProxy', () => {
     expect(fromNewBalance).to.be.lt(fromOldBalance.sub(amount));
     expect(fromNewBalance).to.be.gt(fromOldBalance.sub(amount).mul(95).div(100));
     expect(toNewBalance.toString()).to.equals(toOldBalance.add(amount).toString());
+  });
+
+  it('allow to transfer ethers to a gnosis safe', async () => {
+    const fromOldBalance = await provider.getBalance(from);
+    const gnosisSafeProxyOldBalance = await provider.getBalance(gnosisSafeProxy.address);
+
+    await (
+      await ethProxy.transferWithReference(gnosisSafeProxy.address, referenceExample, {
+        value: amount,
+        gasPrice: DEFAULT_GAS_PRICE,
+      })
+    ).wait();
+
+    const fromNewBalance = await provider.getBalance(from);
+    const gnosisSafeProxyNewBalance = await provider.getBalance(gnosisSafeProxy.address);
+
+    // Check balance changes
+    expect(fromNewBalance).to.be.lt(fromOldBalance.sub(amount));
+    expect(fromNewBalance).to.be.gt(fromOldBalance.sub(amount).mul(95).div(100));
+    expect(gnosisSafeProxyNewBalance.toString()).to.equals(
+      gnosisSafeProxyOldBalance.add(amount).toString(),
+    );
   });
 });


### PR DESCRIPTION
## Description of the changes

Enables to pay requests in ether when the recipient is a proxy smart contract, like smart wallet such as Gnosis Safe.

The `.transfer` is limited to 2300 gas, so when a payment recipient was a Gnosis Safe, we did not pass enough gas for it to execute it's fallback function. I changed it to `.call` which pass all the remaining transaction gas.

New tests cover for this specific case. 
