### PR TITLE
fix: changed graph getTransferEvents return types into IERC20Fee

### DIFF
--- a/packages/payment-detection/src/erc20/thegraph-info-retriever.ts
+++ b/packages/payment-detection/src/erc20/thegraph-info-retriever.ts
@@ -44,7 +44,7 @@ export class TheGraphInfoRetriever {
   }
 
   public async getTransferEvents(): Promise<
-    PaymentTypes.AllNetworkEvents<PaymentTypes.IERC20PaymentEventParameters>
+    PaymentTypes.AllNetworkEvents<PaymentTypes.IERC20FeePaymentEventParameters>
   > {
     const variables = this.getGraphVariables();
     const paymentsAndEscrows = await this.client.GetPaymentsAndEscrowState(variables);

--- a/packages/payment-detection/test/erc20/thegraph-info-retriever.test.ts
+++ b/packages/payment-detection/test/erc20/thegraph-info-retriever.test.ts
@@ -20,6 +20,8 @@ describe('api/erc20/thegraph-info-retriever', () => {
         amount: '30000000000000',
         requestId: '0188791633ff0ec72a7dbdefb886d2db6cccfa98287320839c2f173c7a4e3ce7e1',
         block: 9606098,
+        feeAddress: '0x5000EE9FB9c96A2A09D8efB695aC21D6C429fF11',
+        feeAmount: '0',
       };
       const paymentReference = PaymentReferenceCalculator.calculate(
         paymentData.requestId,
@@ -45,6 +47,8 @@ describe('api/erc20/thegraph-info-retriever', () => {
       expect(transferEvents[0].parameters?.to).toEqual(paymentData.to);
       expect(transferEvents[0].parameters?.txHash).toEqual(paymentData.txHash);
       expect(transferEvents[0].parameters?.block).toEqual(paymentData.block);
+      expect(transferEvents[0].parameters?.feeAddress).toEqual(paymentData.feeAddress);
+      expect(transferEvents[0].parameters?.feeAmount).toEqual(paymentData.feeAmount);
     });
 
     it('should get payment event from ethFeeConversionProxy via subgraph', async () => {


### PR DESCRIPTION
Updated GraphInfoRetriever to return ERC20Fee events that also contain feeAddress and feeAmount