### PR TITLE
feat: Batch payments erc20 eth

### DIFF
--- a/packages/data-format/src/format/rnf_invoice/rnf_invoice-0.0.3.json
+++ b/packages/data-format/src/format/rnf_invoice/rnf_invoice-0.0.3.json
@@ -169,7 +169,7 @@
           "currency": {
             "type": "string",
             "minLength": 2,
-            "maxLength": 6
+            "maxLength": 10
           },
           "deliveryDate": {
             "type": "string",

--- a/packages/smart-contracts/hardhat.config.ts
+++ b/packages/smart-contracts/hardhat.config.ts
@@ -5,7 +5,7 @@ import '@nomiclabs/hardhat-etherscan';
 import '@nomiclabs/hardhat-ethers';
 import { subtask, task } from 'hardhat/config';
 import { config } from 'dotenv';
-import deployAllContracts from './scripts/5_deploy-all';
+import deployAllContracts from './scripts/6_deploy-all';
 import { deployAllPaymentContracts } from './scripts/deploy-payments';
 import { preparePayments } from './scripts/prepare-payments';
 import { checkCreate2Deployer } from './scripts-create2/check-deployer';

--- a/packages/smart-contracts/scripts/5_deploy-batch-erc-eth-deployment.ts
+++ b/packages/smart-contracts/scripts/5_deploy-batch-erc-eth-deployment.ts
@@ -1,0 +1,29 @@
+import '@nomiclabs/hardhat-ethers';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { deployOne } from '../scripts/deploy-one';
+
+// Deploys, set up the contracts
+export async function deployBatchPayment(args: any, hre: HardhatRuntimeEnvironment): Promise<any> {
+  try {
+    const ERC20FeeProxyAddress = '0x75c35C980C0d37ef46DF04d31A140b65503c0eEd';
+    const EthereumFeeProxyAddress = '0x3d49d1eF2adE060a33c6E6Aa213513A7EE9a6241';
+
+    // Deploy BatchPayments contract
+    const { address: BatchPaymentsAddress } = await deployOne(args, hre, 'BatchPayments', {
+      constructorArguments: [
+        ERC20FeeProxyAddress,
+        EthereumFeeProxyAddress,
+        await (await hre.ethers.getSigners())[0].getAddress(),
+      ],
+    });
+    console.log('BatchPaymentsAddress Contract deployed: ' + BatchPaymentsAddress);
+
+    // ----------------------------------
+    console.log('Contracts deployed');
+    console.log(`
+      BatchPaymentsAddress:       ${BatchPaymentsAddress}
+    `);
+  } catch (e) {
+    console.error(e);
+  }
+}

--- a/packages/smart-contracts/scripts/6_deploy-all.ts
+++ b/packages/smart-contracts/scripts/6_deploy-all.ts
@@ -3,11 +3,13 @@ import deployRequest from './1_deploy-request-storage';
 import deployPayment from './2_deploy-main-payments';
 import deployConversion from './3_deploy_chainlink_contract';
 import { deployEscrow } from './4_deploy-escrow-deployment';
+import { deployBatchPayment } from './5_deploy-batch-erc-eth-deployment';
 
 // Deploys, set up the contracts
-export default async function deploy(_args: any, hre: HardhatRuntimeEnvironment) {
+export default async function deploy(_args: any, hre: HardhatRuntimeEnvironment): Promise<any> {
   await deployRequest(_args, hre);
   const mainPaymentAddresses = await deployPayment(_args, hre);
   await deployConversion(_args, hre, mainPaymentAddresses);
   await deployEscrow(hre);
+  await deployBatchPayment(_args, hre);
 }

--- a/packages/smart-contracts/src/contracts/BatchPayments.sol
+++ b/packages/smart-contracts/src/contracts/BatchPayments.sol
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./interfaces/ERC20FeeProxy.sol";
+import "./interfaces/EthereumFeeProxy.sol";
+import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
+
+/**
+ * @title BatchPayments
+ * @notice This contract makes multiple payments with references, in one transaction:
+ *          - on: ERC20 Payment Proxy and ETH Payment Proxy of the Request Network protocol
+ *          - to: multiple addresses
+ *          - fees: Proxy fees can be paid to the same address. 
+ *                  An additional batch fee is added, paid to the same address.
+ */
+contract BatchPayments is Ownable, ReentrancyGuard {
+    
+    // This event is declared in ERC20FeeProxy
+    event TransferWithReferenceAndFee(
+        address tokenAddress,
+        address to,
+        uint256 amount,
+        bytes indexed paymentReference,
+        uint256 feeAmount,
+        address feeAddress
+    );
+    
+    // @dev: Between 0 and 1000, i.e: batchFee = 10 represent 1% of fee
+    uint256 public batchFee;
+
+    IERC20FeeProxy public paymentErc20FeeProxy;
+    IEthereumFeeProxy public paymentEthereumFeeProxy;
+
+    /**
+     * @param _paymentErc20FeeProxy The address to the ERC20 payment proxy to use.
+     * @param _paymentEthereumFeeProxy The address to the Ethereum payment proxy to use.
+     * @param _owner Owner of the contract.
+     */
+    constructor(address _paymentErc20FeeProxy, address _paymentEthereumFeeProxy, address _owner) {
+        paymentErc20FeeProxy  = IERC20FeeProxy(_paymentErc20FeeProxy);
+        paymentEthereumFeeProxy = IEthereumFeeProxy(_paymentEthereumFeeProxy);
+        batchFee = 0;
+        transferOwnership(_owner);
+    }
+
+    // Needed because batchEthPaymentsWithReferenceAndFee requires that the contract has ethers
+    receive() external payable {}
+
+    /**
+    * @notice Send a batch of Ethereum payments w/fees with paymentReferences to multiple accounts.
+    *         The sum of _amounts and _feeAmounts must be <= to msg.value.
+    *         If one payment failed, the whole batch is reverted
+    * @param _recipients List of recipients accounts.
+    * @param _amounts List of amounts, corresponding to recipients[].
+    * @param _paymentReferences List of paymentRefs, corr. to the recipients[].
+    * @param _feeAmounts List of amounts of the payment fee, corr. to the recipients[].
+    * @param _feeAddress The fee recipient.
+    * @dev Uses EthereumFeeProxy.sol to pay an invoice and fees, with a payment reference.
+    *      Make sure: msg.value >= sum(_amouts)+sum(_feeAmounts)
+    */
+    function batchEthPaymentsWithReference(
+        address[] calldata _recipients, 
+        uint256[] calldata _amounts,
+        bytes[] calldata _paymentReferences,
+        uint256[] calldata _feeAmounts,
+        address payable _feeAddress 
+    ) external payable nonReentrant {
+        require(
+            _recipients.length == _amounts.length
+            && _recipients.length == _paymentReferences.length
+            && _recipients.length == _feeAmounts.length
+            , "the input arrays must have the same length"
+        );
+
+        // Sender transfers tokens to the contract
+        payable(address(this)).transfer(msg.value);
+        uint256 toReturn = msg.value;
+        uint256 sumBatchFeeAmount = 0;
+
+        // Contract pays the batch payment
+        for (uint256 i = 0; i < _recipients.length; i++) {
+            uint256 batchFeeAmount = (_amounts[i] * batchFee) / 1000;
+            require(toReturn >= _amounts[i] + _feeAmounts[i] + batchFeeAmount, "not enough funds");
+            sumBatchFeeAmount += batchFeeAmount;
+            toReturn -= (_amounts[i]+_feeAmounts[i] + batchFeeAmount);
+
+            paymentEthereumFeeProxy.transferWithReferenceAndFee{value: _amounts[i]+_feeAmounts[i]}(
+                payable(_recipients[i]), 
+                _paymentReferences[i],
+                _feeAmounts[i],
+                payable(_feeAddress)
+            );
+        }
+        _feeAddress.transfer(sumBatchFeeAmount);
+
+        // Transfer the remaining ethers to the sender
+        (bool sendBackSuccess, ) = payable(msg.sender).call{ value: toReturn }('');
+        require(sendBackSuccess, 'Could not send remaining funds to the payer');
+    }
+
+    /**
+     * @notice Send a batch of erc20 payments w/fees with paymentReferences to multiple accounts.
+     * @param _tokenAddress Token to transact with.
+     * @param _recipients List of recipients accounts.
+     * @param _amounts List of amounts, corresponding to recipients[].
+     * @param _paymentReferences List of paymentRefs, corr. to the recipients[] and .
+     * @param _feeAmounts List of amounts of the payment fee, corr. to the recipients[].
+     * @param _feeAddress The fee recipient.
+     * @dev Uses ERC20FeeProxy.sol to pay an invoice and fees, with a payment reference.
+     *      Make sure the contract has allowance to spend the sender token.
+     */
+    function batchERC20PaymentsWithReference(
+        address _tokenAddress, 
+        address[] calldata _recipients, 
+        uint256[] calldata _amounts,
+        bytes[] calldata _paymentReferences,
+        uint256[] calldata _feeAmounts,
+        address _feeAddress 
+    ) external {
+        require(
+            _recipients.length == _amounts.length
+            && _recipients.length == _paymentReferences.length
+            && _recipients.length == _feeAmounts.length
+            , "the input arrays must have the same length"
+        );
+        
+        uint256 batchAmount = 0;
+
+        for (uint256 i = 0; i < _recipients.length; i++) {
+             batchAmount += _amounts[i];
+           (bool status, ) = address(paymentErc20FeeProxy).delegatecall(
+            abi.encodeWithSignature(
+            "transferFromWithReferenceAndFee(address,address,uint256,bytes,uint256,address)",
+                _tokenAddress,
+                _recipients[i], 
+                _amounts[i],
+                _paymentReferences[i],
+                _feeAmounts[i],
+                _feeAddress
+                )
+            );
+            require(status, "transferFromWithReference failed");
+        }
+
+        require(safeTransferFrom(_tokenAddress, _feeAddress, (batchAmount * batchFee) / 1000),
+         "batch fee transferFrom() failed");
+    }
+
+
+    /**
+     * @notice Send a batch of erc20 payments on multiple tokens w/fees with paymentReferences to multiple accounts.
+     * @param _tokenAddresses List of tokens to transact with.
+     * @param _recipients List of recipients accounts.
+     * @param _amounts List of amounts, corresponding to recipients[].
+     * @param _paymentReferences List of paymentRefs, corr. to the recipients[].
+     * @param _feeAmounts List of amounts of the payment fee, corr. to the recipients[].
+     * @param _feeAddress The fee recipient.
+     * @dev Uses ERC20FeeProxy.sol to pay an invoice and fees, with a payment reference.
+     *      Make sure the contract has allowance to spend the sender token.
+     */
+    function batchERC20PaymentsMultiTokensWithReference(
+        address[] calldata _tokenAddresses, 
+        address[] calldata _recipients, 
+        uint256[] calldata _amounts,
+        bytes[] calldata _paymentReferences,
+        uint256[] calldata _feeAmounts,
+        address _feeAddress 
+    ) external {
+        require(
+            _tokenAddresses.length == _recipients.length
+            && _tokenAddresses.length == _amounts.length
+            && _tokenAddresses.length == _paymentReferences.length
+            && _tokenAddresses.length == _feeAmounts.length
+            , "the input arrays must have the same length"
+        );
+
+        address[] memory uniqueTokens = new address[](_tokenAddresses.length);
+        uint256[] memory amountByToken = new uint256[](_tokenAddresses.length);
+
+        // Pay the requests
+        for (uint256 i = 0; i < _recipients.length; i++) {
+            // Create a list of unique tokens used
+            for(uint j = 0; j < uniqueTokens.length; j++){
+                if(uniqueTokens[j] == _tokenAddresses[i]){
+                    amountByToken[j] += _amounts[i];
+                    break;
+                }
+                if(amountByToken[j] == 0){
+                    uniqueTokens[j] = _tokenAddresses[i];
+                    amountByToken[j] = _amounts[i];
+                    break;
+                }
+            }
+
+           (bool status, ) = address(paymentErc20FeeProxy).delegatecall(
+            abi.encodeWithSignature(
+            "transferFromWithReferenceAndFee(address,address,uint256,bytes,uint256,address)",
+                _tokenAddresses[i],
+                _recipients[i], 
+                _amounts[i],
+                _paymentReferences[i],
+                _feeAmounts[i],
+                _feeAddress
+                )
+            );
+            require(status, "transferFromWithReference failed");
+        }
+
+        // Pay batch fee
+        for(uint i = 0; i < uniqueTokens.length && amountByToken[i] > 0; i++){
+            require(safeTransferFrom(uniqueTokens[i], _feeAddress, (amountByToken[i] * batchFee) / 1000),
+             "batch fee transferFrom() failed");
+             amountByToken[i] = 0;
+        }
+    }
+
+    /**
+    * @notice Call transferFrom ERC20 function and validates the return data of a ERC20 contract call.
+    * @dev This is necessary because of non-standard ERC20 tokens that don't have a return value.
+    * @return result The return value of the ERC20 call, returning true for non-standard tokens
+    */
+    function safeTransferFrom(address _tokenAddress, address _to, uint256 _amount) internal returns (bool result) {
+    /* solium-disable security/no-inline-assembly */
+    // check if the address is a contract
+    assembly {
+        if iszero(extcodesize(_tokenAddress)) { revert(0, 0) }
+    }
+
+    // solium-disable-next-line security/no-low-level-calls
+    (bool success, ) = _tokenAddress.call(abi.encodeWithSignature(
+        "transferFrom(address,address,uint256)",
+        msg.sender,
+        _to,
+        _amount
+    ));
+
+    assembly {
+        switch returndatasize()
+        case 0 { // Not a standard erc20
+            result := 1
+        }
+        case 32 { // Standard erc20
+            returndatacopy(0, 0, 32)
+            result := mload(0)
+        }
+        default { // Anything else, should revert for safety
+            revert(0, 0)
+        }
+    }
+
+    require(success, "transferFrom() has been reverted");
+
+    /* solium-enable security/no-inline-assembly */
+    return result;
+  }
+
+    /*
+    * Admin functions to edit the proxies address
+    */
+
+    function setBatchFee(uint256 _batchFee) public onlyOwner {
+        batchFee = _batchFee;
+    }
+
+    function setPaymentErc20FeeProxy(address _paymentProxyAddress) public onlyOwner {
+        paymentErc20FeeProxy = IERC20FeeProxy(_paymentProxyAddress);
+    }
+
+    function setPaymentEthereumFeeProxy(address _paymentEthereumFeeProxyAddress) public onlyOwner {
+        paymentEthereumFeeProxy = IEthereumFeeProxy(_paymentEthereumFeeProxyAddress);
+    }
+}

--- a/packages/smart-contracts/src/contracts/interfaces/EthereumFeeProxy.sol
+++ b/packages/smart-contracts/src/contracts/interfaces/EthereumFeeProxy.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-interface IERC20FeeProxy {
+interface IEthereumFeeProxy {
   event TransferWithReferenceAndFee(
-    address tokenAddress,
     address to,
     uint256 amount,
     bytes indexed paymentReference,
@@ -11,12 +10,10 @@ interface IERC20FeeProxy {
     address feeAddress
   );
 
-  function transferFromWithReferenceAndFee(
-    address _tokenAddress,
-    address _to,
-    uint256 _amount,
+  function transferWithReferenceAndFee(
+    address payable _to,
     bytes calldata _paymentReference,
     uint256 _feeAmount,
-    address _feeAddress
-  ) external;
+    address payable _feeAddress
+  ) external payable;
 }

--- a/packages/smart-contracts/src/lib/artifacts/BatchPayments/0.1.0.json
+++ b/packages/smart-contracts/src/lib/artifacts/BatchPayments/0.1.0.json
@@ -1,0 +1,255 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_erc20FeeProxy",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_erc20FeeProxy",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_owner",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "tokenAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes",
+          "name": "paymentReference",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "feeAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "feeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "TransferWithReferenceAndFee",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_tokenAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_recipients",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "_values",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "bytes[]",
+          "name": "_paymentReferences",
+          "type": "bytes[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "_feeAmount",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address",
+          "name": "_feeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "batchERC20PaymentsWithReference",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "_recipients",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "_values",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "bytes[]",
+          "name": "_paymentReferences",
+          "type": "bytes[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "_feeAmount",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address payable",
+          "name": "_feeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "batchEthPaymentsWithReference",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_feeBatch",
+          "type": "uint256"
+        }
+      ],
+      "name": "setBatchFee",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "_tokenAddresses",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_recipients",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "_values",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "bytes[]",
+          "name": "_paymentReferences",
+          "type": "bytes[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "_feeAmount",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address",
+          "name": "_feeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "batchERC20PaymentsMultiTokensWithReference",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "erc20FeeProxy",
+      "outputs": [
+        {
+          "internalType": "contract IERC20FeeProxy",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "recieve",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "paymentEthereumFeeProxy",
+      "outputs": [
+        {
+          "internalType": "contract IEthereumFeeProxy",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "paymentErc20FeeProxy",
+      "outputs": [
+        {
+          "internalType": "contract IERC20FeeProxy",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "batchFee",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/packages/smart-contracts/src/lib/artifacts/BatchPayments/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/BatchPayments/index.ts
@@ -1,0 +1,20 @@
+import { ContractArtifact } from '../../ContractArtifact';
+
+import { abi as ABI_0_1_0 } from './0.1.0.json';
+// @ts-ignore Cannot find module
+import type { BatchPayments } from '../../../types/BatchPayments';
+
+export const batchPaymentsArtifact = new ContractArtifact<BatchPayments>(
+  {
+    '0.1.0': {
+      abi: ABI_0_1_0,
+      deployment: {
+        private: {
+          address: '0x74e3FC764c2474f25369B9d021b7F92e8441A2Dc',
+          creationBlockNumber: 0,
+        },
+      },
+    },
+  },
+  '0.1.0',
+);

--- a/packages/smart-contracts/src/lib/artifacts/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/index.ts
@@ -11,6 +11,7 @@ export * from './EthereumProxy';
 export * from './EthereumFeeProxy';
 export * from './EthConversionProxy';
 export * from './ERC20EscrowToPay';
+export * from './BatchPayments';
 /**
  * Request Storage
  */

--- a/packages/smart-contracts/test/contracts/BatchErc20Payments.test.ts
+++ b/packages/smart-contracts/test/contracts/BatchErc20Payments.test.ts
@@ -1,0 +1,558 @@
+import { ethers, network } from 'hardhat';
+import { BigNumber, Signer } from 'ethers';
+import { expect, use } from 'chai';
+import { solidity } from 'ethereum-waffle';
+import { TestERC20__factory, TestERC20, BatchPayments } from '../../src/types';
+import { batchPaymentsArtifact } from '../../src/lib';
+
+use(solidity);
+
+const logGasInfos = false;
+
+describe('contract: BatchPayments: ERC20', () => {
+  let payee1: string;
+  let payee2: string;
+  let payee3: string;
+  let spender3Address: string;
+  let feeAddress: string;
+
+  let token1: TestERC20;
+  let token2: TestERC20;
+  let token3: TestERC20;
+  let batch: BatchPayments;
+
+  let token1Address: string;
+  let token2Address: string;
+  let token3Address: string;
+  let batchAddress: string;
+
+  let owner: Signer;
+  let spender1: Signer;
+  let spender2: Signer;
+  let spender3: Signer;
+
+  let beforeERC20Balance1: BigNumber;
+  let afterERC20Balance1: BigNumber;
+  let beforeERC20Balance2: BigNumber;
+  let afterERC20Balance2: BigNumber;
+  let beforeERC20Balance3: BigNumber;
+  let afterERC20Balance3: BigNumber;
+
+  const referenceExample1 = '0xaaaa';
+  const referenceExample2 = '0xbbbb';
+  const referenceExample3 = '0xcccc';
+
+  const erc20Decimal = BigNumber.from('1000000000000000000');
+
+  before(async () => {
+    [, payee1, payee2, payee3, feeAddress] = (await ethers.getSigners()).map((s) => s.address);
+    [owner, spender1, spender2, spender3] = await ethers.getSigners();
+    batch = batchPaymentsArtifact.connect(network.name, owner);
+    token1 = await new TestERC20__factory(owner).deploy(erc20Decimal.mul(10000));
+    token2 = await new TestERC20__factory(owner).deploy(erc20Decimal.mul(10000));
+    token3 = await new TestERC20__factory(owner).deploy(erc20Decimal.mul(10000));
+
+    const spender1Address = await spender1.getAddress();
+    const spender2Address = await spender2.getAddress();
+    spender3Address = await spender3.getAddress();
+    token1Address = token1.address;
+    token2Address = token2.address;
+    token3Address = token3.address;
+    batchAddress = batch.address;
+
+    await token1.connect(owner).transfer(spender1Address, 1000);
+    await token1.connect(owner).transfer(spender2Address, 160);
+    await token1.connect(owner).transfer(spender3Address, 260);
+    await token1.connect(spender1).approve(batchAddress, 1000);
+    await token1.connect(spender3).approve(batchAddress, 370);
+
+    // 2nd token
+    await token2.connect(owner).transfer(spender1Address, 1000);
+    await token2.connect(spender1).approve(batchAddress, 1000);
+    await token2.connect(owner).transfer(spender3Address, 1000);
+    await token2.connect(spender3).approve(batchAddress, 1000);
+
+    // 3nd token
+    await token3.connect(owner).transfer(spender3Address, 100);
+    await token3.connect(spender3).approve(batchAddress, 100);
+
+    // set batch fee at 100 (=10%) for the purpose of the tests.
+    await batch.connect(owner).setBatchFee(100);
+  });
+
+  describe('Batch working well: right args, and approvals', () => {
+    it('Should pay 3 ERC20 payments with paymentRef and pay batch fee', async function () {
+      beforeERC20Balance1 = await token1.balanceOf(payee1);
+      beforeERC20Balance2 = await token1.balanceOf(payee2);
+      beforeERC20Balance3 = await token1.balanceOf(spender3Address);
+
+      await expect(
+        batch
+          .connect(spender3)
+          .batchERC20PaymentsWithReference(
+            token1Address,
+            [payee1, payee2, payee2],
+            [20, 30, 40],
+            [referenceExample1, referenceExample2, referenceExample3],
+            [1, 2, 3],
+            feeAddress,
+          ),
+      )
+        .to.emit(token1, 'Transfer')
+        .to.emit(token1, 'Transfer')
+        .to.emit(token1, 'Transfer')
+        .to.emit(batch, 'TransferWithReferenceAndFee')
+        .withArgs(
+          token1Address,
+          payee1,
+          '20',
+          ethers.utils.keccak256(referenceExample1),
+          '1',
+          feeAddress,
+        )
+        .to.emit(batch, 'TransferWithReferenceAndFee')
+        .withArgs(
+          token1Address,
+          payee2,
+          '30',
+          ethers.utils.keccak256(referenceExample2),
+          '2',
+          feeAddress,
+        )
+        .to.emit(batch, 'TransferWithReferenceAndFee')
+        .withArgs(
+          token1Address,
+          payee2,
+          '40',
+          ethers.utils.keccak256(referenceExample3),
+          '3',
+          feeAddress,
+        );
+
+      afterERC20Balance1 = await token1.balanceOf(payee1);
+      expect(afterERC20Balance1).to.be.equal(beforeERC20Balance1.add(20));
+      afterERC20Balance2 = await token1.balanceOf(payee2);
+      expect(afterERC20Balance2).to.be.equal(beforeERC20Balance2.add(30 + 40));
+
+      afterERC20Balance3 = await token1.balanceOf(spender3Address);
+      expect(beforeERC20Balance3).to.be.equal(
+        afterERC20Balance3.add(20 + 1 + 2 + (30 + 2 + 3) + (40 + 3 + 4)),
+      );
+    });
+
+    it('Should pay 3 ERC20 payments Multi tokens with paymentRef and pay batch fee', async function () {
+      beforeERC20Balance1 = await token1.balanceOf(payee1);
+      const beforeERC20Balance2_token2 = await token2.balanceOf(payee2);
+      const beforeERC20Balance2_token3 = await token3.balanceOf(payee2);
+      beforeERC20Balance3 = await token1.balanceOf(spender3Address);
+
+      const beforeFeeAddress_token1 = await token1.balanceOf(feeAddress);
+      const beforeFeeAddress_token2 = await token2.balanceOf(feeAddress);
+      const beforeFeeAddress_token3 = await token3.balanceOf(feeAddress);
+
+      let tx = await batch
+        .connect(spender3)
+        .batchERC20PaymentsMultiTokensWithReference(
+          [token1Address, token2Address, token3Address],
+          [payee1, payee2, payee2],
+          [20, 30, 40],
+          [referenceExample1, referenceExample2, referenceExample3],
+          [1, 2, 3],
+          feeAddress,
+        );
+      await tx.wait();
+
+      afterERC20Balance1 = await token1.balanceOf(payee1);
+      expect(afterERC20Balance1).to.be.equal(beforeERC20Balance1.add(20));
+
+      expect(await token1.balanceOf(payee1)).to.be.equal(beforeERC20Balance1.add(20));
+      expect(await token2.balanceOf(payee2)).to.be.equal(beforeERC20Balance2_token2.add(30));
+      expect(await token3.balanceOf(payee2)).to.be.equal(beforeERC20Balance2_token3.add(40));
+      expect(beforeERC20Balance3).to.be.equal(
+        (await token1.balanceOf(spender3Address)).add(20 + 1 + 2),
+      );
+
+      expect(await token1.balanceOf(feeAddress)).to.be.equal(beforeFeeAddress_token1.add(1 + 2));
+      expect(await token2.balanceOf(feeAddress)).to.be.equal(beforeFeeAddress_token2.add(2 + 3));
+      expect(await token3.balanceOf(feeAddress)).to.be.equal(
+        beforeFeeAddress_token3.add((3 + 4) * 1),
+      );
+    });
+
+    it('Should pay 4 ERC20 payments on 2 tokens', async function () {
+      beforeERC20Balance1 = await token1.balanceOf(payee2);
+      beforeERC20Balance2 = await token2.balanceOf(payee2);
+      beforeERC20Balance3 = await token1.balanceOf(spender3Address);
+      const beforeERC20Balance3Token2 = await token2.balanceOf(spender3Address);
+
+      const amount = 20;
+      const feeAmount = 1;
+      const nbTxs = 4;
+      const [
+        tokenAddresses,
+        recipients,
+        amounts,
+        paymentReferences,
+        feeAmounts,
+      ] = getBatchPaymentsInputs(
+        nbTxs,
+        token1Address,
+        payee2,
+        amount,
+        referenceExample1,
+        feeAmount,
+      );
+
+      tokenAddresses[2] = token2Address;
+      tokenAddresses[3] = token2Address;
+
+      const tx = await batch
+        .connect(spender3)
+        .batchERC20PaymentsMultiTokensWithReference(
+          tokenAddresses,
+          recipients,
+          amounts,
+          paymentReferences,
+          feeAmounts,
+          feeAddress,
+        );
+      await tx.wait();
+
+      afterERC20Balance1 = await token1.balanceOf(payee2);
+      expect(afterERC20Balance1).to.be.equal(beforeERC20Balance1.add(amount * 2));
+
+      afterERC20Balance2 = await token2.balanceOf(payee2);
+      expect(afterERC20Balance2).to.be.equal(beforeERC20Balance2.add(amount * 2));
+
+      afterERC20Balance3 = await token1.balanceOf(spender3Address);
+      expect(beforeERC20Balance3).to.be.equal(afterERC20Balance3.add((20 + 1 + 2) * 2));
+
+      const afterERC20Balance3Token2 = await token2.balanceOf(spender3Address);
+      expect(beforeERC20Balance3Token2).to.be.equal(afterERC20Balance3Token2.add((20 + 1 + 2) * 2));
+    });
+
+    it('Should pay 10 ERC20 payments', async function () {
+      beforeERC20Balance1 = await token1.balanceOf(payee3);
+
+      const amount = 2;
+      const feeAmount = 1;
+      const nbTxs = 10;
+      const [
+        token1Addresses,
+        recipients,
+        amounts,
+        paymentReferences,
+        feeAmounts,
+      ] = getBatchPaymentsInputs(
+        nbTxs,
+        token1Address,
+        payee3,
+        amount,
+        referenceExample1,
+        feeAmount,
+      );
+
+      const tx = await batch
+        .connect(spender1)
+        .batchERC20PaymentsWithReference(
+          token1Addresses[0],
+          recipients,
+          amounts,
+          paymentReferences,
+          feeAmounts,
+          feeAddress,
+        );
+      await tx.wait();
+
+      const receipt = await tx.wait();
+      if (logGasInfos) {
+        console.log(`nbTxs= ${nbTxs}, gas consumption: `, receipt.gasUsed.toString());
+      }
+
+      afterERC20Balance1 = await token1.balanceOf(payee3);
+      expect(afterERC20Balance1).to.be.equal(beforeERC20Balance1.add(amount * nbTxs));
+    });
+
+    it('Should pay 10 ERC20 payments on multiple tokens', async function () {
+      beforeERC20Balance1 = await token1.balanceOf(payee3);
+      beforeERC20Balance2 = await token2.balanceOf(payee3);
+
+      const amount = 2;
+      const feeAmount = 1;
+      const nbTxs = 10;
+      const [
+        tokenAddresses,
+        recipients,
+        amounts,
+        paymentReferences,
+        feeAmounts,
+      ] = getBatchPaymentsInputs(
+        nbTxs,
+        token1Address,
+        payee3,
+        amount,
+        referenceExample1,
+        feeAmount,
+      );
+
+      for (let i = 0; i < 5; i++) {
+        tokenAddresses[i] = token2Address;
+      }
+
+      const tx = await batch
+        .connect(spender1)
+        .batchERC20PaymentsMultiTokensWithReference(
+          tokenAddresses,
+          recipients,
+          amounts,
+          paymentReferences,
+          feeAmounts,
+          feeAddress,
+        );
+
+      const receipt = await tx.wait();
+      if (logGasInfos) {
+        console.log(`nbTxs= ${nbTxs}, gas consumption: `, receipt.gasUsed.toString());
+      }
+
+      afterERC20Balance1 = await token1.balanceOf(payee3);
+      expect(afterERC20Balance1).to.be.equal(beforeERC20Balance1.add(amount * 5));
+      afterERC20Balance2 = await token2.balanceOf(payee3);
+      expect(afterERC20Balance2).to.be.equal(beforeERC20Balance2.add(amount * 5));
+    });
+  });
+
+  describe('Batch revert, issues with: args, or funds, or approval', () => {
+    it('Should revert batch if not enough funds to pay the request', async function () {
+      await expect(
+        batch
+          .connect(spender3)
+          .batchERC20PaymentsWithReference(
+            token1Address,
+            [payee1, payee2, payee3],
+            [5, 30, 400],
+            [referenceExample1, referenceExample2, referenceExample3],
+            [1, 2, 3],
+            feeAddress,
+          ),
+      ).revertedWith('revert transferFromWithReference failed');
+    });
+
+    it('Should revert batch if not enough funds to pay the batch fee', async function () {
+      await expect(
+        batch.connect(spender3).batchERC20PaymentsWithReference(
+          token1Address,
+          [payee1, payee2],
+          [5, 131], // 131 = (await token1.balanceOf(spender3Address)).sub(5+1+2)
+          [referenceExample1, referenceExample2],
+          [1, 2],
+          feeAddress,
+        ),
+      ).revertedWith('revert');
+    });
+
+    it('Should revert batch without approval', async function () {
+      await expect(
+        batch
+          .connect(spender2)
+          .batchERC20PaymentsWithReference(
+            token1Address,
+            [payee1, payee2, payee3],
+            [20, 30, 40],
+            [referenceExample1, referenceExample2, referenceExample3],
+            [1, 2, 3],
+            feeAddress,
+          ),
+      ).revertedWith('revert transferFromWithReference failed');
+    });
+
+    it('Should revert batch multi tokens if not enough funds', async function () {
+      await expect(
+        batch
+          .connect(spender3)
+          .batchERC20PaymentsMultiTokensWithReference(
+            [token1Address, token1Address, token1Address],
+            [payee1, payee2, payee3],
+            [5, 30, 400],
+            [referenceExample1, referenceExample2, referenceExample3],
+            [1, 2, 3],
+            feeAddress,
+          ),
+      ).revertedWith('revert transferFromWithReference failed');
+    });
+
+    it('Should revert batch multi tokens if not enough funds to pay the batch fee', async function () {
+      await expect(
+        batch.connect(spender3).batchERC20PaymentsMultiTokensWithReference(
+          [token1Address, token1Address, token1Address],
+          [payee1, payee2, payee2],
+          [5, 30, 75], // 75 = (await token1.balanceOf(spender3Address)).sub(5+1+30+2+3)
+          [referenceExample1, referenceExample2, referenceExample3],
+          [1, 2, 3],
+          feeAddress,
+        ),
+      ).revertedWith('revert');
+    });
+
+    it('Should revert batch multi tokens without approval', async function () {
+      await expect(
+        batch
+          .connect(spender2)
+          .batchERC20PaymentsMultiTokensWithReference(
+            [token1Address, token1Address, token1Address],
+            [payee1, payee2, payee3],
+            [20, 30, 40],
+            [referenceExample1, referenceExample2, referenceExample3],
+            [1, 2, 3],
+            feeAddress,
+          ),
+      ).revertedWith('revert transferFromWithReference failed');
+    });
+
+    it('Should revert batch multi tokens if input s arrays do not have same size', async function () {
+      await expect(
+        batch
+          .connect(spender3)
+          .batchERC20PaymentsMultiTokensWithReference(
+            [token1Address, token1Address],
+            [payee1, payee2, payee3],
+            [5, 30, 40],
+            [referenceExample1, referenceExample2, referenceExample3],
+            [1, 2, 3],
+            feeAddress,
+          ),
+      ).revertedWith('the input arrays must have the same length');
+
+      await expect(
+        batch
+          .connect(spender3)
+          .batchERC20PaymentsMultiTokensWithReference(
+            [token1Address, token1Address, token1Address],
+            [payee1, payee2],
+            [5, 30, 40],
+            [referenceExample1, referenceExample2, referenceExample3],
+            [1, 2, 3],
+            feeAddress,
+          ),
+      ).revertedWith('the input arrays must have the same length');
+
+      await expect(
+        batch
+          .connect(spender3)
+          .batchERC20PaymentsMultiTokensWithReference(
+            [token1Address, token1Address, token1Address],
+            [payee1, payee2, payee3],
+            [5, 30],
+            [referenceExample1, referenceExample2, referenceExample3],
+            [1, 2, 3],
+            feeAddress,
+          ),
+      ).revertedWith('the input arrays must have the same length');
+
+      await expect(
+        batch
+          .connect(spender3)
+          .batchERC20PaymentsMultiTokensWithReference(
+            [token1Address, token1Address, token1Address],
+            [payee1, payee2, payee3],
+            [5, 30, 40],
+            [referenceExample1, referenceExample2],
+            [1, 2, 3],
+            feeAddress,
+          ),
+      ).revertedWith('the input arrays must have the same length');
+
+      await expect(
+        batch
+          .connect(spender3)
+          .batchERC20PaymentsMultiTokensWithReference(
+            [token1Address, token1Address, token1Address],
+            [payee1, payee2, payee3],
+            [5, 30, 40],
+            [referenceExample1, referenceExample2, referenceExample3],
+            [1, 2],
+            feeAddress,
+          ),
+      ).revertedWith('the input arrays must have the same length');
+    });
+
+    it('Should revert batch if input s arrays do not have same size', async function () {
+      await expect(
+        batch
+          .connect(spender3)
+          .batchERC20PaymentsWithReference(
+            token1Address,
+            [payee1, payee2, payee3],
+            [5, 30, 40],
+            [referenceExample1, referenceExample2, referenceExample3],
+            [1, 2],
+            feeAddress,
+          ),
+      ).revertedWith('the input arrays must have the same length');
+
+      await expect(
+        batch
+          .connect(spender3)
+          .batchERC20PaymentsWithReference(
+            token1Address,
+            [payee1, payee2],
+            [5, 30, 40],
+            [referenceExample1, referenceExample2, referenceExample3],
+            [1, 2, 3],
+            feeAddress,
+          ),
+      ).revertedWith('the input arrays must have the same length');
+
+      await expect(
+        batch
+          .connect(spender3)
+          .batchERC20PaymentsWithReference(
+            token1Address,
+            [payee1, payee2, payee3],
+            [5, 30],
+            [referenceExample1, referenceExample2, referenceExample3],
+            [1, 2, 3],
+            feeAddress,
+          ),
+      ).revertedWith('the input arrays must have the same length');
+
+      await expect(
+        batch
+          .connect(spender3)
+          .batchERC20PaymentsWithReference(
+            token1Address,
+            [payee1, payee2, payee3],
+            [5, 30, 40],
+            [referenceExample1, referenceExample2],
+            [1, 2, 3],
+            feeAddress,
+          ),
+      ).revertedWith('the input arrays must have the same length');
+    });
+  });
+});
+
+// Allow to create easly BatchPayments input, especially for gas optimization
+const getBatchPaymentsInputs = function (
+  nbTxs: number,
+  tokenAddress: string,
+  recipient: string,
+  amount: number,
+  referenceExample1: string,
+  feeAmount: number,
+): [Array<string>, Array<string>, Array<number>, Array<string>, Array<number>] {
+  let tokenAddresses = [];
+  let recipients = [];
+  let amounts = [];
+  let paymentReferences = [];
+  let feeAmounts = [];
+
+  for (let i = 0; i < nbTxs; i++) {
+    tokenAddresses.push(tokenAddress);
+    recipients.push(recipient);
+    amounts.push(amount);
+    paymentReferences.push(referenceExample1);
+    feeAmounts.push(feeAmount);
+  }
+  return [tokenAddresses, recipients, amounts, paymentReferences, feeAmounts];
+};

--- a/packages/smart-contracts/test/contracts/BatchEthPayments.test.ts
+++ b/packages/smart-contracts/test/contracts/BatchEthPayments.test.ts
@@ -1,0 +1,326 @@
+import { ethers, network } from 'hardhat';
+import { BigNumber, Signer } from 'ethers';
+import { expect, use } from 'chai';
+import { solidity } from 'ethereum-waffle';
+import { EthereumFeeProxy, BatchPayments } from '../../src/types';
+import { batchPaymentsArtifact } from '../../src/lib';
+
+import { ethereumFeeProxyArtifact } from '../../src/lib';
+import { HttpNetworkConfig } from 'hardhat/types';
+
+use(solidity);
+
+const logGasInfos = false;
+
+describe('contract: BatchPayments: Ethereum', () => {
+  let payee1: string;
+  let payee2: string;
+  let feeAddress: string;
+  let batchAddress: string;
+
+  let owner: Signer;
+  let payee1Sig: Signer;
+
+  let beforeEthBalance1: BigNumber;
+  let beforeEthBalance2: BigNumber;
+  let afterEthBalance1: BigNumber;
+  let afterEthBalance2: BigNumber;
+
+  const referenceExample1 = '0xaaaa';
+  const referenceExample2 = '0xbbbb';
+
+  let ethFeeProxy: EthereumFeeProxy;
+  let batch: BatchPayments;
+  const networkConfig = network.config as HttpNetworkConfig;
+  const provider = new ethers.providers.JsonRpcProvider(networkConfig.url);
+
+  before(async () => {
+    [, payee1, payee2, feeAddress] = (await ethers.getSigners()).map((s) => s.address);
+    [owner, payee1Sig] = await ethers.getSigners();
+
+    ethFeeProxy = ethereumFeeProxyArtifact.connect(network.name, owner);
+    batch = batchPaymentsArtifact.connect(network.name, owner);
+    batchAddress = batch.address;
+    await batch.connect(owner).setBatchFee(10);
+  });
+
+  describe('Batch Eth normal flow', () => {
+    it('Should pay 2 payments and contract do not keep funds of ethers', async function () {
+      beforeEthBalance1 = await provider.getBalance(payee1);
+      beforeEthBalance2 = await provider.getBalance(payee2);
+
+      await expect(
+        batch
+          .connect(owner)
+          .batchEthPaymentsWithReference(
+            [payee1, payee2],
+            [200, 300],
+            [referenceExample1, referenceExample2],
+            [10, 20],
+            feeAddress,
+            {
+              value: BigNumber.from('1000'),
+            },
+          ),
+      )
+        .to.emit(ethFeeProxy, 'TransferWithReferenceAndFee')
+        .withArgs(payee1, '200', ethers.utils.keccak256(referenceExample1), '10', feeAddress)
+        .to.emit(ethFeeProxy, 'TransferWithReferenceAndFee')
+        .withArgs(payee2, '300', ethers.utils.keccak256(referenceExample2), '20', feeAddress);
+
+      afterEthBalance1 = await provider.getBalance(payee1);
+      expect(afterEthBalance1).to.be.equal(beforeEthBalance1.add(200));
+
+      afterEthBalance2 = await provider.getBalance(payee2);
+      expect(afterEthBalance2).to.be.equal(beforeEthBalance2.add(300));
+
+      expect(await provider.getBalance(batchAddress)).to.be.equal(0);
+    });
+
+    it('Should pay 2 payments with the exact amount', async function () {
+      beforeEthBalance1 = await provider.getBalance(payee1);
+      beforeEthBalance2 = await provider.getBalance(payee2);
+
+      const totalAmout = BigNumber.from('535'); // amount: 500, fee: 10+20, batchFee: 2+3
+
+      const tx = await batch
+        .connect(owner)
+        .batchEthPaymentsWithReference(
+          [payee1, payee2],
+          [200, 300],
+          [referenceExample1, referenceExample2],
+          [10, 20],
+          feeAddress,
+          {
+            value: totalAmout,
+          },
+        );
+      await tx.wait();
+
+      afterEthBalance1 = await provider.getBalance(payee1);
+      expect(afterEthBalance1).to.be.equal(beforeEthBalance1.add(200));
+
+      afterEthBalance2 = await provider.getBalance(payee2);
+      expect(afterEthBalance2).to.be.equal(beforeEthBalance2.add(300));
+
+      expect(await provider.getBalance(batchAddress)).to.be.equal(0);
+    });
+
+    it('Should pay 10 Ethereum payments', async function () {
+      beforeEthBalance2 = await provider.getBalance(payee2);
+
+      const amount = 2;
+      const feeAmount = 1;
+      const nbTxs = 10; // to compare gas optim, go to 100.
+      const [_, recipients, amounts, paymentReferences, feeAmounts] = getBatchPaymentsInputs(
+        nbTxs,
+        '_noTokenAddress',
+        payee2,
+        amount,
+        referenceExample1,
+        feeAmount,
+      );
+      const totalAmount = BigNumber.from(((amount + feeAmount) * nbTxs).toString());
+
+      const tx = await batch
+        .connect(owner)
+        .batchEthPaymentsWithReference(
+          recipients,
+          amounts,
+          paymentReferences,
+          feeAmounts,
+          feeAddress,
+          {
+            value: totalAmount,
+          },
+        );
+
+      const receipt = await tx.wait();
+      if (logGasInfos) {
+        console.log(`nbTxs= ${nbTxs}, gas consumption: `, receipt.gasUsed.toString());
+      }
+
+      afterEthBalance2 = await provider.getBalance(payee2);
+      expect(afterEthBalance2).to.be.equal(beforeEthBalance2.add(amount * nbTxs));
+
+      expect(await provider.getBalance(batchAddress)).to.be.equal(0);
+    });
+  });
+
+  describe('Batch revert, issues with: args, or funds, or approval', () => {
+    it('Should revert batch if not enough funds', async function () {
+      beforeEthBalance1 = await provider.getBalance(payee1);
+      beforeEthBalance2 = await provider.getBalance(payee2);
+
+      const totalAmout = BigNumber.from('400');
+
+      await expect(
+        batch
+          .connect(owner)
+          .batchEthPaymentsWithReference(
+            [payee1, payee2],
+            [200, 300],
+            [referenceExample1, referenceExample2],
+            [10, 20],
+            feeAddress,
+            {
+              value: totalAmout,
+            },
+          ),
+      ).revertedWith('not enough funds');
+
+      afterEthBalance1 = await provider.getBalance(payee1);
+      expect(afterEthBalance1).to.be.equal(beforeEthBalance1);
+
+      afterEthBalance2 = await provider.getBalance(payee2);
+      expect(afterEthBalance2).to.be.equal(beforeEthBalance2);
+
+      expect(await provider.getBalance(batchAddress)).to.be.equal(0);
+    });
+
+    it('Should revert batch if not enough funds for the batch fee', async function () {
+      beforeEthBalance1 = await provider.getBalance(payee1);
+      beforeEthBalance2 = await provider.getBalance(payee2);
+
+      const totalAmout = BigNumber.from('530'); // missing 5 (= (200+300) * 1%)
+
+      await expect(
+        batch
+          .connect(owner)
+          .batchEthPaymentsWithReference(
+            [payee1, payee2],
+            [200, 300],
+            [referenceExample1, referenceExample2],
+            [10, 20],
+            feeAddress,
+            {
+              value: totalAmout,
+            },
+          ),
+      ).revertedWith('not enough funds');
+
+      afterEthBalance1 = await provider.getBalance(payee1);
+      expect(afterEthBalance1).to.be.equal(beforeEthBalance1);
+
+      afterEthBalance2 = await provider.getBalance(payee2);
+      expect(afterEthBalance2).to.be.equal(beforeEthBalance2);
+
+      expect(await provider.getBalance(batchAddress)).to.be.equal(0);
+    });
+
+    it('Should revert batch if input s arrays do not have same size', async function () {
+      await expect(
+        batch
+          .connect(owner)
+          .batchEthPaymentsWithReference(
+            [payee1, payee2],
+            [5, 30],
+            [referenceExample1, referenceExample2],
+            [1],
+            feeAddress,
+          ),
+      ).revertedWith('the input arrays must have the same length');
+
+      await expect(
+        batch
+          .connect(owner)
+          .batchEthPaymentsWithReference(
+            [payee1],
+            [5, 30],
+            [referenceExample1, referenceExample2],
+            [1, 2],
+            feeAddress,
+          ),
+      ).revertedWith('the input arrays must have the same length');
+
+      await expect(
+        batch
+          .connect(owner)
+          .batchEthPaymentsWithReference(
+            [payee1, payee2],
+            [5],
+            [referenceExample1, referenceExample2],
+            [1, 2],
+            feeAddress,
+          ),
+      ).revertedWith('the input arrays must have the same length');
+
+      await expect(
+        batch
+          .connect(owner)
+          .batchEthPaymentsWithReference(
+            [payee1, payee2],
+            [5, 30],
+            [referenceExample1],
+            [1, 2],
+            feeAddress,
+          ),
+      ).revertedWith('the input arrays must have the same length');
+
+      expect(await provider.getBalance(batchAddress)).to.be.equal(0);
+    });
+  });
+
+  describe('Function allowed only to the owner', () => {
+    it('Should allow the owner to update batchFee', async function () {
+      const beforeBatchFee = await batch.batchFee.call({ from: owner });
+      let tx = await batch.connect(owner).setBatchFee(beforeBatchFee.add(10));
+      await tx.wait();
+      const afterBatchFee = await batch.batchFee.call({ from: owner });
+      expect(afterBatchFee).to.be.equal(beforeBatchFee.add(10));
+    });
+
+    it('Should applied the new batchFee', async function () {
+      // check if batch fee applied are the one updated
+      const beforeFeeAddress = await provider.getBalance(feeAddress);
+
+      const tx = await batch
+        .connect(owner)
+        .batchEthPaymentsWithReference(
+          [payee1, payee2],
+          [200, 300],
+          [referenceExample1, referenceExample2],
+          [10, 20],
+          feeAddress,
+          {
+            value: BigNumber.from('1000'),
+          },
+        );
+      await tx.wait();
+
+      const afterFeeAddress = await provider.getBalance(feeAddress);
+      expect(afterFeeAddress).to.be.equal(beforeFeeAddress.add(10 + 20 + (4 + 6))); // fee: (10+20), batch fee: (4+6)
+    });
+
+    it('Should revert if it is not the owner that try to update batchFee', async function () {
+      await expect(batch.connect(payee1Sig).setBatchFee(30)).revertedWith(
+        'revert Ownable: caller is not the owner',
+      );
+    });
+  });
+});
+
+// Allow to create easly BatchPayments input, especially for gas optimization.
+const getBatchPaymentsInputs = function (
+  nbTxs: number,
+  tokenAddress: string,
+  recipient: string,
+  amount: number,
+  referenceExample1: string,
+  feeAmount: number,
+): [Array<string>, Array<string>, Array<number>, Array<string>, Array<number>] {
+  let tokenAddresses = [];
+  let recipients = [];
+  let amounts = [];
+  let paymentReferences = [];
+  let feeAmounts = [];
+
+  for (let i = 0; i < nbTxs; i++) {
+    tokenAddresses.push(tokenAddress);
+    recipients.push(recipient);
+    amounts.push(amount);
+    paymentReferences.push(referenceExample1);
+    feeAmounts.push(feeAmount);
+  }
+  return [tokenAddresses, recipients, amounts, paymentReferences, feeAmounts];
+};


### PR DESCRIPTION
## Description of the changes
Add BatchPayment smart contract and tests, to do batch payments with ERC20 tokens and Ethers, with multiple recipients addresses, and possibly multiple tokens in a batch.

Main functions:
- batchEthPaymentsWithReference
- batchERC20PaymentsWithReference
- batchERC20PaymentsMultiTokensWithReference

The owner of the contract manages:
- feeBatch: between 0 and 1000, initialized at 0. 
                    ex: batchFee = 10 is equivalent to 1.0% of batch fee
- ERC20FeeProxy address
- EthereumFeeProxy address