### PR TITLE
fix: add ERC777 support to getHash

### DIFF
--- a/packages/currency/src/getHash.ts
+++ b/packages/currency/src/getHash.ts
@@ -2,7 +2,8 @@ import { RequestLogicTypes } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 
 export const getHash = (curr: RequestLogicTypes.ICurrency): string => {
-  return curr.type === RequestLogicTypes.CURRENCY.ERC20
+  return curr.type === RequestLogicTypes.CURRENCY.ERC20 ||
+    curr.type === RequestLogicTypes.CURRENCY.ERC777
     ? curr.value
     : Utils.crypto.last20bytesOfNormalizedKeccak256Hash({
         type: curr.type,


### PR DESCRIPTION
## Description of the changes
add missing support of ERC777 currency type in the getHash function even if it's not needed yet because hash is well precised for fDAIX-rinkeby