### PR TITLE
feat: transaction encoding

### DIFF
--- a/packages/payment-processor/src/index.ts
+++ b/packages/payment-processor/src/index.ts
@@ -14,6 +14,8 @@ export * from './payment/swap-erc20-fee-proxy';
 export * from './payment/conversion-erc20';
 export * from './payment/any-to-erc20-proxy';
 export * from './payment/any-to-eth-proxy';
+export * from './payment/encoder-payment';
+export * from './payment/encoder-approval';
 export * as Escrow from './payment/erc20-escrow-payment';
 import * as utils from './payment/utils';
 

--- a/packages/payment-processor/src/payment/encoder-approval.ts
+++ b/packages/payment-processor/src/payment/encoder-approval.ts
@@ -174,6 +174,25 @@ export function encodeRequestErc20ApprovalWithSwap(
 }
 
 /**
+ * Check if for a given request and user, an approval transaction is needed.
+ * @param request the request
+ * @param provider generic provider
+ * @param from user who will make the payment
+ * @param options specific to the request payment (conversion, ...)
+ */
+export async function isRequestErc20ApprovalNeeded(
+  request: ClientTypes.IRequestData,
+  provider: providers.Provider,
+  from: string,
+  options?: IRequestPaymentOptions,
+): Promise<boolean> {
+  if (options && options.swap) {
+    return isRequestErc20ApprovalWithSwapNeeded(request, provider, from, options);
+  }
+  return isRequestErc20ApprovalWithoutSwapNeeded(request, provider, from, options);
+}
+
+/**
  * Check if for a given request and user, an approval transaction is needed when swap is not used.
  * @param request the request
  * @param provider generic provider

--- a/packages/payment-processor/src/payment/encoder-approval.ts
+++ b/packages/payment-processor/src/payment/encoder-approval.ts
@@ -104,12 +104,13 @@ export function encodeRequestErc20ApprovalWithoutSwap(
   options?: IRequestPaymentOptions,
 ): IPreparedTransaction | void {
   const paymentNetwork = getPaymentNetworkExtension(request)?.id;
+  const overrides = options?.overrides ? options.overrides : undefined;
 
   switch (paymentNetwork) {
     case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT:
-      return prepareApproveErc20(request, provider);
+      return prepareApproveErc20(request, provider, overrides);
     case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT:
-      return prepareApproveErc20(request, provider);
+      return prepareApproveErc20(request, provider, overrides);
     case ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY: {
       if (
         !options ||
@@ -123,6 +124,7 @@ export function encodeRequestErc20ApprovalWithoutSwap(
         request,
         options.conversion.currency.value,
         provider,
+        overrides,
       );
     }
   }
@@ -140,11 +142,12 @@ export function encodeRequestErc20ApprovalWithSwap(
   options: IRequestPaymentOptions,
 ): IPreparedTransaction | void {
   const paymentNetwork = getPaymentNetworkExtension(request)?.id;
+  const overrides = options?.overrides ? options.overrides : undefined;
 
   switch (paymentNetwork) {
     case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT:
       if (options && options.swap) {
-        return prepareApprovalErc20ForSwapToPay(request, options.swap.path[0], provider);
+        return prepareApprovalErc20ForSwapToPay(request, options.swap.path[0], provider, overrides);
       } else {
         throw new Error('No swap options');
       }
@@ -163,6 +166,7 @@ export function encodeRequestErc20ApprovalWithSwap(
           request,
           options.swap.path[0],
           provider,
+          overrides,
         );
       } else {
         throw new Error('No swap options');

--- a/packages/payment-processor/src/payment/encoder-approval.ts
+++ b/packages/payment-processor/src/payment/encoder-approval.ts
@@ -1,0 +1,145 @@
+import { IRequestPaymentOptions } from './settings';
+import { IPreparedTransaction } from './prepared-transaction';
+import { providers, BigNumber } from 'ethers';
+import { hasErc20Approval, prepareApproveErc20 } from './erc20';
+import { ClientTypes, ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
+import {
+  hasErc20ApprovalForProxyConversion,
+  prepareApproveErc20ForProxyConversion,
+} from './conversion-erc20';
+import { hasApprovalErc20ForSwapToPay, prepareApprovalErc20ForSwapToPay } from './swap-erc20';
+import {
+  hasErc20ApprovalForSwapWithConversion,
+  prepareApprovalErc20ForSwapWithConversionToPay,
+} from './swap-conversion-erc20';
+import { getPaymentNetworkExtension } from './utils';
+
+export function encodeRequestApprovalIfNeeded(
+  request: ClientTypes.IRequestData,
+  provider: providers.Provider,
+  from: string,
+  options?: IRequestPaymentOptions,
+): Promise<IPreparedTransaction | void> {
+  if (options && options.swap) {
+    return encodeRequestApprovalWithSwapIfNeeded(request, provider, from, options);
+  } else {
+    return encodeRequestApprovalWithoutSwapIfNeeded(request, provider, from, options);
+  }
+}
+
+export async function encodeRequestApprovalWithoutSwapIfNeeded(
+  request: ClientTypes.IRequestData,
+  provider: providers.Provider,
+  from: string,
+  options?: IRequestPaymentOptions,
+): Promise<IPreparedTransaction | void> {
+  const paymentNetwork = getPaymentNetworkExtension(request)?.id;
+
+  switch (paymentNetwork) {
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT:
+      if (!(await hasErc20Approval(request, from))) {
+        return prepareApproveErc20(request, provider);
+      }
+      break;
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT:
+      if (!(await hasErc20Approval(request, from))) {
+        return prepareApproveErc20(request, provider);
+      }
+
+      break;
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY: {
+      if (
+        !options ||
+        !options.conversion ||
+        !options.conversion.currency ||
+        options.conversion.currency.type !== RequestLogicTypes.CURRENCY.ERC20
+      ) {
+        throw new Error('Conversion settings missing');
+      }
+      const amount = options.conversion.maxToSpend
+        ? options.conversion.maxToSpend
+        : BigNumber.from(0);
+      if (
+        !(await hasErc20ApprovalForProxyConversion(
+          request,
+          from,
+          options.conversion.currency.value,
+          provider,
+          amount,
+        ))
+      ) {
+        return prepareApproveErc20ForProxyConversion(
+          request,
+          options.conversion.currency.value,
+          provider,
+        );
+      }
+      break;
+    }
+  }
+}
+
+export async function encodeRequestApprovalWithSwapIfNeeded(
+  request: ClientTypes.IRequestData,
+  provider: providers.Provider,
+  from: string,
+  options: IRequestPaymentOptions,
+): Promise<IPreparedTransaction | void> {
+  const paymentNetwork = getPaymentNetworkExtension(request)?.id;
+
+  switch (paymentNetwork) {
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT:
+      if (options && options.swap) {
+        if (
+          !(await hasApprovalErc20ForSwapToPay(
+            request,
+            from,
+            options.swap.path[0],
+            provider,
+            options.swap.maxInputAmount,
+          ))
+        ) {
+          return prepareApprovalErc20ForSwapToPay(request, options.swap.path[0], provider);
+        }
+      } else {
+        throw new Error('No swap options');
+      }
+      break;
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY: {
+      if (
+        !options ||
+        !options.conversion ||
+        !options.conversion.currency ||
+        options.conversion.currency.type !== RequestLogicTypes.CURRENCY.ERC20
+      ) {
+        throw new Error('Conversion settings missing');
+      }
+
+      if (options.swap) {
+        const amount = options.swap.maxInputAmount
+          ? options.swap.maxInputAmount
+          : BigNumber.from(0);
+        if (
+          !(await hasErc20ApprovalForSwapWithConversion(
+            request,
+            from,
+            options.swap.path[options.swap.path.length - 1],
+            provider,
+            amount,
+          ))
+        ) {
+          return prepareApprovalErc20ForSwapWithConversionToPay(
+            request,
+            options.swap.path[options.swap.path.length - 1],
+            provider,
+          );
+        }
+      } else {
+        throw new Error('No swap options');
+      }
+      break;
+    }
+    default:
+      return;
+  }
+}

--- a/packages/payment-processor/src/payment/encoder-payment.ts
+++ b/packages/payment-processor/src/payment/encoder-payment.ts
@@ -1,0 +1,109 @@
+import { IRequestPaymentOptions } from './settings';
+import { IPreparedTransaction } from './prepared-transaction';
+import { providers } from 'ethers';
+import { ClientTypes, ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
+import { prepareErc20ProxyPaymentTransaction } from './erc20-proxy';
+import { prepareErc20FeeProxyPaymentTransaction } from './erc20-fee-proxy';
+import { prepareAnyToErc20ProxyPaymentTransaction } from './any-to-erc20-proxy';
+import { prepareSwapToPayErc20FeeRequest } from './swap-erc20-fee-proxy';
+import { prepareSwapToPayAnyToErc20Request } from './swap-any-to-erc20';
+import { prepareEthProxyPaymentTransaction } from './eth-proxy';
+import { prepareEthFeeProxyPaymentTransaction } from './eth-fee-proxy';
+import { prepareAnyToEthProxyPaymentTransaction } from './any-to-eth-proxy';
+import { IConversionPaymentSettings } from '.';
+import { getPaymentNetworkExtension } from './utils';
+
+export function encodeRequestPayment(
+  request: ClientTypes.IRequestData,
+  provider: providers.Provider,
+  options?: IRequestPaymentOptions,
+): Promise<IPreparedTransaction> {
+  if (options && options.swap) {
+    return encodeRequestPaymentWithSwap(request, provider, options);
+  } else {
+    return encodeRequestPaymentWithoutSwap(request, options);
+  }
+}
+
+export async function encodeRequestPaymentWithoutSwap(
+  request: ClientTypes.IRequestData,
+  options?: IRequestPaymentOptions,
+): Promise<IPreparedTransaction> {
+  const paymentNetwork = getPaymentNetworkExtension(request)?.id;
+
+  switch (paymentNetwork) {
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT:
+      return prepareErc20ProxyPaymentTransaction(request);
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT:
+      return prepareErc20FeeProxyPaymentTransaction(request);
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY: {
+      if (
+        !options ||
+        !options.conversion ||
+        !options.conversion.currency ||
+        options.conversion.currency.type !== RequestLogicTypes.CURRENCY.ERC20
+      ) {
+        throw new Error('Conversion settings missing');
+      }
+      return prepareAnyToErc20ProxyPaymentTransaction(
+        request,
+        options.conversion as IConversionPaymentSettings,
+      );
+    }
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ETH_PROXY: {
+      if (
+        !options ||
+        !options.conversion ||
+        !options.conversion.currency ||
+        options.conversion.currency.type !== RequestLogicTypes.CURRENCY.ETH
+      ) {
+        throw new Error('Encoding settings missing');
+      }
+      return prepareAnyToEthProxyPaymentTransaction(
+        request,
+        options.conversion as IConversionPaymentSettings,
+      );
+    }
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA:
+      return prepareEthProxyPaymentTransaction(request);
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ETH_FEE_PROXY_CONTRACT:
+      return prepareEthFeeProxyPaymentTransaction(request);
+    default:
+      throw new Error('Payment network not found');
+  }
+}
+
+export async function encodeRequestPaymentWithSwap(
+  request: ClientTypes.IRequestData,
+  provider: providers.Provider,
+  options: IRequestPaymentOptions,
+): Promise<IPreparedTransaction> {
+  const paymentNetwork = getPaymentNetworkExtension(request)?.id;
+
+  switch (paymentNetwork) {
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT:
+      if (options && options.swap) {
+        return prepareSwapToPayErc20FeeRequest(request, provider, options.swap);
+      } else {
+        throw new Error('No swap options');
+      }
+    case ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY: {
+      if (
+        !options ||
+        !options.conversion ||
+        !options.conversion.currency ||
+        options.conversion.currency.type !== RequestLogicTypes.CURRENCY.ERC20
+      ) {
+        throw new Error('Conversion settings missing');
+      }
+
+      if (options.swap) {
+        return prepareSwapToPayAnyToErc20Request(request, provider, options);
+      } else {
+        throw new Error('Swap settings missing');
+      }
+    }
+    default:
+      throw new Error(`Payment network {paymentNetwork} does not support swap`);
+  }
+}

--- a/packages/payment-processor/src/payment/encoder-payment.ts
+++ b/packages/payment-processor/src/payment/encoder-payment.ts
@@ -17,7 +17,7 @@ export function encodeRequestPayment(
   request: ClientTypes.IRequestData,
   provider: providers.Provider,
   options?: IRequestPaymentOptions,
-): Promise<IPreparedTransaction> {
+): IPreparedTransaction {
   if (options && options.swap) {
     return encodeRequestPaymentWithSwap(request, provider, options);
   } else {
@@ -25,10 +25,10 @@ export function encodeRequestPayment(
   }
 }
 
-export async function encodeRequestPaymentWithoutSwap(
+export function encodeRequestPaymentWithoutSwap(
   request: ClientTypes.IRequestData,
   options?: IRequestPaymentOptions,
-): Promise<IPreparedTransaction> {
+): IPreparedTransaction {
   const paymentNetwork = getPaymentNetworkExtension(request)?.id;
   const amount = options?.amount ? options.amount : undefined;
   const feeAmount = options?.feeAmount ? options.feeAmount : undefined;
@@ -98,11 +98,11 @@ export async function encodeRequestPaymentWithoutSwap(
   }
 }
 
-export async function encodeRequestPaymentWithSwap(
+export function encodeRequestPaymentWithSwap(
   request: ClientTypes.IRequestData,
   provider: providers.Provider,
   options: IRequestPaymentOptions,
-): Promise<IPreparedTransaction> {
+): IPreparedTransaction {
   const paymentNetwork = getPaymentNetworkExtension(request)?.id;
   const amount = options?.amount ? options.amount : undefined;
   const feeAmount = options?.feeAmount ? options.feeAmount : undefined;

--- a/packages/payment-processor/src/payment/encoder-payment.ts
+++ b/packages/payment-processor/src/payment/encoder-payment.ts
@@ -71,7 +71,7 @@ export function encodeRequestPaymentWithoutSwap(
         !options.conversion.currency ||
         options.conversion.currency.type !== RequestLogicTypes.CURRENCY.ETH
       ) {
-        throw new Error('Encoding settings missing');
+        throw new Error('Conversion settings missing');
       }
       return {
         ...prepareAnyToEthProxyPaymentTransaction(

--- a/packages/payment-processor/src/payment/encoder-payment.ts
+++ b/packages/payment-processor/src/payment/encoder-payment.ts
@@ -32,12 +32,19 @@ export async function encodeRequestPaymentWithoutSwap(
   const paymentNetwork = getPaymentNetworkExtension(request)?.id;
   const amount = options?.amount ? options.amount : undefined;
   const feeAmount = options?.feeAmount ? options.feeAmount : undefined;
+  const overrides = options?.overrides ? options.overrides : {};
 
   switch (paymentNetwork) {
     case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT:
-      return prepareErc20ProxyPaymentTransaction(request, amount);
+      return {
+        ...prepareErc20ProxyPaymentTransaction(request, amount),
+        ...overrides,
+      };
     case ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT:
-      return prepareErc20FeeProxyPaymentTransaction(request, amount, feeAmount);
+      return {
+        ...prepareErc20FeeProxyPaymentTransaction(request, amount, feeAmount),
+        ...overrides,
+      };
     case ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY: {
       if (
         !options ||
@@ -47,12 +54,15 @@ export async function encodeRequestPaymentWithoutSwap(
       ) {
         throw new Error('Conversion settings missing');
       }
-      return prepareAnyToErc20ProxyPaymentTransaction(
-        request,
-        options.conversion as IConversionPaymentSettings,
-        amount,
-        feeAmount,
-      );
+      return {
+        ...prepareAnyToErc20ProxyPaymentTransaction(
+          request,
+          options.conversion as IConversionPaymentSettings,
+          amount,
+          feeAmount,
+        ),
+        ...overrides,
+      };
     }
     case ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ETH_PROXY: {
       if (
@@ -63,17 +73,26 @@ export async function encodeRequestPaymentWithoutSwap(
       ) {
         throw new Error('Encoding settings missing');
       }
-      return prepareAnyToEthProxyPaymentTransaction(
-        request,
-        options.conversion as IConversionPaymentSettings,
-        amount,
-        feeAmount,
-      );
+      return {
+        ...prepareAnyToEthProxyPaymentTransaction(
+          request,
+          options.conversion as IConversionPaymentSettings,
+          amount,
+          feeAmount,
+        ),
+        ...overrides,
+      };
     }
     case ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA:
-      return prepareEthProxyPaymentTransaction(request, amount);
+      return {
+        ...prepareEthProxyPaymentTransaction(request, amount),
+        ...overrides,
+      };
     case ExtensionTypes.ID.PAYMENT_NETWORK_ETH_FEE_PROXY_CONTRACT:
-      return prepareEthFeeProxyPaymentTransaction(request, amount, feeAmount);
+      return {
+        ...prepareEthFeeProxyPaymentTransaction(request, amount, feeAmount),
+        ...overrides,
+      };
     default:
       throw new Error('Payment network not found');
   }

--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -16,7 +16,7 @@ import { payAnyToEthProxyRequest } from './any-to-eth-proxy';
 import { WalletConnection } from 'near-api-js';
 import { isNearNetwork, isNearAccountSolvent } from './utils-near';
 import { ICurrencyManager } from '@requestnetwork/currency';
-import { encodeRequestApprovalIfNeeded } from './encoder-approval';
+import { encodeRequestErc20ApprovalIfNeeded } from './encoder-approval';
 import { encodeRequestPayment } from './encoder-payment';
 import { IPreparedTransaction } from './prepared-transaction';
 import { IRequestPaymentOptions } from './settings';
@@ -128,7 +128,7 @@ export async function payRequest(
  * @param options encoding options
  * @returns
  */
-export async function encodeRequest(
+export async function encodeRequestApprovalAndPayment(
   request: ClientTypes.IRequestData,
   signerOrProvider: providers.Provider,
   from?: string,
@@ -137,7 +137,7 @@ export async function encodeRequest(
   const preparedTransactions: IPreparedTransaction[] = [];
 
   if (from) {
-    const approvalTx = await encodeRequestApprovalIfNeeded(
+    const approvalTx = await encodeRequestErc20ApprovalIfNeeded(
       request,
       signerOrProvider,
       from,

--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -147,7 +147,7 @@ export async function encodeRequestApprovalAndPayment(
       preparedTransactions.push(approvalTx);
     }
   }
-  preparedTransactions.push(await encodeRequestPayment(request, signerOrProvider, options));
+  preparedTransactions.push(encodeRequestPayment(request, signerOrProvider, options));
   return preparedTransactions;
 }
 

--- a/packages/payment-processor/test/payment/encoder-approval.test.ts
+++ b/packages/payment-processor/test/payment/encoder-approval.test.ts
@@ -45,10 +45,10 @@ const alphaSwapConversionSettings = {
 };
 
 const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
-const mnemonicPath = `m/44'/60'/0'/0/9`;
+const mnemonicPath = `m/44'/60'/0'/0/19`;
 const paymentAddress = '0x821aEa9a577a9b44299B9c15c88cf3087F3b5544';
 const provider = new providers.JsonRpcProvider('http://localhost:8545');
-const wallet = Wallet.fromMnemonic(mnemonic, mnemonicPath).connect(provider);
+let wallet = Wallet.fromMnemonic(mnemonic, mnemonicPath).connect(provider);
 const erc20ApprovalData = (proxy: string) => {
   return `0x095ea7b3000000000000000000000000${proxy
     .slice(2)
@@ -211,6 +211,16 @@ const validRequestEthConversionProxy: ClientTypes.IRequestData = {
     },
   },
 };
+
+beforeAll(async () => {
+  const mainAddress = wallet.address;
+  wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
+  wallet.sendTransaction({
+    to: mainAddress,
+    value: BigNumber.from('1000000000000000000'),
+  });
+  wallet = Wallet.fromMnemonic(mnemonic, mnemonicPath).connect(provider);
+});
 
 describe('Approval encoder handles ERC20 Proxy', () => {
   it('Should return a valid transaction', async () => {

--- a/packages/payment-processor/test/payment/encoder-approval.test.ts
+++ b/packages/payment-processor/test/payment/encoder-approval.test.ts
@@ -404,7 +404,7 @@ describe('Approval encoder handles ERC20 Swap & Conversion Proxy', () => {
 
     expect(approvalTransaction).toEqual({
       data: erc20ApprovalData(proxyAddress),
-      to: alphaContractAddress,
+      to: erc20ContractAddress,
       value: 0,
     });
   });

--- a/packages/payment-processor/test/payment/encoder-approval.test.ts
+++ b/packages/payment-processor/test/payment/encoder-approval.test.ts
@@ -1,0 +1,472 @@
+import { Wallet, providers, BigNumber } from 'ethers';
+import {
+  ClientTypes,
+  ExtensionTypes,
+  IdentityTypes,
+  PaymentTypes,
+  RequestLogicTypes,
+} from '@requestnetwork/types';
+import { encodeRequestApprovalIfNeeded } from '../../src';
+import { getProxyAddress } from '../../src/payment/utils';
+import { AnyToERC20PaymentDetector, Erc20PaymentNetwork } from '@requestnetwork/payment-detection';
+import { currencyManager } from './shared';
+import { IPreparedTransaction } from 'payment-processor/dist/payment/prepared-transaction';
+import {
+  erc20SwapToPayArtifact,
+  erc20SwapConversionArtifact,
+} from '@requestnetwork/smart-contracts';
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+/* eslint-disable @typescript-eslint/await-thenable */
+
+const erc20ContractAddress = '0x9FBDa871d559710256a2502A2517b794B482Db40';
+const feeAddress = '0xC5fdf4076b8F3A5357c5E395ab970B5B54098Fef';
+
+// Cf. ERC20Alpha in TestERC20.sol
+const alphaContractAddress = '0x38cF23C52Bb4B13F051Aec09580a2dE845a7FA35';
+const alphaConversionSettings = {
+  currency: {
+    type: RequestLogicTypes.CURRENCY.ERC20,
+    value: alphaContractAddress,
+    network: 'private',
+  },
+  maxToSpend: BigNumber.from(2).pow(256).sub(1),
+  currencyManager,
+};
+const alphaSwapSettings = {
+  deadline: 2599732187000, // This test will fail in 2052
+  maxInputAmount: 204,
+  path: [alphaContractAddress, erc20ContractAddress],
+};
+const alphaSwapConversionSettings = {
+  deadline: 2599732187000, // This test will fail in 2052
+  maxInputAmount: 204,
+  path: [erc20ContractAddress, alphaContractAddress],
+};
+
+const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
+const mnemonicPath = `m/44'/60'/0'/0/3`;
+const paymentAddress = '0x821aEa9a577a9b44299B9c15c88cf3087F3b5544';
+const provider = new providers.JsonRpcProvider('http://localhost:8545');
+const wallet = Wallet.fromMnemonic(mnemonic, mnemonicPath).connect(provider);
+const erc20ApprovalData = (proxy: string) => {
+  return `0x095ea7b3000000000000000000000000${proxy
+    .slice(2)
+    .toLowerCase()}ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff`;
+};
+
+const baseValidRequest: ClientTypes.IRequestData = {
+  balance: {
+    balance: '0',
+    events: [],
+  },
+  contentData: {},
+  creator: {
+    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
+    value: wallet.address,
+  },
+  currency: 'DAI',
+  currencyInfo: {
+    network: 'private',
+    type: RequestLogicTypes.CURRENCY.ERC20,
+    value: erc20ContractAddress,
+  },
+
+  events: [],
+  expectedAmount: '100',
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ERC20_PROXY_CONTRACT]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '0.1.0',
+    },
+  },
+  extensionsData: [],
+  meta: {
+    transactionManagerMeta: {},
+  },
+  pending: null,
+  requestId: 'abcd',
+  state: RequestLogicTypes.STATE.CREATED,
+  timestamp: 0,
+  version: '1.0',
+};
+
+const validRequestERC20FeeProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress,
+        feeAmount: '2',
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '0.1.0',
+    },
+  },
+};
+
+const validRequestERC20ConversionProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  currency: 'EUR',
+  currencyInfo: {
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+    value: 'EUR',
+  },
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ANY_TO_ERC20_PROXY]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress,
+        feeAmount: '2',
+        paymentAddress,
+        salt: 'salt',
+        network: 'private',
+        tokensAccepted: [alphaContractAddress],
+      },
+      version: '0.1.0',
+    },
+  },
+};
+
+const validRequestEthProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  currency: 'ETH',
+  currencyInfo: {
+    network: 'private',
+    type: RequestLogicTypes.CURRENCY.ETH,
+    value: RequestLogicTypes.CURRENCY.ETH,
+  },
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ETH_INPUT_DATA]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '0.1.0',
+    },
+  },
+  version: '2.0.3',
+};
+
+const validRequestEthFeeProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  currency: 'ETH',
+  currencyInfo: {
+    network: 'private',
+    type: RequestLogicTypes.CURRENCY.ETH,
+    value: RequestLogicTypes.CURRENCY.ETH,
+  },
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ETH_FEE_PROXY_CONTRACT,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress,
+        feeAmount: '2',
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '0.1.0',
+    },
+  },
+  version: '2.0.3',
+};
+
+const validRequestEthConversionProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  currency: 'EUR',
+  currencyInfo: {
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+    value: 'EUR',
+  },
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ANY_TO_ETH_PROXY]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ETH_PROXY,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress,
+        feeAmount: '2',
+        paymentAddress,
+        salt: 'salt',
+        network: 'private',
+      },
+      version: '0.1.0',
+    },
+  },
+};
+
+describe('Approval encoder handles ERC20 Proxy', () => {
+  it('Should return a valid transaction', async () => {
+    const approvalTransaction = await encodeRequestApprovalIfNeeded(
+      baseValidRequest,
+      provider,
+      wallet.address,
+    );
+
+    const proxyAddress = getProxyAddress(
+      baseValidRequest,
+      Erc20PaymentNetwork.ERC20ProxyPaymentDetector.getDeploymentInformation,
+    );
+
+    expect(approvalTransaction).toEqual({
+      data: erc20ApprovalData(proxyAddress),
+      to: erc20ContractAddress,
+      value: 0,
+    });
+  });
+
+  it('Should not return anything', async () => {
+    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+      baseValidRequest,
+      provider,
+      wallet.address,
+    );
+    await wallet.sendTransaction(approvalTransaction as IPreparedTransaction);
+
+    approvalTransaction = await encodeRequestApprovalIfNeeded(
+      baseValidRequest,
+      provider,
+      wallet.address,
+    );
+    expect(approvalTransaction).toBeUndefined();
+  });
+});
+
+describe('Approval encoder handles ERC20 Fee Proxy', () => {
+  it('Should return a valid transaction', async () => {
+    const approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestERC20FeeProxy,
+      provider,
+      wallet.address,
+    );
+
+    const proxyAddress = getProxyAddress(
+      validRequestERC20FeeProxy,
+      Erc20PaymentNetwork.ERC20FeeProxyPaymentDetector.getDeploymentInformation,
+    );
+
+    expect(approvalTransaction).toEqual({
+      data: erc20ApprovalData(proxyAddress),
+      to: erc20ContractAddress,
+      value: 0,
+    });
+  });
+  it('Should not return anything', async () => {
+    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestERC20FeeProxy,
+      provider,
+      wallet.address,
+    );
+    await wallet.sendTransaction(approvalTransaction as IPreparedTransaction);
+
+    approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestERC20FeeProxy,
+      provider,
+      wallet.address,
+    );
+    expect(approvalTransaction).toBeUndefined();
+  });
+});
+
+describe('Approval encoder handles ERC20 Conversion Proxy', () => {
+  it('Should return a valid transaction', async () => {
+    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestERC20ConversionProxy,
+      provider,
+      wallet.address,
+      {
+        conversion: alphaConversionSettings,
+      },
+    );
+
+    const proxyAddress = getProxyAddress(
+      validRequestERC20ConversionProxy,
+      AnyToERC20PaymentDetector.getDeploymentInformation,
+    );
+
+    expect(approvalTransaction).toEqual({
+      data: erc20ApprovalData(proxyAddress),
+      to: alphaContractAddress,
+      value: 0,
+    });
+  });
+
+  it('Should not return anything', async () => {
+    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestERC20ConversionProxy,
+      provider,
+      wallet.address,
+      {
+        conversion: alphaConversionSettings,
+      },
+    );
+    await wallet.sendTransaction(approvalTransaction as IPreparedTransaction);
+
+    approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestERC20ConversionProxy,
+      provider,
+      wallet.address,
+      {
+        conversion: alphaConversionSettings,
+      },
+    );
+    expect(approvalTransaction).toBeUndefined();
+  });
+
+  it('Should not be possible to encode a conversion transaction without passing options', async () => {
+    await expect(
+      encodeRequestApprovalIfNeeded(validRequestERC20ConversionProxy, provider, wallet.address),
+    ).rejects.toThrowError('Conversion settings missing');
+  });
+});
+
+describe('Approval encoder handles ERC20 Swap Proxy', () => {
+  it('Should return a valid transaction', async () => {
+    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestERC20FeeProxy,
+      provider,
+      wallet.address,
+      {
+        swap: alphaSwapSettings,
+      },
+    );
+
+    const proxyAddress = erc20SwapToPayArtifact.getAddress(
+      validRequestERC20FeeProxy.currencyInfo.network!,
+    );
+
+    expect(approvalTransaction).toEqual({
+      data: erc20ApprovalData(proxyAddress),
+      to: alphaContractAddress,
+      value: 0,
+    });
+  });
+
+  it('Should not return anything', async () => {
+    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestERC20FeeProxy,
+      provider,
+      wallet.address,
+      {
+        swap: alphaSwapSettings,
+      },
+    );
+    await wallet.sendTransaction(approvalTransaction as IPreparedTransaction);
+
+    approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestERC20FeeProxy,
+      provider,
+      wallet.address,
+      {
+        swap: alphaSwapSettings,
+      },
+    );
+    expect(approvalTransaction).toBeUndefined();
+  });
+});
+
+describe('Approval encoder handles ERC20 Swap & Conversion Proxy', () => {
+  it('Should return a valid transaction', async () => {
+    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestERC20ConversionProxy,
+      provider,
+      wallet.address,
+      {
+        swap: alphaSwapConversionSettings,
+        conversion: alphaConversionSettings,
+      },
+    );
+
+    const proxyAddress = erc20SwapConversionArtifact.getAddress(
+      validRequestERC20FeeProxy.currencyInfo.network!,
+    );
+
+    expect(approvalTransaction).toEqual({
+      data: erc20ApprovalData(proxyAddress),
+      to: alphaContractAddress,
+      value: 0,
+    });
+  });
+
+  it('Should not return anything', async () => {
+    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestERC20ConversionProxy,
+      provider,
+      wallet.address,
+      {
+        swap: alphaSwapSettings,
+        conversion: alphaConversionSettings,
+      },
+    );
+    await wallet.sendTransaction(approvalTransaction as IPreparedTransaction);
+
+    approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestERC20ConversionProxy,
+      provider,
+      wallet.address,
+      {
+        swap: alphaSwapSettings,
+        conversion: alphaConversionSettings,
+      },
+    );
+    expect(approvalTransaction).toBeUndefined();
+  });
+
+  it('Should not be possible to encode a conversion transaction without passing options', async () => {
+    await expect(
+      encodeRequestApprovalIfNeeded(validRequestERC20ConversionProxy, provider, wallet.address),
+    ).rejects.toThrowError();
+  });
+
+  it('Should not be possible to encode a conversion transaction without passing conversion options', async () => {
+    await expect(
+      encodeRequestApprovalIfNeeded(validRequestERC20ConversionProxy, provider, wallet.address, {
+        swap: alphaSwapSettings,
+      }),
+    ).rejects.toThrowError();
+  });
+});
+
+describe('Approval encoder handles Eth Requests', () => {
+  it('Should not return anything for Eth Proxy', async () => {
+    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestEthProxy,
+      provider,
+      wallet.address,
+    );
+    expect(approvalTransaction).toBeUndefined();
+  });
+  it('Should not return anything for Eth Fee Proxy', async () => {
+    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestEthFeeProxy,
+      provider,
+      wallet.address,
+    );
+    expect(approvalTransaction).toBeUndefined();
+  });
+  it('Should not return anything for Eth Conversion Proxy', async () => {
+    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+      validRequestEthConversionProxy,
+      provider,
+      wallet.address,
+    );
+    expect(approvalTransaction).toBeUndefined();
+  });
+});

--- a/packages/payment-processor/test/payment/encoder-approval.test.ts
+++ b/packages/payment-processor/test/payment/encoder-approval.test.ts
@@ -6,7 +6,7 @@ import {
   PaymentTypes,
   RequestLogicTypes,
 } from '@requestnetwork/types';
-import { encodeRequestApprovalIfNeeded } from '../../src';
+import { encodeRequestErc20ApprovalIfNeeded } from '../../src';
 import { getProxyAddress } from '../../src/payment/utils';
 import { AnyToERC20PaymentDetector, Erc20PaymentNetwork } from '@requestnetwork/payment-detection';
 import { currencyManager } from './shared';
@@ -214,7 +214,7 @@ const validRequestEthConversionProxy: ClientTypes.IRequestData = {
 
 describe('Approval encoder handles ERC20 Proxy', () => {
   it('Should return a valid transaction', async () => {
-    const approvalTransaction = await encodeRequestApprovalIfNeeded(
+    const approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       baseValidRequest,
       provider,
       wallet.address,
@@ -233,14 +233,14 @@ describe('Approval encoder handles ERC20 Proxy', () => {
   });
 
   it('Should not return anything', async () => {
-    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+    let approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       baseValidRequest,
       provider,
       wallet.address,
     );
     await wallet.sendTransaction(approvalTransaction as IPreparedTransaction);
 
-    approvalTransaction = await encodeRequestApprovalIfNeeded(
+    approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       baseValidRequest,
       provider,
       wallet.address,
@@ -251,7 +251,7 @@ describe('Approval encoder handles ERC20 Proxy', () => {
 
 describe('Approval encoder handles ERC20 Fee Proxy', () => {
   it('Should return a valid transaction', async () => {
-    const approvalTransaction = await encodeRequestApprovalIfNeeded(
+    const approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestERC20FeeProxy,
       provider,
       wallet.address,
@@ -269,14 +269,14 @@ describe('Approval encoder handles ERC20 Fee Proxy', () => {
     });
   });
   it('Should not return anything', async () => {
-    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+    let approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestERC20FeeProxy,
       provider,
       wallet.address,
     );
     await wallet.sendTransaction(approvalTransaction as IPreparedTransaction);
 
-    approvalTransaction = await encodeRequestApprovalIfNeeded(
+    approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestERC20FeeProxy,
       provider,
       wallet.address,
@@ -287,7 +287,7 @@ describe('Approval encoder handles ERC20 Fee Proxy', () => {
 
 describe('Approval encoder handles ERC20 Conversion Proxy', () => {
   it('Should return a valid transaction', async () => {
-    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+    let approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestERC20ConversionProxy,
       provider,
       wallet.address,
@@ -309,7 +309,7 @@ describe('Approval encoder handles ERC20 Conversion Proxy', () => {
   });
 
   it('Should not return anything', async () => {
-    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+    let approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestERC20ConversionProxy,
       provider,
       wallet.address,
@@ -319,7 +319,7 @@ describe('Approval encoder handles ERC20 Conversion Proxy', () => {
     );
     await wallet.sendTransaction(approvalTransaction as IPreparedTransaction);
 
-    approvalTransaction = await encodeRequestApprovalIfNeeded(
+    approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestERC20ConversionProxy,
       provider,
       wallet.address,
@@ -332,14 +332,18 @@ describe('Approval encoder handles ERC20 Conversion Proxy', () => {
 
   it('Should not be possible to encode a conversion transaction without passing options', async () => {
     await expect(
-      encodeRequestApprovalIfNeeded(validRequestERC20ConversionProxy, provider, wallet.address),
+      encodeRequestErc20ApprovalIfNeeded(
+        validRequestERC20ConversionProxy,
+        provider,
+        wallet.address,
+      ),
     ).rejects.toThrowError('Conversion settings missing');
   });
 });
 
 describe('Approval encoder handles ERC20 Swap Proxy', () => {
   it('Should return a valid transaction', async () => {
-    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+    let approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestERC20FeeProxy,
       provider,
       wallet.address,
@@ -360,7 +364,7 @@ describe('Approval encoder handles ERC20 Swap Proxy', () => {
   });
 
   it('Should not return anything', async () => {
-    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+    let approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestERC20FeeProxy,
       provider,
       wallet.address,
@@ -370,7 +374,7 @@ describe('Approval encoder handles ERC20 Swap Proxy', () => {
     );
     await wallet.sendTransaction(approvalTransaction as IPreparedTransaction);
 
-    approvalTransaction = await encodeRequestApprovalIfNeeded(
+    approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestERC20FeeProxy,
       provider,
       wallet.address,
@@ -384,7 +388,7 @@ describe('Approval encoder handles ERC20 Swap Proxy', () => {
 
 describe('Approval encoder handles ERC20 Swap & Conversion Proxy', () => {
   it('Should return a valid transaction', async () => {
-    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+    let approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestERC20ConversionProxy,
       provider,
       wallet.address,
@@ -406,7 +410,7 @@ describe('Approval encoder handles ERC20 Swap & Conversion Proxy', () => {
   });
 
   it('Should not return anything', async () => {
-    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+    let approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestERC20ConversionProxy,
       provider,
       wallet.address,
@@ -417,7 +421,7 @@ describe('Approval encoder handles ERC20 Swap & Conversion Proxy', () => {
     );
     await wallet.sendTransaction(approvalTransaction as IPreparedTransaction);
 
-    approvalTransaction = await encodeRequestApprovalIfNeeded(
+    approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestERC20ConversionProxy,
       provider,
       wallet.address,
@@ -431,22 +435,31 @@ describe('Approval encoder handles ERC20 Swap & Conversion Proxy', () => {
 
   it('Should not be possible to encode a conversion transaction without passing options', async () => {
     await expect(
-      encodeRequestApprovalIfNeeded(validRequestERC20ConversionProxy, provider, wallet.address),
+      encodeRequestErc20ApprovalIfNeeded(
+        validRequestERC20ConversionProxy,
+        provider,
+        wallet.address,
+      ),
     ).rejects.toThrowError();
   });
 
   it('Should not be possible to encode a conversion transaction without passing conversion options', async () => {
     await expect(
-      encodeRequestApprovalIfNeeded(validRequestERC20ConversionProxy, provider, wallet.address, {
-        swap: alphaSwapSettings,
-      }),
+      encodeRequestErc20ApprovalIfNeeded(
+        validRequestERC20ConversionProxy,
+        provider,
+        wallet.address,
+        {
+          swap: alphaSwapSettings,
+        },
+      ),
     ).rejects.toThrowError();
   });
 });
 
 describe('Approval encoder handles Eth Requests', () => {
   it('Should not return anything for Eth Proxy', async () => {
-    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+    let approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestEthProxy,
       provider,
       wallet.address,
@@ -454,7 +467,7 @@ describe('Approval encoder handles Eth Requests', () => {
     expect(approvalTransaction).toBeUndefined();
   });
   it('Should not return anything for Eth Fee Proxy', async () => {
-    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+    let approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestEthFeeProxy,
       provider,
       wallet.address,
@@ -462,7 +475,7 @@ describe('Approval encoder handles Eth Requests', () => {
     expect(approvalTransaction).toBeUndefined();
   });
   it('Should not return anything for Eth Conversion Proxy', async () => {
-    let approvalTransaction = await encodeRequestApprovalIfNeeded(
+    let approvalTransaction = await encodeRequestErc20ApprovalIfNeeded(
       validRequestEthConversionProxy,
       provider,
       wallet.address,

--- a/packages/payment-processor/test/payment/encoder-approval.test.ts
+++ b/packages/payment-processor/test/payment/encoder-approval.test.ts
@@ -45,7 +45,7 @@ const alphaSwapConversionSettings = {
 };
 
 const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
-const mnemonicPath = `m/44'/60'/0'/0/3`;
+const mnemonicPath = `m/44'/60'/0'/0/9`;
 const paymentAddress = '0x821aEa9a577a9b44299B9c15c88cf3087F3b5544';
 const provider = new providers.JsonRpcProvider('http://localhost:8545');
 const wallet = Wallet.fromMnemonic(mnemonic, mnemonicPath).connect(provider);

--- a/packages/payment-processor/test/payment/encoder-payment.test.ts
+++ b/packages/payment-processor/test/payment/encoder-payment.test.ts
@@ -278,9 +278,9 @@ describe('Payment encoder handles ERC20 Conversion Proxy', () => {
     });
   });
   it('Should not be possible to encode a conversion transaction without passing options', async () => {
-    await expect(
-      encodeRequestPayment(validRequestERC20ConversionProxy, provider),
-    ).rejects.toThrowError('Conversion settings missing');
+    expect(() => encodeRequestPayment(validRequestERC20ConversionProxy, provider)).toThrowError(
+      'Conversion settings missing',
+    );
   });
 });
 
@@ -326,18 +326,18 @@ describe('Payment encoder handles ERC20 Swap & Conversion Proxy', () => {
     });
   });
 
-  it('Should not be possible to encode a conversion transaction without passing options', async () => {
-    await expect(
-      encodeRequestPayment(validRequestERC20ConversionProxy, provider),
-    ).rejects.toThrowError();
+  it('Should not be possible to encode a conversion transaction without passing options', () => {
+    expect(() => encodeRequestPayment(validRequestERC20ConversionProxy, provider)).toThrowError(
+      'Conversion settings missing',
+    );
   });
 
-  it('Should not be possible to encode a conversion transaction without passing conversion options', async () => {
-    await expect(
+  it('Should not be possible to encode a conversion transaction without passing conversion options', () => {
+    expect(() =>
       encodeRequestPayment(validRequestERC20ConversionProxy, provider, {
         swap: alphaSwapSettings,
       }),
-    ).rejects.toThrowError();
+    ).toThrowError('Conversion settings missing');
   });
 });
 
@@ -395,9 +395,9 @@ describe('Payment encoder handles Eth Conversion Proxy', () => {
       value: BigNumber.from(ethConversionSettings.maxToSpend),
     });
   });
-  it('Should not be possible to encode a conversion transaction without passing conversion options', async () => {
-    await expect(
-      encodeRequestPayment(validRequestEthConversionProxy, provider),
-    ).rejects.toThrowError();
+  it('Should not be possible to encode a conversion transaction without passing conversion options', () => {
+    expect(() => encodeRequestPayment(validRequestEthConversionProxy, provider)).toThrowError(
+      'Conversion settings missing',
+    );
   });
 });

--- a/packages/payment-processor/test/payment/encoder-payment.test.ts
+++ b/packages/payment-processor/test/payment/encoder-payment.test.ts
@@ -1,0 +1,403 @@
+import { Wallet, providers, BigNumber } from 'ethers';
+import {
+  ClientTypes,
+  ExtensionTypes,
+  IdentityTypes,
+  PaymentTypes,
+  RequestLogicTypes,
+} from '@requestnetwork/types';
+import { encodeRequestPayment } from '../../src';
+import { getProxyAddress } from '../../src/payment/utils';
+import {
+  AnyToERC20PaymentDetector,
+  AnyToEthFeeProxyPaymentDetector,
+  Erc20PaymentNetwork,
+  EthFeeProxyPaymentDetector,
+  EthInputDataPaymentDetector,
+} from '@requestnetwork/payment-detection';
+import { currencyManager } from './shared';
+import {
+  erc20SwapToPayArtifact,
+  erc20SwapConversionArtifact,
+} from '@requestnetwork/smart-contracts';
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+/* eslint-disable @typescript-eslint/await-thenable */
+
+const erc20ContractAddress = '0x9FBDa871d559710256a2502A2517b794B482Db40';
+const feeAddress = '0xC5fdf4076b8F3A5357c5E395ab970B5B54098Fef';
+
+// Cf. ERC20Alpha in TestERC20.sol
+const alphaContractAddress = '0x38cF23C52Bb4B13F051Aec09580a2dE845a7FA35';
+const alphaConversionSettings = {
+  currency: {
+    type: RequestLogicTypes.CURRENCY.ERC20,
+    value: alphaContractAddress,
+    network: 'private',
+  },
+  maxToSpend: BigNumber.from(2).pow(256).sub(1),
+  currencyManager,
+};
+const ethConversionSettings = {
+  currency: {
+    type: RequestLogicTypes.CURRENCY.ETH,
+    value: 'ETH',
+  },
+  maxToSpend: '2500000000000000',
+  currencyManager,
+};
+const alphaSwapSettings = {
+  deadline: 2599732187000, // This test will fail in 2052
+  maxInputAmount: 204,
+  path: [alphaContractAddress, erc20ContractAddress],
+};
+const alphaSwapConversionSettings = {
+  deadline: 2599732187000, // This test will fail in 2052
+  maxInputAmount: 204,
+  path: [erc20ContractAddress, alphaContractAddress],
+};
+
+const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
+const paymentAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
+const provider = new providers.JsonRpcProvider('http://localhost:8545');
+const wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
+
+const baseValidRequest: ClientTypes.IRequestData = {
+  balance: {
+    balance: '0',
+    events: [],
+  },
+  contentData: {},
+  creator: {
+    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
+    value: wallet.address,
+  },
+  currency: 'DAI',
+  currencyInfo: {
+    network: 'private',
+    type: RequestLogicTypes.CURRENCY.ERC20,
+    value: erc20ContractAddress,
+  },
+
+  events: [],
+  expectedAmount: '100',
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ERC20_PROXY_CONTRACT]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '0.1.0',
+    },
+  },
+  extensionsData: [],
+  meta: {
+    transactionManagerMeta: {},
+  },
+  pending: null,
+  requestId: 'abcd',
+  state: RequestLogicTypes.STATE.CREATED,
+  timestamp: 0,
+  version: '1.0',
+};
+
+const validRequestERC20FeeProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress,
+        feeAmount: '2',
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '0.1.0',
+    },
+  },
+};
+
+const validRequestERC20ConversionProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  currency: 'EUR',
+  currencyInfo: {
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+    value: 'EUR',
+  },
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ANY_TO_ERC20_PROXY]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress,
+        feeAmount: '2',
+        paymentAddress,
+        salt: 'salt',
+        network: 'private',
+        acceptedTokens: [alphaContractAddress],
+      },
+      version: '0.1.0',
+    },
+  },
+};
+
+const validRequestEthProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  currency: 'ETH',
+  currencyInfo: {
+    network: 'private',
+    type: RequestLogicTypes.CURRENCY.ETH,
+    value: RequestLogicTypes.CURRENCY.ETH,
+  },
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ETH_INPUT_DATA]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '0.1.0',
+    },
+  },
+  version: '2.0.3',
+};
+
+const validRequestEthFeeProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  currency: 'ETH',
+  currencyInfo: {
+    network: 'private',
+    type: RequestLogicTypes.CURRENCY.ETH,
+    value: RequestLogicTypes.CURRENCY.ETH,
+  },
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ETH_FEE_PROXY_CONTRACT,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress,
+        feeAmount: '2',
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '0.1.0',
+    },
+  },
+  version: '2.0.3',
+};
+
+const validRequestEthConversionProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  currency: 'EUR',
+  currencyInfo: {
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+    value: 'EUR',
+  },
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ANY_TO_ETH_PROXY]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ETH_PROXY,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress,
+        feeAmount: '2',
+        paymentAddress,
+        salt: 'salt',
+        network: 'private',
+      },
+      version: '0.1.0',
+    },
+  },
+};
+
+describe('Payment encoder handles ERC20 Proxy', () => {
+  it('Should return a valid transaction', async () => {
+    const paymentTransaction = await encodeRequestPayment(baseValidRequest, provider);
+
+    const proxyAddress = getProxyAddress(
+      baseValidRequest,
+      Erc20PaymentNetwork.ERC20ProxyPaymentDetector.getDeploymentInformation,
+    );
+
+    expect(paymentTransaction).toEqual({
+      data:
+        '0x0784bca30000000000000000000000009fbda871d559710256a2502a2517b794b482db40000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b73200000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000886dfbccad783599a000000000000000000000000000000000000000000000000',
+      to: proxyAddress,
+      value: 0,
+    });
+  });
+});
+
+describe('Payment encoder handles ERC20 Fee Proxy', () => {
+  it('Should return a valid transaction', async () => {
+    const paymentTransaction = await encodeRequestPayment(validRequestERC20FeeProxy, provider);
+
+    const proxyAddress = getProxyAddress(
+      validRequestERC20FeeProxy,
+      Erc20PaymentNetwork.ERC20FeeProxyPaymentDetector.getDeploymentInformation,
+    );
+
+    expect(paymentTransaction).toEqual({
+      data:
+        '0xc219a14d0000000000000000000000009fbda871d559710256a2502a2517b794b482db40000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b732000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c5fdf4076b8f3a5357c5e395ab970b5b54098fef000000000000000000000000000000000000000000000000000000000000000886dfbccad783599a000000000000000000000000000000000000000000000000',
+      to: proxyAddress,
+      value: 0,
+    });
+  });
+});
+
+describe('Payment encoder handles ERC20 Conversion Proxy', () => {
+  it('Should return a valid transaction', async () => {
+    let paymentTransaction = await encodeRequestPayment(
+      validRequestERC20ConversionProxy,
+      provider,
+      {
+        conversion: alphaConversionSettings,
+      },
+    );
+
+    const proxyAddress = getProxyAddress(
+      validRequestERC20ConversionProxy,
+      AnyToERC20PaymentDetector.getDeploymentInformation,
+    );
+
+    expect(paymentTransaction).toEqual({
+      data:
+        '0x3af2c012000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b7320000000000000000000000000000000000000000000000000000000005f5e1000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000001e8480000000000000000000000000c5fdf4076b8f3a5357c5e395ab970b5b54098fefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000017b4158805772ced11225e77339f90beb5aae968000000000000000000000000775eb53d00dd0acd3ec1696472105d579b9b386b00000000000000000000000038cf23c52bb4b13f051aec09580a2de845a7fa35000000000000000000000000000000000000000000000000000000000000000886dfbccad783599a000000000000000000000000000000000000000000000000',
+      to: proxyAddress,
+      value: 0,
+    });
+  });
+  it('Should not be possible to encode a conversion transaction without passing options', async () => {
+    await expect(
+      encodeRequestPayment(validRequestERC20ConversionProxy, provider),
+    ).rejects.toThrowError('Conversion settings missing');
+  });
+});
+
+describe('Payment encoder handles ERC20 Swap Proxy', () => {
+  it('Should return a valid transaction', async () => {
+    let paymentTransaction = await encodeRequestPayment(validRequestERC20FeeProxy, provider, {
+      swap: alphaSwapSettings,
+    });
+
+    const proxyAddress = erc20SwapToPayArtifact.getAddress(
+      validRequestERC20FeeProxy.currencyInfo.network!,
+    );
+
+    expect(paymentTransaction).toEqual({
+      data:
+        '0x8d09fe2b000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b732000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000000cc000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c5fdf4076b8f3a5357c5e395ab970b5b54098fef000000000000000000000000000000000000000000000000000000009af4c3db000000000000000000000000000000000000000000000000000000000000000200000000000000000000000038cf23c52bb4b13f051aec09580a2de845a7fa350000000000000000000000009fbda871d559710256a2502a2517b794b482db40000000000000000000000000000000000000000000000000000000000000000886dfbccad783599a000000000000000000000000000000000000000000000000',
+      to: proxyAddress,
+      value: 0,
+    });
+  });
+});
+
+describe('Payment encoder handles ERC20 Swap & Conversion Proxy', () => {
+  it('Should return a valid transaction', async () => {
+    let paymentTransaction = await encodeRequestPayment(
+      validRequestERC20ConversionProxy,
+      provider,
+      {
+        swap: alphaSwapConversionSettings,
+        conversion: alphaConversionSettings,
+      },
+    );
+
+    const proxyAddress = erc20SwapConversionArtifact.getAddress(
+      alphaConversionSettings.currency.network,
+    );
+
+    expect(paymentTransaction).toEqual({
+      data:
+        '0xb2964b11000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b7320000000000000000000000000000000000000000000000000000000005f5e10000000000000000000000000000000000000000000000000000000000000000cc000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000001a0000000000000000000000000000000000000000000000000000000000000022000000000000000000000000000000000000000000000000000000000001e8480000000000000000000000000c5fdf4076b8f3a5357c5e395ab970b5b54098fef000000000000000000000000000000000000000000000000000000009af4c3db000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000009fbda871d559710256a2502a2517b794b482db4000000000000000000000000038cf23c52bb4b13f051aec09580a2de845a7fa35000000000000000000000000000000000000000000000000000000000000000300000000000000000000000017b4158805772ced11225e77339f90beb5aae968000000000000000000000000775eb53d00dd0acd3ec1696472105d579b9b386b00000000000000000000000038cf23c52bb4b13f051aec09580a2de845a7fa35000000000000000000000000000000000000000000000000000000000000000886dfbccad783599a000000000000000000000000000000000000000000000000',
+      to: proxyAddress,
+      value: 0,
+    });
+  });
+
+  it('Should not be possible to encode a conversion transaction without passing options', async () => {
+    await expect(
+      encodeRequestPayment(validRequestERC20ConversionProxy, provider),
+    ).rejects.toThrowError();
+  });
+
+  it('Should not be possible to encode a conversion transaction without passing conversion options', async () => {
+    await expect(
+      encodeRequestPayment(validRequestERC20ConversionProxy, provider, {
+        swap: alphaSwapSettings,
+      }),
+    ).rejects.toThrowError();
+  });
+});
+
+describe('Payment encoder handles Eth Proxy', () => {
+  it('Should return a valid transaction', async () => {
+    let paymentTransaction = await encodeRequestPayment(validRequestEthProxy, provider);
+
+    const proxyAddress = getProxyAddress(
+      validRequestEthProxy,
+      EthInputDataPaymentDetector.getDeploymentInformation,
+    );
+
+    expect(paymentTransaction).toEqual({
+      data:
+        '0xeb7d8df3000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b7320000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000886dfbccad783599a000000000000000000000000000000000000000000000000',
+      to: proxyAddress,
+      value: BigNumber.from(validRequestEthProxy.expectedAmount),
+    });
+  });
+});
+
+describe('Payment encoder handles Eth Fee Proxy', () => {
+  it('Should return a valid transaction', async () => {
+    let paymentTransaction = await encodeRequestPayment(validRequestEthFeeProxy, provider);
+
+    const proxyAddress = getProxyAddress(
+      validRequestEthFeeProxy,
+      EthFeeProxyPaymentDetector.getDeploymentInformation,
+    );
+
+    expect(paymentTransaction).toEqual({
+      data:
+        '0xb868980b000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b73200000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c5fdf4076b8f3a5357c5e395ab970b5b54098fef000000000000000000000000000000000000000000000000000000000000000886dfbccad783599a000000000000000000000000000000000000000000000000',
+      to: proxyAddress,
+      value: BigNumber.from(validRequestERC20FeeProxy.expectedAmount).add(2),
+    });
+  });
+});
+
+describe('Payment encoder handles Eth Conversion Proxy', () => {
+  it('Should return a valid transaction', async () => {
+    let paymentTransaction = await encodeRequestPayment(validRequestEthConversionProxy, provider, {
+      conversion: ethConversionSettings,
+    });
+
+    const proxyAddress = getProxyAddress(
+      validRequestEthConversionProxy,
+      AnyToEthFeeProxyPaymentDetector.getDeploymentInformation,
+    );
+
+    expect(paymentTransaction).toEqual({
+      data:
+        '0xac473c8a000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b7320000000000000000000000000000000000000000000000000000000005f5e10000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000001e8480000000000000000000000000c5fdf4076b8f3a5357c5e395ab970b5b54098fef0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000017b4158805772ced11225e77339f90beb5aae968000000000000000000000000775eb53d00dd0acd3ec1696472105d579b9b386b000000000000000000000000f5af88e117747e87fc5929f2ff87221b1447652e000000000000000000000000000000000000000000000000000000000000000886dfbccad783599a000000000000000000000000000000000000000000000000',
+      to: proxyAddress,
+      value: BigNumber.from(ethConversionSettings.maxToSpend),
+    });
+  });
+  it('Should not be possible to encode a conversion transaction without passing conversion options', async () => {
+    await expect(
+      encodeRequestPayment(validRequestEthConversionProxy, provider),
+    ).rejects.toThrowError();
+  });
+});

--- a/packages/payment-processor/test/payment/encoder.test.ts
+++ b/packages/payment-processor/test/payment/encoder.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@requestnetwork/types';
 import { encodeRequestApprovalAndPayment } from '../../src';
 import { currencyManager } from './shared';
+import { ERC20__factory } from '@requestnetwork/smart-contracts/types';
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 /* eslint-disable @typescript-eslint/await-thenable */
@@ -46,10 +47,10 @@ const alphaSwapConversionSettings = {
 };
 
 const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
-const mnemonicPath = `m/44'/60'/0'/0/0`;
+const mnemonicPath = `m/44'/60'/0'/0/8`;
 const paymentAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
 const provider = new providers.JsonRpcProvider('http://localhost:8545');
-const wallet = Wallet.fromMnemonic(mnemonic, mnemonicPath).connect(provider);
+let wallet = Wallet.fromMnemonic(mnemonic, mnemonicPath).connect(provider);
 
 const baseValidRequest: ClientTypes.IRequestData = {
   balance: {
@@ -207,6 +208,16 @@ const validRequestEthConversionProxy: ClientTypes.IRequestData = {
     },
   },
 };
+
+beforeAll(async () => {
+  const mainAddress = wallet.address;
+  wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
+  const alphaContract = ERC20__factory.connect(alphaContractAddress, wallet);
+  await alphaContract.transfer(mainAddress, BigNumber.from('500000000000000000000'));
+  const erc20Contract = ERC20__factory.connect(erc20ContractAddress, wallet);
+  await erc20Contract.transfer(mainAddress, BigNumber.from('500000000000000000000'));
+  wallet = Wallet.fromMnemonic(mnemonic, mnemonicPath).connect(provider);
+});
 
 describe('Encoder', () => {
   it('Should handle ERC20 Proxy request', async () => {

--- a/packages/payment-processor/test/payment/encoder.test.ts
+++ b/packages/payment-processor/test/payment/encoder.test.ts
@@ -6,7 +6,7 @@ import {
   PaymentTypes,
   RequestLogicTypes,
 } from '@requestnetwork/types';
-import { encodeRequest } from '../../src';
+import { encodeRequestApprovalAndPayment } from '../../src';
 import { currencyManager } from './shared';
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
@@ -41,7 +41,7 @@ const alphaSwapSettings = {
 };
 const alphaSwapConversionSettings = {
   deadline: 2599732187000, // This test will fail in 2052
-  maxInputAmount: 204,
+  maxInputAmount: '100000000000000000000',
   path: [erc20ContractAddress, alphaContractAddress],
 };
 
@@ -210,7 +210,11 @@ const validRequestEthConversionProxy: ClientTypes.IRequestData = {
 
 describe('Encoder', () => {
   it('Should handle ERC20 Proxy request', async () => {
-    const encodedTransactions = await encodeRequest(baseValidRequest, provider, wallet.address);
+    const encodedTransactions = await encodeRequestApprovalAndPayment(
+      baseValidRequest,
+      provider,
+      wallet.address,
+    );
 
     let tx = await wallet.sendTransaction(encodedTransactions[0]);
     let confirmedTx = await tx.wait(1);
@@ -224,7 +228,7 @@ describe('Encoder', () => {
   });
 
   it('Should handle ERC20 Fee Proxy request', async () => {
-    const encodedTransactions = await encodeRequest(
+    const encodedTransactions = await encodeRequestApprovalAndPayment(
       validRequestERC20FeeProxy,
       provider,
       wallet.address,
@@ -242,7 +246,7 @@ describe('Encoder', () => {
   });
 
   it('Should handle ERC20 Conversion Proxy request', async () => {
-    let encodedTransactions = await encodeRequest(
+    let encodedTransactions = await encodeRequestApprovalAndPayment(
       validRequestERC20ConversionProxy,
       provider,
       wallet.address,
@@ -263,7 +267,7 @@ describe('Encoder', () => {
   });
 
   it('Should handle ERC20 Swap Proxy request', async () => {
-    let encodedTransactions = await encodeRequest(
+    let encodedTransactions = await encodeRequestApprovalAndPayment(
       validRequestERC20FeeProxy,
       provider,
       wallet.address,
@@ -284,7 +288,7 @@ describe('Encoder', () => {
   });
 
   it.only('Should handle ERC20 Swap and Conversion Proxy request', async () => {
-    let encodedTransactions = await encodeRequest(
+    let encodedTransactions = await encodeRequestApprovalAndPayment(
       validRequestERC20ConversionProxy,
       provider,
       wallet.address,
@@ -306,7 +310,11 @@ describe('Encoder', () => {
   });
 
   it('Should handle Eth Proxy request', async () => {
-    let encodedTransactions = await encodeRequest(validRequestEthProxy, provider, wallet.address);
+    let encodedTransactions = await encodeRequestApprovalAndPayment(
+      validRequestEthProxy,
+      provider,
+      wallet.address,
+    );
 
     let tx = await wallet.sendTransaction(encodedTransactions[0]);
     let confirmedTx = await tx.wait(1);
@@ -315,7 +323,7 @@ describe('Encoder', () => {
   });
 
   it('Should handle Eth Fee Proxy request', async () => {
-    let encodedTransactions = await encodeRequest(
+    let encodedTransactions = await encodeRequestApprovalAndPayment(
       validRequestEthFeeProxy,
       provider,
       wallet.address,
@@ -328,7 +336,7 @@ describe('Encoder', () => {
   });
 
   it('Should handle Eth Conversion Proxy', async () => {
-    let encodedTransactions = await encodeRequest(
+    let encodedTransactions = await encodeRequestApprovalAndPayment(
       validRequestEthConversionProxy,
       provider,
       wallet.address,

--- a/packages/payment-processor/test/payment/encoder.test.ts
+++ b/packages/payment-processor/test/payment/encoder.test.ts
@@ -1,0 +1,345 @@
+import { Wallet, providers, BigNumber } from 'ethers';
+import {
+  ClientTypes,
+  ExtensionTypes,
+  IdentityTypes,
+  PaymentTypes,
+  RequestLogicTypes,
+} from '@requestnetwork/types';
+import { encodeRequest } from '../../src';
+import { currencyManager } from './shared';
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+/* eslint-disable @typescript-eslint/await-thenable */
+
+const erc20ContractAddress = '0x9FBDa871d559710256a2502A2517b794B482Db40';
+const feeAddress = '0xC5fdf4076b8F3A5357c5E395ab970B5B54098Fef';
+
+// Cf. ERC20Alpha in TestERC20.sol
+const alphaContractAddress = '0x38cF23C52Bb4B13F051Aec09580a2dE845a7FA35';
+const alphaConversionSettings = {
+  currency: {
+    type: RequestLogicTypes.CURRENCY.ERC20,
+    value: alphaContractAddress,
+    network: 'private',
+  },
+  maxToSpend: BigNumber.from(2).pow(256).sub(1),
+  currencyManager,
+};
+const ethConversionSettings = {
+  currency: {
+    type: RequestLogicTypes.CURRENCY.ETH,
+    value: 'ETH',
+  },
+  maxToSpend: '2500000000000000',
+  currencyManager,
+};
+const alphaSwapSettings = {
+  deadline: 2599732187000, // This test will fail in 2052
+  maxInputAmount: 204,
+  path: [alphaContractAddress, erc20ContractAddress],
+};
+const alphaSwapConversionSettings = {
+  deadline: 2599732187000, // This test will fail in 2052
+  maxInputAmount: 204,
+  path: [erc20ContractAddress, alphaContractAddress],
+};
+
+const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
+const mnemonicPath = `m/44'/60'/0'/0/0`;
+const paymentAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
+const provider = new providers.JsonRpcProvider('http://localhost:8545');
+const wallet = Wallet.fromMnemonic(mnemonic, mnemonicPath).connect(provider);
+
+const baseValidRequest: ClientTypes.IRequestData = {
+  balance: {
+    balance: '0',
+    events: [],
+  },
+  contentData: {},
+  creator: {
+    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
+    value: wallet.address,
+  },
+  currency: 'DAI',
+  currencyInfo: {
+    network: 'private',
+    type: RequestLogicTypes.CURRENCY.ERC20,
+    value: erc20ContractAddress,
+  },
+
+  events: [],
+  expectedAmount: '100',
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ERC20_PROXY_CONTRACT]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '0.1.0',
+    },
+  },
+  extensionsData: [],
+  meta: {
+    transactionManagerMeta: {},
+  },
+  pending: null,
+  requestId: 'abcd',
+  state: RequestLogicTypes.STATE.CREATED,
+  timestamp: 0,
+  version: '1.0',
+};
+
+const validRequestERC20FeeProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress,
+        feeAmount: '2',
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '0.1.0',
+    },
+  },
+};
+
+const validRequestERC20ConversionProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  currency: 'EUR',
+  currencyInfo: {
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+    value: 'EUR',
+  },
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ANY_TO_ERC20_PROXY]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress,
+        feeAmount: '2',
+        paymentAddress,
+        salt: 'salt',
+        network: 'private',
+        acceptedTokens: [alphaContractAddress],
+      },
+      version: '0.1.0',
+    },
+  },
+};
+
+const validRequestEthProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  currency: 'ETH',
+  currencyInfo: {
+    network: 'private',
+    type: RequestLogicTypes.CURRENCY.ETH,
+    value: RequestLogicTypes.CURRENCY.ETH,
+  },
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ETH_INPUT_DATA]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '0.1.0',
+    },
+  },
+  version: '2.0.3',
+};
+
+const validRequestEthFeeProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  currency: 'ETH',
+  currencyInfo: {
+    network: 'private',
+    type: RequestLogicTypes.CURRENCY.ETH,
+    value: RequestLogicTypes.CURRENCY.ETH,
+  },
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ETH_FEE_PROXY_CONTRACT,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress,
+        feeAmount: '2',
+        paymentAddress,
+        salt: 'salt',
+      },
+      version: '0.1.0',
+    },
+  },
+  version: '2.0.3',
+};
+
+const validRequestEthConversionProxy: ClientTypes.IRequestData = {
+  ...baseValidRequest,
+  currency: 'EUR',
+  currencyInfo: {
+    type: RequestLogicTypes.CURRENCY.ISO4217,
+    value: 'EUR',
+  },
+  extensions: {
+    [PaymentTypes.PAYMENT_NETWORK_ID.ANY_TO_ETH_PROXY]: {
+      events: [],
+      id: ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ETH_PROXY,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        feeAddress,
+        feeAmount: '2',
+        paymentAddress,
+        salt: 'salt',
+        network: 'private',
+      },
+      version: '0.1.0',
+    },
+  },
+};
+
+describe('Encoder', () => {
+  it('Should handle ERC20 Proxy request', async () => {
+    const encodedTransactions = await encodeRequest(baseValidRequest, provider, wallet.address);
+
+    let tx = await wallet.sendTransaction(encodedTransactions[0]);
+    let confirmedTx = await tx.wait(1);
+    expect(confirmedTx.status).toBe(1);
+    expect(tx.hash).not.toBeUndefined();
+
+    tx = await wallet.sendTransaction(encodedTransactions[1]);
+    confirmedTx = await tx.wait(1);
+    expect(confirmedTx.status).toBe(1);
+    expect(tx.hash).not.toBeUndefined();
+  });
+
+  it('Should handle ERC20 Fee Proxy request', async () => {
+    const encodedTransactions = await encodeRequest(
+      validRequestERC20FeeProxy,
+      provider,
+      wallet.address,
+    );
+
+    let tx = await wallet.sendTransaction(encodedTransactions[0]);
+    let confirmedTx = await tx.wait(1);
+    expect(confirmedTx.status).toBe(1);
+    expect(tx.hash).not.toBeUndefined();
+
+    tx = await wallet.sendTransaction(encodedTransactions[1]);
+    confirmedTx = await tx.wait(1);
+    expect(confirmedTx.status).toBe(1);
+    expect(tx.hash).not.toBeUndefined();
+  });
+
+  it('Should handle ERC20 Conversion Proxy request', async () => {
+    let encodedTransactions = await encodeRequest(
+      validRequestERC20ConversionProxy,
+      provider,
+      wallet.address,
+      {
+        conversion: alphaConversionSettings,
+      },
+    );
+
+    let tx = await wallet.sendTransaction(encodedTransactions[0]);
+    let confirmedTx = await tx.wait(1);
+    expect(confirmedTx.status).toBe(1);
+    expect(tx.hash).not.toBeUndefined();
+
+    tx = await wallet.sendTransaction(encodedTransactions[1]);
+    confirmedTx = await tx.wait(1);
+    expect(confirmedTx.status).toBe(1);
+    expect(tx.hash).not.toBeUndefined();
+  });
+
+  it('Should handle ERC20 Swap Proxy request', async () => {
+    let encodedTransactions = await encodeRequest(
+      validRequestERC20FeeProxy,
+      provider,
+      wallet.address,
+      {
+        swap: alphaSwapSettings,
+      },
+    );
+
+    let tx = await wallet.sendTransaction(encodedTransactions[0]);
+    let confirmedTx = await tx.wait(1);
+    expect(confirmedTx.status).toBe(1);
+    expect(tx.hash).not.toBeUndefined();
+
+    tx = await wallet.sendTransaction(encodedTransactions[1]);
+    confirmedTx = await tx.wait(1);
+    expect(confirmedTx.status).toBe(1);
+    expect(tx.hash).not.toBeUndefined();
+  });
+
+  it.only('Should handle ERC20 Swap and Conversion Proxy request', async () => {
+    let encodedTransactions = await encodeRequest(
+      validRequestERC20ConversionProxy,
+      provider,
+      wallet.address,
+      {
+        swap: alphaSwapConversionSettings,
+        conversion: alphaConversionSettings,
+      },
+    );
+
+    let tx = await wallet.sendTransaction(encodedTransactions[0]);
+    let confirmedTx = await tx.wait(1);
+    expect(confirmedTx.status).toBe(1);
+    expect(tx.hash).not.toBeUndefined();
+
+    tx = await wallet.sendTransaction(encodedTransactions[1]);
+    confirmedTx = await tx.wait(1);
+    expect(confirmedTx.status).toBe(1);
+    expect(tx.hash).not.toBeUndefined();
+  });
+
+  it('Should handle Eth Proxy request', async () => {
+    let encodedTransactions = await encodeRequest(validRequestEthProxy, provider, wallet.address);
+
+    let tx = await wallet.sendTransaction(encodedTransactions[0]);
+    let confirmedTx = await tx.wait(1);
+    expect(confirmedTx.status).toBe(1);
+    expect(tx.hash).not.toBeUndefined();
+  });
+
+  it('Should handle Eth Fee Proxy request', async () => {
+    let encodedTransactions = await encodeRequest(
+      validRequestEthFeeProxy,
+      provider,
+      wallet.address,
+    );
+
+    let tx = await wallet.sendTransaction(encodedTransactions[0]);
+    let confirmedTx = await tx.wait(1);
+    expect(confirmedTx.status).toBe(1);
+    expect(tx.hash).not.toBeUndefined();
+  });
+
+  it('Should handle Eth Conversion Proxy', async () => {
+    let encodedTransactions = await encodeRequest(
+      validRequestEthConversionProxy,
+      provider,
+      wallet.address,
+      {
+        conversion: ethConversionSettings,
+      },
+    );
+
+    let tx = await wallet.sendTransaction(encodedTransactions[0]);
+    let confirmedTx = await tx.wait(1);
+    expect(confirmedTx.status).toBe(1);
+    expect(tx.hash).not.toBeUndefined();
+  });
+});

--- a/packages/payment-processor/test/payment/encoder.test.ts
+++ b/packages/payment-processor/test/payment/encoder.test.ts
@@ -47,7 +47,7 @@ const alphaSwapConversionSettings = {
 };
 
 const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
-const mnemonicPath = `m/44'/60'/0'/0/8`;
+const mnemonicPath = `m/44'/60'/0'/0/20`;
 const paymentAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
 const provider = new providers.JsonRpcProvider('http://localhost:8545');
 let wallet = Wallet.fromMnemonic(mnemonic, mnemonicPath).connect(provider);
@@ -216,6 +216,10 @@ beforeAll(async () => {
   await alphaContract.transfer(mainAddress, BigNumber.from('500000000000000000000'));
   const erc20Contract = ERC20__factory.connect(erc20ContractAddress, wallet);
   await erc20Contract.transfer(mainAddress, BigNumber.from('500000000000000000000'));
+  wallet.sendTransaction({
+    to: mainAddress,
+    value: BigNumber.from('10000000000000000000'),
+  });
   wallet = Wallet.fromMnemonic(mnemonic, mnemonicPath).connect(provider);
 });
 

--- a/packages/payment-processor/test/payment/encoder.test.ts
+++ b/packages/payment-processor/test/payment/encoder.test.ts
@@ -287,7 +287,7 @@ describe('Encoder', () => {
     expect(tx.hash).not.toBeUndefined();
   });
 
-  it.only('Should handle ERC20 Swap and Conversion Proxy request', async () => {
+  it('Should handle ERC20 Swap and Conversion Proxy request', async () => {
     let encodedTransactions = await encodeRequestApprovalAndPayment(
       validRequestERC20ConversionProxy,
       provider,


### PR DESCRIPTION
## Description of the changes

It exports new methods from the `payment-processor` package:
- Encoding of the approval transaction for a request payment
- Check for knowing if an approval is needed for a request payment
- Encoding of an approval transaction if needed for a request payment
- Encoding of the payment transaction for a request payment
- Encoding of all necessary transactions (approval if needed + payment) for a request payment

New tests cover these methods