### PR TITLE
chore: apply lint-staged on every file types

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,4 @@
 {
-  "*.[jt]s": ["eslint --fix --quiet", "prettier --write"]
+  "*.[jt]s": ["eslint --fix --quiet", "prettier --write"],
+  "!(*.[jt]s)": ["prettier --write"]
 }


### PR DESCRIPTION
## Description of the changes

Now that we apply `prettier` on every file, we need to apply `lint-staged` on every file types too, so that `husky` could work properly.