### PR TITLE
feat: deployments on bsc aggregator

### DIFF
--- a/packages/currency/src/chainlink-path-aggregators.ts
+++ b/packages/currency/src/chainlink-path-aggregators.ts
@@ -23,6 +23,7 @@ export const chainlinkCurrencyPairs: Record<string, CurrencyPairs> = {
   'arbitrum-one': {},
   xdai: {},
   avalanche: {},
+  bsc: {},
 };
 
 export const chainlinkSupportedNetworks = Object.keys(chainlinkCurrencyPairs);

--- a/packages/currency/src/erc20/networks/bsc.ts
+++ b/packages/currency/src/erc20/networks/bsc.ts
@@ -7,4 +7,9 @@ export const supportedBSCERC20: TokenMap = {
     symbol: 'DAI',
     decimals: 18,
   },
+  '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56': {
+    name: 'Binance-Peg BUSD Token',
+    symbol: 'BUSD',
+    decimals: 18,
+  },
 };

--- a/packages/smart-contracts/hardhat.config.ts
+++ b/packages/smart-contracts/hardhat.config.ts
@@ -14,6 +14,7 @@ import { HardhatRuntimeEnvironmentExtended } from './scripts-create2/types';
 import { computeCreate2DeploymentAddressesFromList } from './scripts-create2/compute-one-address';
 import { VerifyCreate2FromList } from './scripts-create2/verify-one';
 import { deployWithCreate2FromList } from './scripts-create2/deploy-one';
+import { erc20ConversionProxy } from './src/lib';
 
 config();
 
@@ -54,7 +55,7 @@ export default {
   networks: {
     private: {
       url: 'http://127.0.0.1:8545',
-      accounts: undefined,
+      accounts,
     },
     mainnet: {
       url: process.env.WEB3_PROVIDER_URL || 'https://mainnet.infura.io/v3/YOUR_API_KEY',
@@ -181,6 +182,27 @@ task(
     await hre.run(DEPLOYER_KEY_GUARD);
     await deployAllPaymentContracts(args, hre as HardhatRuntimeEnvironmentExtended);
   });
+
+task('info', 'TODO remove').setAction(async (_args, hre) => {
+  const [deployer] = await hre.ethers.getSigners();
+  const contract = new hre.ethers.Contract(
+    '0xA5186dec7dC1ec85B42A3cd2Dc8289e248530B07',
+    erc20ConversionProxy.getContractAbi(),
+    deployer,
+  );
+  let filter = contract.filters.WhitelistAdminAdded();
+  contract.on(filter, (account) => {
+    console.log(`acct: ${account}`);
+  });
+});
+
+task('topup', 'TODO remove').setAction(async (_args, hre) => {
+  const [payer] = await hre.ethers.getSigners();
+  const deployer = '0x42479654251c6d2561dcf352d4eb39f9c4a45ccd';
+  console.log((await payer.getBalance()).toString());
+  await payer.sendTransaction({ to: deployer, value: hre.ethers.utils.parseEther('1') });
+  console.log((await payer.getBalance()).toString());
+});
 
 task(
   'prepare-live-payments',

--- a/packages/smart-contracts/hardhat.config.ts
+++ b/packages/smart-contracts/hardhat.config.ts
@@ -14,7 +14,6 @@ import { HardhatRuntimeEnvironmentExtended } from './scripts-create2/types';
 import { computeCreate2DeploymentAddressesFromList } from './scripts-create2/compute-one-address';
 import { VerifyCreate2FromList } from './scripts-create2/verify-one';
 import { deployWithCreate2FromList } from './scripts-create2/deploy-one';
-import { erc20ConversionProxy } from './src/lib';
 
 config();
 
@@ -55,7 +54,7 @@ export default {
   networks: {
     private: {
       url: 'http://127.0.0.1:8545',
-      accounts,
+      accounts: undefined,
     },
     mainnet: {
       url: process.env.WEB3_PROVIDER_URL || 'https://mainnet.infura.io/v3/YOUR_API_KEY',
@@ -182,27 +181,6 @@ task(
     await hre.run(DEPLOYER_KEY_GUARD);
     await deployAllPaymentContracts(args, hre as HardhatRuntimeEnvironmentExtended);
   });
-
-task('info', 'TODO remove').setAction(async (_args, hre) => {
-  const [deployer] = await hre.ethers.getSigners();
-  const contract = new hre.ethers.Contract(
-    '0xA5186dec7dC1ec85B42A3cd2Dc8289e248530B07',
-    erc20ConversionProxy.getContractAbi(),
-    deployer,
-  );
-  let filter = contract.filters.WhitelistAdminAdded();
-  contract.on(filter, (account) => {
-    console.log(`acct: ${account}`);
-  });
-});
-
-task('topup', 'TODO remove').setAction(async (_args, hre) => {
-  const [payer] = await hre.ethers.getSigners();
-  const deployer = '0x42479654251c6d2561dcf352d4eb39f9c4a45ccd';
-  console.log((await payer.getBalance()).toString());
-  await payer.sendTransaction({ to: deployer, value: hre.ethers.utils.parseEther('1') });
-  console.log((await payer.getBalance()).toString());
-});
 
 task(
   'prepare-live-payments',

--- a/packages/smart-contracts/scripts/utils.ts
+++ b/packages/smart-contracts/scripts/utils.ts
@@ -11,6 +11,7 @@ export const uniswapV2RouterAddresses: Record<string, string> = {
   kovan: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D',
   private: '0x4E72770760c011647D4873f60A3CF6cDeA896CD8',
   bsctest: '0x10ED43C718714eb63d5aA57B78B54704E256024E',
+  bsc: '0x10ED43C718714eb63d5aA57B78B54704E256024E',
   xdai: '0x1C232F01118CB8B424793ae03F870aa7D0ac7f77',
   // https://layer3.gitbook.io/spirit-swap/contracts
   fantom: '0x16327e3fbdaca3bcf7e38f5af2599d2ddc33ae52',

--- a/packages/smart-contracts/src/lib/artifacts/ERC20SwapToPay/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/ERC20SwapToPay/index.ts
@@ -38,6 +38,10 @@ export const erc20SwapToPayArtifact = new ContractArtifact<ERC20SwapToPay>(
           address: '0x1B5077Ca852d39CDDeDaF45FAF1235841854420b',
           creationBlockNumber: 7408086,
         },
+        bsc: {
+          address: '0x75740D9b5cA3BCCb356CA7f0D0dB71aBE427a835',
+          creationBlockNumber: 16165020,
+        },
         bsctest: {
           address: '0x75740D9b5cA3BCCb356CA7f0D0dB71aBE427a835',
           creationBlockNumber: 12759707,

--- a/packages/smart-contracts/src/lib/artifacts/Erc20SwapConversion/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/Erc20SwapConversion/index.ts
@@ -17,6 +17,10 @@ export const erc20SwapConversionArtifact = new ContractArtifact<ERC20SwapToConve
           address: '0x1d6B06C6f7adFd9314BD4C58a6D306261113a1D4',
           creationBlockNumber: 9447192,
         },
+        bsc: {
+          address: '0x1d6B06C6f7adFd9314BD4C58a6D306261113a1D4',
+          creationBlockNumber: 16165023,
+        },
         bsctest: {
           address: '0x1d6B06C6f7adFd9314BD4C58a6D306261113a1D4',
           creationBlockNumber: 12759710,

--- a/packages/smart-contracts/src/lib/artifacts/EthConversionProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/EthConversionProxy/index.ts
@@ -71,6 +71,10 @@ export const ethConversionArtifact = new ContractArtifact<EthConversionProxy>(
           address: '0x7Ebf48a26253810629C191b56C3212Fd0D211c26',
           creationBlockNumber: 11969006,
         },
+        bsc: {
+          address: '0x7Ebf48a26253810629C191b56C3212Fd0D211c26',
+          creationBlockNumber: 16170265,
+        },
       },
     },
   },

--- a/packages/smart-contracts/src/lib/artifacts/EthereumFeeProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/EthereumFeeProxy/index.ts
@@ -45,6 +45,10 @@ export const ethereumFeeProxyArtifact = new ContractArtifact<EthereumFeeProxy>(
           address: '0xC6E23a20C0a1933ACC8E30247B5D1e2215796C1F',
           creationBlockNumber: 11671666,
         },
+        bsc: {
+          address: '0xC6E23a20C0a1933ACC8E30247B5D1e2215796C1F',
+          creationBlockNumber: 16165026,
+        },
       },
     },
     '0.2.0': {

--- a/packages/toolbox/README.md
+++ b/packages/toolbox/README.md
@@ -35,7 +35,7 @@ yarn run:create 12
 
 #### Adding & removing aggregators
 
-The following command guides you in detecting missing aggregators.
+The following command guides you in adding missing aggregators.
 
 ```bash
 yarn request-toolbox addAggregators mainnet --privateKey $PRIVATE_KEY --dryRun

--- a/packages/toolbox/README.md
+++ b/packages/toolbox/README.md
@@ -42,6 +42,7 @@ yarn request-toolbox addAggregators mainnet --privateKey $PRIVATE_KEY --dryRun
 ```
 
 It will suggest pairs of currencies:
+
 - With a Chainlink price feed oracle (according to [a cached JSON](https://cl-docs-addresses.web.app/addresses.json]))
 - If they exist in Currency Manager (cf. [../currency/src/erc20/networks]())
 - If they are not already added to the Chainlink Aggregation Path contract, as reported by the Price Aggregators subgraph ([Example for BSC](https://thegraph.com/hosted-service/subgraph/requestnetwork/price-aggregators-bsc))

--- a/packages/toolbox/README.md
+++ b/packages/toolbox/README.md
@@ -35,21 +35,24 @@ yarn run:create 12
 
 #### Adding & removing aggregators
 
-The following commands can add and remove aggregators
-
-- `addAggregators` will fetch available aggregators from Chainlink and interactively prompt for selection
-- `addAggregator` can be used if you have all information about an aggregator you want to add
-- `removeAggregator` will set the given currency pair to the 0x00[...]00 address.
-
-Example usage:
+The following command guides you in detecting missing aggregators.
 
 ```bash
 yarn request-toolbox addAggregators mainnet --privateKey $PRIVATE_KEY --dryRun
 ```
 
-Use `--help` for details about each command.
+It will suggest pairs of currencies:
+- With a Chainlink price feed oracle (according to [a cached JSON](https://cl-docs-addresses.web.app/addresses.json]))
+- If they exist in Currency Manager (cf. [../currency/src/erc20/networks]())
+- If they are not already added to the Chainlink Aggregation Path contract, as reported by the Price Aggregators subgraph ([Example for BSC](https://thegraph.com/hosted-service/subgraph/requestnetwork/price-aggregators-bsc))
 
-Additionally, the command `listMissingAggregators` will display missing aggregators for all networks.
+The following commands are also available:
+
+- `yarn cli addAggregator` can be used if you have all information about an aggregator you want to add
+- `yarn cli removeAggregator` will set the given currency pair to the 0x00[...]00 address.
+- `yarn cli listMissingAggregators <name>` (where `name` is a valid Request Finance currency list, [https://api.request.network/currency/list/name]() should be valid) will display missing aggregators for that list on all networks.
+
+Use `--help` for details about each command.
 
 #### Updating conversion paths
 

--- a/packages/toolbox/src/commands/chainlink/addAggregators.ts
+++ b/packages/toolbox/src/commands/chainlink/addAggregators.ts
@@ -2,6 +2,7 @@ import * as yargs from 'yargs';
 import inquirer from 'inquirer';
 import { runUpdate } from './contractUtils';
 import { Aggregator, getAvailableAggregators, getCurrencyManager } from './aggregatorsUtils';
+import { conversionSupportedNetworks } from '@requestnetwork/currency';
 
 type Options = {
   dryRun: boolean;
@@ -71,6 +72,13 @@ export const handler = async (args: Options): Promise<void> => {
   const pairs = pair?.map((x) => x.toLowerCase().trim());
 
   const currencyManager = await getCurrencyManager(args.list);
+
+  if (!conversionSupportedNetworks.includes(network)) {
+    console.warn(
+      `WARNING: ${network} is missing in chainlinkSupportedNetworks from the Currency package.`,
+      `Add '${network}: {}' to chainlinkCurrencyPairs, in currency/src/chainlink-path-aggregators.ts.`,
+    );
+  }
 
   const availableAggregators = await getAvailableAggregators(
     network,

--- a/packages/toolbox/src/commands/chainlink/aggregatorsUtils.ts
+++ b/packages/toolbox/src/commands/chainlink/aggregatorsUtils.ts
@@ -32,6 +32,7 @@ const feedMap: Record<string, [chainKey: string, networkName: string]> = {
   fantom: ['fantom-price-feeds', 'Fantom Mainnet'],
   matic: ['matic-addresses', 'Polygon Mainnet'],
   xdai: ['data-feeds-gnosis-chain', 'Gnosis Chain Mainnet'],
+  bsc: ['bnb-chain-addresses-price', 'BNB Chain Testnet'],
 };
 
 export const getAvailableAggregators = async (

--- a/packages/toolbox/src/commands/chainlink/aggregatorsUtils.ts
+++ b/packages/toolbox/src/commands/chainlink/aggregatorsUtils.ts
@@ -32,7 +32,7 @@ const feedMap: Record<string, [chainKey: string, networkName: string]> = {
   fantom: ['fantom-price-feeds', 'Fantom Mainnet'],
   matic: ['matic-addresses', 'Polygon Mainnet'],
   xdai: ['data-feeds-gnosis-chain', 'Gnosis Chain Mainnet'],
-  bsc: ['bnb-chain-addresses-price', 'BNB Chain Testnet'],
+  bsc: ['bnb-chain-addresses-price', 'BNB Chain Mainnet'],
 };
 
 export const getAvailableAggregators = async (
@@ -58,8 +58,8 @@ export const getAvailableAggregators = async (
   const missingAggregators: Aggregator[] = [];
   for (const proxy of proxies) {
     const [from, to] = proxy.pair.split(' / ');
-    const fromCurrency = cm.from(from);
-    const toCurrency = cm.from(to);
+    const fromCurrency = cm.from(from, network);
+    const toCurrency = cm.from(to, network);
     if (pairs && !pairs.includes(`${from}-${to}`.toLowerCase())) {
       continue;
     }


### PR DESCRIPTION
## Description of the changes
fix: `toolbox` addAggregators was missing some currencies with equivalent on mainnet
depl: BSC deployments of `EthConversion`, `EthFeeProxy` (0.1.0), `Erc20SwapToPay` and `Erc20SwapWithConversion`
chore: `toolbox` clarified the documentation for addAggregators