### PR TITLE
chore: apply lint-staged on every file types

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,4 @@
 {
-  "*.[jt]s": ["eslint --fix --quiet", "prettier --write"]
+  "*.[jt]s": ["eslint --fix --quiet", "prettier --write"],
+  "!(*.[jt]s)": ["prettier --write --ignore-unknown"]
 }


### PR DESCRIPTION
## Description of the changes

This is a follow-up to https://github.com/RequestNetwork/requestNetwork/pull/812, which has been rolled-back since.