### PR TITLE
refactor: payment-processor

### DIFF
--- a/packages/payment-processor/src/index.ts
+++ b/packages/payment-processor/src/index.ts
@@ -12,6 +12,8 @@ export * from './payment/swap-any-to-erc20';
 export * from './payment/swap-erc20';
 export * from './payment/swap-erc20-fee-proxy';
 export * from './payment/conversion-erc20';
+export * from './payment/any-to-erc20-proxy';
+export * from './payment/any-to-eth-proxy';
 export * as Escrow from './payment/erc20-escrow-payment';
 import * as utils from './payment/utils';
 

--- a/packages/payment-processor/src/payment/any-to-erc20-proxy.ts
+++ b/packages/payment-processor/src/payment/any-to-erc20-proxy.ts
@@ -30,7 +30,7 @@ import { IConversionPaymentSettings } from './index';
  */
 export async function payAnyToErc20ProxyRequest(
   request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Provider | Signer = getProvider(),
   paymentSettings: IConversionPaymentSettings,
   amount?: BigNumberish,
   feeAmount?: BigNumberish,

--- a/packages/payment-processor/src/payment/any-to-eth-proxy.ts
+++ b/packages/payment-processor/src/payment/any-to-eth-proxy.ts
@@ -24,7 +24,7 @@ import { getProxyAddress } from './utils';
  */
 export async function payAnyToEthProxyRequest(
   request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Provider | Signer = getProvider(),
   paymentSettings: IConversionPaymentSettings,
   amount?: BigNumberish,
   feeAmount?: BigNumberish,

--- a/packages/payment-processor/src/payment/conversion-erc20.ts
+++ b/packages/payment-processor/src/payment/conversion-erc20.ts
@@ -6,6 +6,7 @@ import { ClientTypes } from '@requestnetwork/types';
 import { ITransactionOverrides } from './transaction-overrides';
 import { getProvider, getSigner, getProxyAddress } from './utils';
 import { checkErc20Allowance, encodeApproveAnyErc20 } from './erc20';
+import { IPreparedTransaction } from './prepared-transaction';
 
 /**
  * Processes the approval transaction of a given payment ERC20 to be spent by the conversion proxy,
@@ -25,13 +26,12 @@ export async function approveErc20ForProxyConversionIfNeeded(
   minAmount: BigNumberish,
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction | void> {
-  const proxyAddress = getProxyAddress(request, AnyToERC20PaymentDetector.getDeploymentInformation);
   if (
-    !(await checkErc20Allowance(
+    !(await hasErc20AllowanceForProxyConversion(
+      request,
       ownerAddress,
-      proxyAddress,
-      signerOrProvider,
       paymentTokenAddress,
+      signerOrProvider,
       minAmount,
     ))
   ) {
@@ -42,6 +42,31 @@ export async function approveErc20ForProxyConversionIfNeeded(
       overrides,
     );
   }
+}
+
+/**
+ * Verify if a given payment ERC20 can be spent by the conversion proxy,
+ * @param request request to pay, used to know the network
+ * @param ownerAddress address of the payer
+ * @param paymentTokenAddress ERC20 currency used to pay
+ * @param signerOrProvider the web3 provider. Defaults to Etherscan.
+ * @param minAmount ensures the approved amount is sufficient to pay this amount
+ */
+export async function hasErc20AllowanceForProxyConversion(
+  request: ClientTypes.IRequestData,
+  ownerAddress: string,
+  paymentTokenAddress: string,
+  signerOrProvider: providers.Provider | Signer = getProvider(),
+  minAmount: BigNumberish,
+): Promise<boolean> {
+  const proxyAddress = getProxyAddress(request, AnyToERC20PaymentDetector.getDeploymentInformation);
+  return checkErc20Allowance(
+    ownerAddress,
+    proxyAddress,
+    signerOrProvider,
+    paymentTokenAddress,
+    minAmount,
+  );
 }
 
 /**
@@ -58,14 +83,37 @@ export async function approveErc20ForProxyConversion(
   signerOrProvider: providers.Provider | Signer = getProvider(),
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {
+  const preparedTx = prepareApproveErc20ForProxyConversion(
+    request,
+    paymentTokenAddress,
+    signerOrProvider,
+    overrides,
+  );
+  const signer = getSigner(signerOrProvider);
+  const tx = await signer.sendTransaction(preparedTx);
+  return tx;
+}
+
+/**
+ * Prepare the approval transaction of the payment ERC20 to be spent by the conversion proxy,
+ * during the fee proxy delegate call.
+ * @param request request to pay, used to know the network
+ * @param paymentTokenAddress picked currency to pay
+ * @param signerOrProvider the web3 provider. Defaults to Etherscan.
+ * @param overrides optionally, override default transaction values, like gas.
+ */
+export function prepareApproveErc20ForProxyConversion(
+  request: ClientTypes.IRequestData,
+  paymentTokenAddress: string,
+  signerOrProvider: providers.Provider | Signer = getProvider(),
+  overrides?: ITransactionOverrides,
+): IPreparedTransaction {
   const proxyAddress = getProxyAddress(request, AnyToERC20PaymentDetector.getDeploymentInformation);
   const encodedTx = encodeApproveAnyErc20(paymentTokenAddress, proxyAddress, signerOrProvider);
-  const signer = getSigner(signerOrProvider);
-  const tx = await signer.sendTransaction({
+  return {
     data: encodedTx,
     to: paymentTokenAddress,
     value: 0,
     ...overrides,
-  });
-  return tx;
+  };
 }

--- a/packages/payment-processor/src/payment/conversion-erc20.ts
+++ b/packages/payment-processor/src/payment/conversion-erc20.ts
@@ -27,7 +27,7 @@ export async function approveErc20ForProxyConversionIfNeeded(
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction | void> {
   if (
-    !(await hasErc20AllowanceForProxyConversion(
+    !(await hasErc20ApprovalForProxyConversion(
       request,
       ownerAddress,
       paymentTokenAddress,
@@ -52,7 +52,7 @@ export async function approveErc20ForProxyConversionIfNeeded(
  * @param signerOrProvider the web3 provider. Defaults to Etherscan.
  * @param minAmount ensures the approved amount is sufficient to pay this amount
  */
-export async function hasErc20AllowanceForProxyConversion(
+export async function hasErc20ApprovalForProxyConversion(
   request: ClientTypes.IRequestData,
   ownerAddress: string,
   paymentTokenAddress: string,

--- a/packages/payment-processor/src/payment/erc20-fee-proxy.ts
+++ b/packages/payment-processor/src/payment/erc20-fee-proxy.ts
@@ -26,7 +26,7 @@ import { IPreparedTransaction } from './prepared-transaction';
  */
 export async function payErc20FeeProxyRequest(
   request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Provider | Signer = getProvider(),
   amount?: BigNumberish,
   feeAmount?: BigNumberish,
   overrides?: ITransactionOverrides,

--- a/packages/payment-processor/src/payment/erc20-proxy.ts
+++ b/packages/payment-processor/src/payment/erc20-proxy.ts
@@ -24,7 +24,7 @@ import { IPreparedTransaction } from './prepared-transaction';
  */
 export async function payErc20ProxyRequest(
   request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Provider | Signer = getProvider(),
   amount?: BigNumberish,
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {

--- a/packages/payment-processor/src/payment/erc20.ts
+++ b/packages/payment-processor/src/payment/erc20.ts
@@ -17,6 +17,7 @@ import {
   getSigner,
   validateRequest,
 } from './utils';
+import { IPreparedTransaction } from './prepared-transaction';
 
 /**
  * Processes a transaction to pay an ERC20 Request.
@@ -29,7 +30,7 @@ import {
  */
 export async function payErc20Request(
   request: ClientTypes.IRequestData,
-  signerOrProvider?: providers.Web3Provider | Signer,
+  signerOrProvider?: providers.Provider | Signer,
   amount?: BigNumberish,
   feeAmount?: BigNumberish,
   overrides?: ITransactionOverrides,
@@ -122,19 +123,35 @@ export async function approveErc20IfNeeded(
  */
 export async function approveErc20(
   request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Provider | Signer = getProvider(),
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {
-  const encodedTx = encodeApproveErc20(request, signerOrProvider);
+  const preparedTx = prepareApproveErc20(request, signerOrProvider, overrides);
   const signer = getSigner(signerOrProvider);
+  const tx = await signer.sendTransaction(preparedTx);
+  return tx;
+}
+
+/**
+ * Prepare the transaction to approve the proxy to spend signer's tokens to pay
+ * the request in its payment currency. Can be used with a Multisig contract.
+ * @param request request to pay
+ * @param provider the web3 provider. Defaults to Etherscan.
+ * @param overrides optionally, override default transaction values, like gas.
+ */
+export function prepareApproveErc20(
+  request: ClientTypes.IRequestData,
+  signerOrProvider: providers.Provider | Signer = getProvider(),
+  overrides?: ITransactionOverrides,
+): IPreparedTransaction {
+  const encodedTx = encodeApproveErc20(request, signerOrProvider);
   const tokenAddress = request.currencyInfo.value;
-  const tx = await signer.sendTransaction({
+  return {
     data: encodedTx,
     to: tokenAddress,
     value: 0,
     ...overrides,
-  });
-  return tx;
+  };
 }
 
 /**
@@ -145,7 +162,7 @@ export async function approveErc20(
  */
 export function encodeApproveErc20(
   request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Provider | Signer = getProvider(),
 ): string {
   const paymentNetworkId = (getPaymentNetworkExtension(request)
     ?.id as unknown) as PaymentTypes.PAYMENT_NETWORK_ID;

--- a/packages/payment-processor/src/payment/eth-fee-proxy.ts
+++ b/packages/payment-processor/src/payment/eth-fee-proxy.ts
@@ -25,7 +25,7 @@ import { IPreparedTransaction } from './prepared-transaction';
  */
 export async function payEthFeeProxyRequest(
   request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Provider | Signer = getProvider(),
   amount?: BigNumberish,
   feeAmount?: BigNumberish,
   overrides?: ITransactionOverrides,
@@ -38,7 +38,6 @@ export async function payEthFeeProxyRequest(
 /**
  * Encodes the call to pay a request through the ETH fee proxy contract, can be used with a Multisig contract.
  * @param request request to pay
- * @param signerOrProvider the Web3 provider, or signer. Defaults to window.ethereum.
  * @param amount optionally, the amount to pay. Defaults to remaining amount of the request.
  * @param feeAmountOverride optionally, the fee amount to pay. Defaults to the fee amount of the request.
  */

--- a/packages/payment-processor/src/payment/eth-input-data.ts
+++ b/packages/payment-processor/src/payment/eth-input-data.ts
@@ -10,6 +10,7 @@ import {
   getSigner,
   validateRequest,
 } from './utils';
+import { IPreparedTransaction } from './prepared-transaction';
 
 /**
  * processes the transaction to pay an ETH request.
@@ -20,23 +21,38 @@ import {
  */
 export async function payEthInputDataRequest(
   request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Provider | Signer = getProvider(),
   amount?: BigNumberish,
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {
-  validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ETH_INPUT_DATA);
   const signer = getSigner(signerOrProvider);
+  const preparedTx = prepareEthInputDataRequest(request, amount, overrides);
+  const tx = await signer.sendTransaction(preparedTx);
+  return tx;
+}
+
+/**
+ * processes the transaction to pay an ETH request.
+ * @param request the request to pay
+ * @param amount optionally, the amount to pay. Defaults to remaining amount of the request.
+ * @param overrides optionally, override default transaction values, like gas.
+ */
+export function prepareEthInputDataRequest(
+  request: ClientTypes.IRequestData,
+  amount?: BigNumberish,
+  overrides?: ITransactionOverrides,
+): IPreparedTransaction {
+  validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ETH_INPUT_DATA);
   const { paymentReference, paymentAddress } = getRequestPaymentValues(request);
 
   const amountToPay = getAmountToPay(request, amount);
 
-  const tx = await signer.sendTransaction({
+  return {
     data: `0x${paymentReference}`,
     to: paymentAddress,
     value: amountToPay,
     ...overrides,
-  });
-  return tx;
+  };
 }
 
 /**

--- a/packages/payment-processor/src/payment/eth-proxy.ts
+++ b/packages/payment-processor/src/payment/eth-proxy.ts
@@ -22,7 +22,7 @@ import { IPreparedTransaction } from './prepared-transaction';
  */
 export async function payEthProxyRequest(
   request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Provider | Signer = getProvider(),
   amount?: BigNumberish,
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {

--- a/packages/payment-processor/src/payment/swap-any-to-erc20.ts
+++ b/packages/payment-processor/src/payment/swap-any-to-erc20.ts
@@ -13,6 +13,7 @@ import {
 } from './utils';
 import { CurrencyManager, UnsupportedCurrencyError } from '@requestnetwork/currency';
 import { IRequestPaymentOptions } from './settings';
+import { IPreparedTransaction } from './prepared-transaction';
 
 export { ISwapSettings } from './swap-erc20-fee-proxy';
 
@@ -24,9 +25,26 @@ export { ISwapSettings } from './swap-erc20-fee-proxy';
  */
 export async function swapToPayAnyToErc20Request(
   request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Provider | Signer = getProvider(),
   options: IRequestPaymentOptions,
 ): Promise<ContractTransaction> {
+  const preparedTx = prepareSwapToPayAnyToErc20Request(request, signerOrProvider, options);
+  const signer = getSigner(signerOrProvider);
+  const tx = await signer.sendTransaction(preparedTx);
+  return tx;
+}
+
+/**
+ * Processes a transaction to swap tokens and pay an ERC20 Request through a proxy with fees.
+ * @param request
+ * @param signerOrProvider the Web3 provider, or signer. Defaults to window.ethereum.
+ * @param options to override amount, feeAmount and transaction parameters
+ */
+export function prepareSwapToPayAnyToErc20Request(
+  request: ClientTypes.IRequestData,
+  signerOrProvider: providers.Provider | Signer = getProvider(),
+  options: IRequestPaymentOptions,
+): IPreparedTransaction {
   if (!request.extensions[PaymentTypes.PAYMENT_NETWORK_ID.ANY_TO_ERC20_PROXY]) {
     throw new Error(`The request must have the payment network any-to-erc20-proxy`);
   }
@@ -39,15 +57,13 @@ export async function swapToPayAnyToErc20Request(
 
   const encodedTx = encodeSwapToPayAnyToErc20Request(request, signerOrProvider, options);
   const proxyAddress = erc20SwapConversionArtifact.getAddress(network);
-  const signer = getSigner(signerOrProvider);
 
-  const tx = await signer.sendTransaction({
+  return {
     data: encodedTx,
     to: proxyAddress,
     value: 0,
     ...options?.overrides,
-  });
-  return tx;
+  };
 }
 
 /**
@@ -58,7 +74,7 @@ export async function swapToPayAnyToErc20Request(
  */
 export function encodeSwapToPayAnyToErc20Request(
   request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
+  signerOrProvider: providers.Provider | Signer = getProvider(),
   options: IRequestPaymentOptions,
 ): string {
   const conversionSettings = options?.conversion;


### PR DESCRIPTION
## Description of the changes

Refactoring of the payment-processor package.

Before:
- For some payment methods we had signing, preparing and encoding functions, in others only signing and encoding.
- Same kind of issue for approval functions.
- In some files we used `Web3Provider `in other `Provider`

Now:
- All payment methods have signing, preparing and encoding functions.
- All kind of approvals have distinct `approvefNeeded`, `hasApproval` and `prepareApproval` functions 
- All files use `Provider` which allows to pass `ethers.providers.JsonRpcProvider` which can be useful if we only want to prepare a transaction and sign it externally.

