### PR TITLE
feat: retrieve active escrow data

### DIFF
--- a/packages/payment-detection/src/erc20/escrow-info-retriever.ts
+++ b/packages/payment-detection/src/erc20/escrow-info-retriever.ts
@@ -6,14 +6,6 @@ import { IEventRetriever } from '../types';
 import { getDefaultProvider } from '../provider';
 import { parseLogArgs } from '../utils';
 
-// The ERC20 escrow smart contract ABI fragment containing escrow specific events.
-// const erc20EscrowContractAbiFragment = [
-//   'event RequestFrozen(bytes indexed paymentReference)',
-//   'event InitiatedEmergencyClaim(bytes indexed paymentReference)',
-//   'event RevertedEmergencyClaim(bytes indexed paymentReference)',
-//   'event TransferWithReferenceAndFee(address tokenAddress, address to,uint256 amount,bytes indexed paymentReference,uint256 feeAmount,address feeAddress)',
-// ];
-
 /** Escrow contract event arguments. */
 type EscrowArgs = {
   paymentReference: string;

--- a/packages/payment-detection/src/erc20/escrow-info-retriever.ts
+++ b/packages/payment-detection/src/erc20/escrow-info-retriever.ts
@@ -1,5 +1,5 @@
 import { PaymentTypes } from '@requestnetwork/types';
-
+import { erc20EscrowToPayArtifact } from '@requestnetwork/smart-contracts';
 import { BigNumber, ethers } from 'ethers';
 import { IEventRetriever } from '../types';
 
@@ -7,12 +7,12 @@ import { getDefaultProvider } from '../provider';
 import { parseLogArgs } from '../utils';
 
 // The ERC20 escrow smart contract ABI fragment containing escrow specific events.
-const erc20EscrowContractAbiFragment = [
-  'event RequestFrozen(bytes indexed paymentReference)',
-  'event InitiatedEmergencyClaim(bytes indexed paymentReference)',
-  'event RevertedEmergencyClaim(bytes indexed paymentReference)',
-  'event TransferWithReferenceAndFee(address tokenAddress, address to,uint256 amount,bytes indexed paymentReference,uint256 feeAmount,address feeAddress)',
-];
+// const erc20EscrowContractAbiFragment = [
+//   'event RequestFrozen(bytes indexed paymentReference)',
+//   'event InitiatedEmergencyClaim(bytes indexed paymentReference)',
+//   'event RevertedEmergencyClaim(bytes indexed paymentReference)',
+//   'event TransferWithReferenceAndFee(address tokenAddress, address to,uint256 amount,bytes indexed paymentReference,uint256 feeAmount,address feeAddress)',
+// ];
 
 /** Escrow contract event arguments. */
 type EscrowArgs = {
@@ -64,7 +64,7 @@ export class EscrowERC20InfoRetriever
     // Setup the ERC20 escrow contract interface.
     this.contractEscrow = new ethers.Contract(
       this.escrowContractAddress,
-      erc20EscrowContractAbiFragment,
+      erc20EscrowToPayArtifact.getContractAbi(),
       this.provider,
     );
   }
@@ -182,5 +182,12 @@ export class EscrowERC20InfoRetriever
       }));
 
     return Promise.all(eventPromises);
+  }
+
+  /**
+   * Retrieves current escrow data from requestMapping in the Escrow smart contract
+   */
+  public async getEscrowRequestMapping(): Promise<PaymentTypes.EscrowChainData> {
+    return this.contractEscrow.requestMapping(`0x${this.paymentReference}`);
   }
 }

--- a/packages/payment-detection/src/index.ts
+++ b/packages/payment-detection/src/index.ts
@@ -17,6 +17,7 @@ import {
 import { NearNativeTokenPaymentDetector } from './near-detector';
 import { FeeReferenceBasedDetector } from './fee-reference-based-detector';
 import { SuperFluidPaymentDetector } from './erc777/superfluid-detector';
+import { EscrowERC20InfoRetriever } from './erc20/escrow-info-retriever';
 
 export type { TheGraphClient } from './thegraph';
 
@@ -43,4 +44,5 @@ export {
   padAmountForChainlink,
   unpadAmountFromChainlink,
   calculateEscrowState,
+  EscrowERC20InfoRetriever,
 };

--- a/packages/payment-detection/test/erc20/escrow-info-retriever.test.ts
+++ b/packages/payment-detection/test/erc20/escrow-info-retriever.test.ts
@@ -140,4 +140,28 @@ describe('api/erc20/escrow-info-retriever', () => {
       expect(getLogsSpy).toHaveBeenCalledTimes(3);
     });
   });
+  describe('test on rinkeby', () => {
+    let infoRetriever: EscrowERC20InfoRetriever;
+    beforeAll(() => {
+      infoRetriever = new EscrowERC20InfoRetriever(
+        paymentReferenceMock,
+        '0x8230e703B1c4467A4543422b2cC3284133B9AB5e',
+        0,
+        '',
+        '',
+        'rinkeby',
+      );
+    });
+    it('should get escrow chain data', async () => {
+      const escrowChainData = await infoRetriever.getEscrowRequestMapping();
+      expect(escrowChainData.tokenAddress).toEqual('0x745861AeD1EEe363b4AaA5F1994Be40b1e05Ff90');
+      expect(escrowChainData.payee).toEqual('0xB9B7e0cb2EDF5Ea031C8B297A5A1Fa20379b6A0a');
+      expect(escrowChainData.payer).toEqual('0x0c051a1f4E209b00c8E7C00AD0ce79B3630a7401');
+      expect(escrowChainData.amount.toString()).toEqual('123000000000000000000');
+      expect(escrowChainData.unlockDate.toString()).toEqual('1670505020');
+      expect(escrowChainData.emergencyClaimDate.toString()).toEqual('0');
+      expect(escrowChainData.emergencyState).toEqual(false);
+      expect(escrowChainData.isFrozen).toEqual(true);
+    });
+  });
 });

--- a/packages/request-client.js/src/api/request.ts
+++ b/packages/request-client.js/src/api/request.ts
@@ -1,12 +1,16 @@
 import { EventEmitter } from 'events';
 
-import { DeclarativePaymentDetector } from '@requestnetwork/payment-detection';
+import {
+  DeclarativePaymentDetector,
+  EscrowERC20InfoRetriever,
+} from '@requestnetwork/payment-detection';
 import { IdentityTypes, PaymentTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { ICurrencyManager } from '@requestnetwork/currency';
 import Utils from '@requestnetwork/utils';
 import * as Types from '../types';
 import ContentDataExtension from './content-data-extension';
 import localUtils from './utils';
+import { erc20EscrowToPayArtifact } from '@requestnetwork/smart-contracts';
 
 /**
  * Class representing a request.
@@ -643,6 +647,22 @@ export default class Request {
       meta: this.requestMeta,
       pending,
     });
+  }
+
+  public async getEscrowData(
+    paymentReference: string,
+    network: string,
+  ): Promise<PaymentTypes.EscrowChainData> {
+    const escrowContractAddress = erc20EscrowToPayArtifact.getAddress(network);
+    const escrowInfoRetriever = new EscrowERC20InfoRetriever(
+      paymentReference,
+      escrowContractAddress,
+      0,
+      '',
+      '',
+      network,
+    );
+    return await escrowInfoRetriever.getEscrowRequestMapping();
   }
 
   /**

--- a/packages/request-client.js/test/api/request.test.ts
+++ b/packages/request-client.js/test/api/request.test.ts
@@ -2,6 +2,7 @@ import { CurrencyManager } from '@requestnetwork/currency';
 import { IdentityTypes, PaymentTypes, RequestLogicTypes } from '@requestnetwork/types';
 
 import { EventEmitter } from 'events';
+import { PaymentReferenceCalculator } from '@requestnetwork/payment-detection';
 
 import Request from '../../src/api/request';
 
@@ -530,6 +531,21 @@ describe('api/request', () => {
       await request.refresh();
 
       expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe('Gets escrow chain data', () => {
+    it('fetches escrow onchain data from the smart contract', async () => {
+      const request = new Request('1', mockRequestLogic, currencyManager);
+      const reference = PaymentReferenceCalculator.calculate(
+        '01227296c706fa0a188d685b13d7aa0db970b06fcea2c01169739131d48e09bd6b',
+        '410abec1ce481357',
+        '0x5000EE9FB9c96A2A09D8efB695aC21D6C429fF11',
+      );
+      const escrowChainData = await request.getEscrowData(reference, 'rinkeby');
+      expect(escrowChainData.payee).toEqual('0x5000EE9FB9c96A2A09D8efB695aC21D6C429fF11');
+      expect(escrowChainData.payer).toEqual('0x5000EE9FB9c96A2A09D8efB695aC21D6C429fF11');
+      expect(escrowChainData.tokenAddress).toEqual('0xFab46E002BbF0b4509813474841E0716E6730136');
+      expect(escrowChainData.amount.toString()).toEqual('2300000000000000000');
     });
   });
 });

--- a/packages/types/src/payment-types.ts
+++ b/packages/types/src/payment-types.ts
@@ -264,6 +264,19 @@ export interface IEscrowParameters {
 /** Represents the current state of an escrow instance */
 export type EscrowData = IEscrowParameters;
 
+export interface IEscrowChainData {
+  tokenAddress: string;
+  payee: string;
+  payer: string;
+  amount: number;
+  unlockDate: number;
+  emergencyClaimDate: number;
+  emergencyState: boolean;
+  isFrozen: boolean;
+}
+/** Represents the escrow data stored onchain */
+export type EscrowChainData = IEscrowChainData;
+
 /** escrow payment network event */
 export interface IPaymentNetworkEscrowEvent<TEventParameters, TEventNames = EVENTS_NAMES>
   extends IPaymentNetworkBaseEvent<TEventNames> {


### PR DESCRIPTION
This ads a method for reading data from the Escrow smart contract directly to the EscrowInfoRetriever.
We need to read data from a mapping in the Escrow contract to be able to figure out some deadlines when freezing funds etc.
This data is not broadcasted in any events so the only way to get it is from the contract directly.

This new function is exposed to 3rd party users via request-client.js, within the Request class.