### PR TITLE
test(ipfs-storage): increase timeout for bad DNS resolution

### DIFF
--- a/packages/ethereum-storage/test/ipfs-storage.test.ts
+++ b/packages/ethereum-storage/test/ipfs-storage.test.ts
@@ -12,7 +12,7 @@ const invalidHostIpfsGatewayConnection: StorageTypes.IIpfsGatewayConnection = {
   host: 'nonexistent',
   port: 5001,
   protocol: StorageTypes.IpfsGatewayProtocol.HTTP,
-  timeout: 1000,
+  timeout: 10000,
 };
 
 const hash1 = 'QmNXA5DyFZkdf4XkUT81nmJSo3nS2bL25x7YepxeoDa6tY';


### PR DESCRIPTION
## Description of the changes

Non-existent DNS resolution can take more than 1s, cf https://app.circleci.com/pipelines/github/RequestNetwork/requestNetwork/6191/workflows/5ea87810-802d-4050-a4b4-3b9424785d71/jobs/102393