### PR TITLE
feat: escrow deployment info

### DIFF
--- a/packages/payment-detection/src/erc20/escrow-info-retriever.ts
+++ b/packages/payment-detection/src/erc20/escrow-info-retriever.ts
@@ -4,7 +4,12 @@ import { BigNumber, ethers } from 'ethers';
 import { IEventRetriever } from '../types';
 
 import { getDefaultProvider } from '../provider';
-import { parseLogArgs } from '../utils';
+import { makeGetDeploymentInformation, parseLogArgs } from '../utils';
+
+const ESCROW_CONTRACT_ADDRESS_MAP = {
+  ['0.1.0']: '0.1.0',
+  ['0.2.0']: '0.1.0',
+};
 
 /** Escrow contract event arguments. */
 type EscrowArgs = {
@@ -28,8 +33,7 @@ export class EscrowERC20InfoRetriever
     IEventRetriever<
       PaymentTypes.IPaymentNetworkBaseEvent<PaymentTypes.ESCROW_EVENTS_NAMES>,
       PaymentTypes.ESCROW_EVENTS_NAMES
-    >
-{
+    > {
   public contractEscrow: ethers.Contract;
   public provider: ethers.providers.Provider;
 
@@ -183,4 +187,9 @@ export class EscrowERC20InfoRetriever
   public async getEscrowRequestMapping(): Promise<PaymentTypes.EscrowChainData> {
     return this.contractEscrow.requestMapping(`0x${this.paymentReference}`);
   }
+
+  public static getEscrowDeploymentInformation = makeGetDeploymentInformation(
+    erc20EscrowToPayArtifact,
+    ESCROW_CONTRACT_ADDRESS_MAP,
+  );
 }

--- a/packages/payment-detection/src/erc20/escrow-info-retriever.ts
+++ b/packages/payment-detection/src/erc20/escrow-info-retriever.ts
@@ -33,7 +33,8 @@ export class EscrowERC20InfoRetriever
     IEventRetriever<
       PaymentTypes.IPaymentNetworkBaseEvent<PaymentTypes.ESCROW_EVENTS_NAMES>,
       PaymentTypes.ESCROW_EVENTS_NAMES
-    > {
+    >
+{
   public contractEscrow: ethers.Contract;
   public provider: ethers.providers.Provider;
 

--- a/packages/payment-processor/src/index.ts
+++ b/packages/payment-processor/src/index.ts
@@ -19,6 +19,7 @@ export * from './payment/any-to-eth-proxy';
 export * from './payment/encoder-payment';
 export * from './payment/encoder-approval';
 export * as Escrow from './payment/erc20-escrow-payment';
+export * from './payment/prepared-transaction';
 import * as utils from './payment/utils';
 
 export { utils };

--- a/packages/payment-processor/src/payment/erc20-escrow-payment.ts
+++ b/packages/payment-processor/src/payment/erc20-escrow-payment.ts
@@ -245,19 +245,31 @@ export function encodePayEscrow(
 }
 
 /**
- * Returns the encoded data to freezeRequest().
- * @param request request to pay.
+ * Encapsulates the validation, paymentReference calculation and escrow contract interface creation.
+ * These steps are used in all subsequent functions encoding escrow interaction transactions
+ * @param request Request data
+ * @returns {erc20EscrowToPayContract, paymentReference}
  */
-export function encodeFreezeRequest(request: ClientTypes.IRequestData): string {
+function prepareForEncoding(request: ClientTypes.IRequestData) {
   validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
 
   // collects the parameters to be used from the request
   const { paymentReference } = getRequestPaymentValues(request);
 
-  // interface of the escrow contract
+  // connections to the escrow contract
   const erc20EscrowToPayContract = ERC20EscrowToPay__factory.createInterface();
+  return {
+    erc20EscrowToPayContract,
+    paymentReference,
+  };
+}
 
-  // encodes the function data and returns them
+/**
+ * Returns the encoded data to freezeRequest().
+ * @param request request to pay.
+ */
+export function encodeFreezeRequest(request: ClientTypes.IRequestData): string {
+  const { erc20EscrowToPayContract, paymentReference } = prepareForEncoding(request);
   return erc20EscrowToPayContract.encodeFunctionData('freezeRequest', [`0x${paymentReference}`]);
 }
 
@@ -266,15 +278,7 @@ export function encodeFreezeRequest(request: ClientTypes.IRequestData): string {
  * @param request request for pay
  */
 export function encodePayRequestFromEscrow(request: ClientTypes.IRequestData): string {
-  validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
-
-  // collects the parameters to be used from the request
-  const { paymentReference } = getRequestPaymentValues(request);
-
-  // connections to the escrow contract
-  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.createInterface();
-
-  // encodes the function data and returns them
+  const { erc20EscrowToPayContract, paymentReference } = prepareForEncoding(request);
   return erc20EscrowToPayContract.encodeFunctionData('payRequestFromEscrow', [
     `0x${paymentReference}`,
   ]);
@@ -285,15 +289,7 @@ export function encodePayRequestFromEscrow(request: ClientTypes.IRequestData): s
  * @param request request to pay.
  */
 export function encodeInitiateEmergencyClaim(request: ClientTypes.IRequestData): string {
-  validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
-
-  // collects the parameters to be used from the request
-  const { paymentReference } = getRequestPaymentValues(request);
-
-  // connections to the escrow contract
-  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.createInterface();
-
-  // encodes the function data and returns them
+  const { erc20EscrowToPayContract, paymentReference } = prepareForEncoding(request);
   return erc20EscrowToPayContract.encodeFunctionData('initiateEmergencyClaim', [
     `0x${paymentReference}`,
   ]);
@@ -304,15 +300,7 @@ export function encodeInitiateEmergencyClaim(request: ClientTypes.IRequestData):
  * @param request request to pay.
  */
 export function encodeCompleteEmergencyClaim(request: ClientTypes.IRequestData): string {
-  validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
-
-  // collects the parameters to be used from the request
-  const { paymentReference } = getRequestPaymentValues(request);
-
-  // connections to the escrow contract
-  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.createInterface();
-
-  // encodes the function data and returns them
+  const { erc20EscrowToPayContract, paymentReference } = prepareForEncoding(request);
   return erc20EscrowToPayContract.encodeFunctionData('completeEmergencyClaim', [
     `0x${paymentReference}`,
   ]);
@@ -323,15 +311,7 @@ export function encodeCompleteEmergencyClaim(request: ClientTypes.IRequestData):
  * @param request request to pay.
  */
 export function encodeRevertEmergencyClaim(request: ClientTypes.IRequestData): string {
-  validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
-
-  // collects the parameters to be used from the request
-  const { paymentReference } = getRequestPaymentValues(request);
-
-  // connections to the escrow contract
-  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.createInterface();
-
-  // encodes the function data and returns them
+  const { erc20EscrowToPayContract, paymentReference } = prepareForEncoding(request);
   return erc20EscrowToPayContract.encodeFunctionData('revertEmergencyClaim', [
     `0x${paymentReference}`,
   ]);
@@ -342,15 +322,7 @@ export function encodeRevertEmergencyClaim(request: ClientTypes.IRequestData): s
  * @param request request to pay.
  */
 export function encodeRefundFrozenFunds(request: ClientTypes.IRequestData): string {
-  validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
-
-  // collects the parameters to be used from the request
-  const { paymentReference } = getRequestPaymentValues(request);
-
-  // connections to the escrow contract
-  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.createInterface();
-
-  // encodes the function data and returns them
+  const { erc20EscrowToPayContract, paymentReference } = prepareForEncoding(request);
   return erc20EscrowToPayContract.encodeFunctionData('refundFrozenFunds', [
     `0x${paymentReference}`,
   ]);

--- a/packages/payment-processor/src/payment/erc20-escrow-payment.ts
+++ b/packages/payment-processor/src/payment/erc20-escrow-payment.ts
@@ -54,7 +54,7 @@ export async function payEscrow(
   feeAmount?: BigNumberish,
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {
-  const encodedTx = encodePayEscrow(request, signerOrProvider, amount, feeAmount);
+  const encodedTx = encodePayEscrow(request, amount, feeAmount);
   const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
   const signer = getSigner(signerOrProvider);
 
@@ -78,7 +78,7 @@ export async function freezeRequest(
   signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {
-  const encodedTx = encodeFreezeRequest(request, signerOrProvider);
+  const encodedTx = encodeFreezeRequest(request);
   const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
 
   const signer = getSigner(signerOrProvider);
@@ -102,7 +102,7 @@ export async function payRequestFromEscrow(
   signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {
-  const encodedTx = encodePayRequestFromEscrow(request, signerOrProvider);
+  const encodedTx = encodePayRequestFromEscrow(request);
   const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
 
   const signer = getSigner(signerOrProvider);
@@ -126,7 +126,7 @@ export async function initiateEmergencyClaim(
   signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {
-  const encodedTx = encodeInitiateEmergencyClaim(request, signerOrProvider);
+  const encodedTx = encodeInitiateEmergencyClaim(request);
   const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
 
   const signer = getSigner(signerOrProvider);
@@ -150,7 +150,7 @@ export async function completeEmergencyClaim(
   signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {
-  const encodedTx = encodeCompleteEmergencyClaim(request, signerOrProvider);
+  const encodedTx = encodeCompleteEmergencyClaim(request);
   const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
 
   const signer = getSigner(signerOrProvider);
@@ -174,7 +174,7 @@ export async function revertEmergencyClaim(
   signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {
-  const encodedTx = encodeRevertEmergencyClaim(request, signerOrProvider);
+  const encodedTx = encodeRevertEmergencyClaim(request);
   const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
 
   const signer = getSigner(signerOrProvider);
@@ -198,7 +198,7 @@ export async function refundFrozenFunds(
   signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   overrides?: ITransactionOverrides,
 ): Promise<ContractTransaction> {
-  const encodedTx = encodeRefundFrozenFunds(request, signerOrProvider);
+  const encodedTx = encodeRefundFrozenFunds(request);
   const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
 
   const signer = getSigner(signerOrProvider);
@@ -219,26 +219,23 @@ export async function refundFrozenFunds(
  */
 export function encodePayEscrow(
   request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
   amount?: BigNumberish,
   feeAmountOverride?: BigNumberish,
 ): string {
   validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
-  const signer = getSigner(signerOrProvider);
-
   const tokenAddress = request.currencyInfo.value;
-  const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
 
   // collects the parameters to be used, from the request
-  const { paymentReference, paymentAddress, feeAmount, feeAddress } =
-    getRequestPaymentValues(request);
+  const { paymentReference, paymentAddress, feeAmount, feeAddress } = getRequestPaymentValues(
+    request,
+  );
 
   const amountToPay = getAmountToPay(request, amount);
   const feeToPay = BigNumber.from(feeAmountOverride || feeAmount || 0);
 
-  const erc20EscrowContract = ERC20EscrowToPay__factory.connect(contractAddress, signer);
+  const erc20EscrowContract = ERC20EscrowToPay__factory.createInterface();
 
-  return erc20EscrowContract.interface.encodeFunctionData('payEscrow', [
+  return erc20EscrowContract.encodeFunctionData('payEscrow', [
     tokenAddress,
     paymentAddress,
     amountToPay,
@@ -251,49 +248,35 @@ export function encodePayEscrow(
 /**
  * Returns the encoded data to freezeRequest().
  * @param request request to pay.
- * @param signerOrProvider the Web3 provider, or signer. Defaults to window.ethereum.
  */
-export function encodeFreezeRequest(
-  request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
-): string {
+export function encodeFreezeRequest(request: ClientTypes.IRequestData): string {
   validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
-  const signer = getSigner(signerOrProvider);
 
   // collects the parameters to be used from the request
   const { paymentReference } = getRequestPaymentValues(request);
 
-  // connections to the escrow contract
-  const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
-  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.connect(contractAddress, signer);
+  // interface of the escrow contract
+  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.createInterface();
 
   // encodes the function data and returns them
-  return erc20EscrowToPayContract.interface.encodeFunctionData('freezeRequest', [
-    `0x${paymentReference}`,
-  ]);
+  return erc20EscrowToPayContract.encodeFunctionData('freezeRequest', [`0x${paymentReference}`]);
 }
 
 /**
  * Returns the encoded data to payRequestFromEscrow().
  * @param request request for pay
- * @param signerOrProvider the Web3 provider, or signer. Defaults to window.ethereum.
  */
-export function encodePayRequestFromEscrow(
-  request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
-): string {
+export function encodePayRequestFromEscrow(request: ClientTypes.IRequestData): string {
   validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
-  const signer = getSigner(signerOrProvider);
 
   // collects the parameters to be used from the request
   const { paymentReference } = getRequestPaymentValues(request);
 
   // connections to the escrow contract
-  const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
-  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.connect(contractAddress, signer);
+  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.createInterface();
 
   // encodes the function data and returns them
-  return erc20EscrowToPayContract.interface.encodeFunctionData('payRequestFromEscrow', [
+  return erc20EscrowToPayContract.encodeFunctionData('payRequestFromEscrow', [
     `0x${paymentReference}`,
   ]);
 }
@@ -301,24 +284,18 @@ export function encodePayRequestFromEscrow(
 /**
  * Returns the encoded data to initiateEmergencyClaim().
  * @param request request to pay.
- * @param signerOrProvider the Web3 provider, or signer. Defaults to window.ethereum.
  */
-export function encodeInitiateEmergencyClaim(
-  request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
-): string {
+export function encodeInitiateEmergencyClaim(request: ClientTypes.IRequestData): string {
   validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
-  const signer = getSigner(signerOrProvider);
 
   // collects the parameters to be used from the request
   const { paymentReference } = getRequestPaymentValues(request);
 
   // connections to the escrow contract
-  const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
-  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.connect(contractAddress, signer);
+  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.createInterface();
 
   // encodes the function data and returns them
-  return erc20EscrowToPayContract.interface.encodeFunctionData('initiateEmergencyClaim', [
+  return erc20EscrowToPayContract.encodeFunctionData('initiateEmergencyClaim', [
     `0x${paymentReference}`,
   ]);
 }
@@ -326,24 +303,18 @@ export function encodeInitiateEmergencyClaim(
 /**
  * Returns the encoded data to completeEmergencyClaim().
  * @param request request to pay.
- * @param signerOrProvider the Web3 provider, or signer. Defaults to window.ethereum.
  */
-export function encodeCompleteEmergencyClaim(
-  request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
-): string {
+export function encodeCompleteEmergencyClaim(request: ClientTypes.IRequestData): string {
   validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
-  const signer = getSigner(signerOrProvider);
 
   // collects the parameters to be used from the request
   const { paymentReference } = getRequestPaymentValues(request);
 
   // connections to the escrow contract
-  const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
-  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.connect(contractAddress, signer);
+  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.createInterface();
 
   // encodes the function data and returns them
-  return erc20EscrowToPayContract.interface.encodeFunctionData('completeEmergencyClaim', [
+  return erc20EscrowToPayContract.encodeFunctionData('completeEmergencyClaim', [
     `0x${paymentReference}`,
   ]);
 }
@@ -351,24 +322,18 @@ export function encodeCompleteEmergencyClaim(
 /**
  * Returns the encoded data to revertEmergencyClaim().
  * @param request request to pay.
- * @param signerOrProvider the Web3 provider, or signer. Defaults to window.ethereum.
  */
-export function encodeRevertEmergencyClaim(
-  request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
-): string {
+export function encodeRevertEmergencyClaim(request: ClientTypes.IRequestData): string {
   validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
-  const signer = getSigner(signerOrProvider);
 
   // collects the parameters to be used from the request
   const { paymentReference } = getRequestPaymentValues(request);
 
   // connections to the escrow contract
-  const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
-  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.connect(contractAddress, signer);
+  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.createInterface();
 
   // encodes the function data and returns them
-  return erc20EscrowToPayContract.interface.encodeFunctionData('revertEmergencyClaim', [
+  return erc20EscrowToPayContract.encodeFunctionData('revertEmergencyClaim', [
     `0x${paymentReference}`,
   ]);
 }
@@ -376,24 +341,18 @@ export function encodeRevertEmergencyClaim(
 /**
  * Returns the encoded data to refundFrozenFunds().
  * @param request request to pay.
- * @param signerOrProvider the Web3 provider, or signer. Defaults to window.ethereum.
  */
-export function encodeRefundFrozenFunds(
-  request: ClientTypes.IRequestData,
-  signerOrProvider: providers.Web3Provider | Signer = getProvider(),
-): string {
+export function encodeRefundFrozenFunds(request: ClientTypes.IRequestData): string {
   validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
-  const signer = getSigner(signerOrProvider);
 
   // collects the parameters to be used from the request
   const { paymentReference } = getRequestPaymentValues(request);
 
   // connections to the escrow contract
-  const contractAddress = erc20EscrowToPayArtifact.getAddress(request.currencyInfo.network!);
-  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.connect(contractAddress, signer);
+  const erc20EscrowToPayContract = ERC20EscrowToPay__factory.createInterface();
 
   // encodes the function data and returns them
-  return erc20EscrowToPayContract.interface.encodeFunctionData('refundFrozenFunds', [
+  return erc20EscrowToPayContract.encodeFunctionData('refundFrozenFunds', [
     `0x${paymentReference}`,
   ]);
 }

--- a/packages/payment-processor/src/payment/erc20-escrow-payment.ts
+++ b/packages/payment-processor/src/payment/erc20-escrow-payment.ts
@@ -226,9 +226,8 @@ export function encodePayEscrow(
   const tokenAddress = request.currencyInfo.value;
 
   // collects the parameters to be used, from the request
-  const { paymentReference, paymentAddress, feeAmount, feeAddress } = getRequestPaymentValues(
-    request,
-  );
+  const { paymentReference, paymentAddress, feeAmount, feeAddress } =
+    getRequestPaymentValues(request);
 
   const amountToPay = getAmountToPay(request, amount);
   const feeToPay = BigNumber.from(feeAmountOverride || feeAmount || 0);

--- a/packages/payment-processor/test/payment/erc20-escrow-payment.test.ts
+++ b/packages/payment-processor/test/payment/erc20-escrow-payment.test.ts
@@ -138,37 +138,37 @@ describe('erc20-escrow-payment tests:', () => {
     const values = getRequestPaymentValues(validRequest);
 
     it('Should encode data to execute payEscrow().', () => {
-      expect(Escrow.encodePayEscrow(validRequest, wallet)).toBe(
+      expect(Escrow.encodePayEscrow(validRequest)).toBe(
         `0x325a00f00000000000000000000000009fbda871d559710256a2502a2517b794b482db40000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b732000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c5fdf4076b8f3a5357c5e395ab970b5b54098fef0000000000000000000000000000000000000000000000000000000000000008${values.paymentReference}000000000000000000000000000000000000000000000000`,
       );
     });
     it('Should encode data to execute payRequestFromEscrow().', () => {
-      expect(Escrow.encodePayRequestFromEscrow(validRequest, wallet)).toBe(
+      expect(Escrow.encodePayRequestFromEscrow(validRequest)).toBe(
         `0x2a16f4c300000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000008${values.paymentReference}000000000000000000000000000000000000000000000000`,
       );
     });
     it('Should encode data to execute freezeRequest().', () => {
-      expect(Escrow.encodeFreezeRequest(validRequest, wallet)).toBe(
+      expect(Escrow.encodeFreezeRequest(validRequest)).toBe(
         `0x82865e9d00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000008${values.paymentReference}000000000000000000000000000000000000000000000000`,
       );
     });
     it('Should encode data to execute initiateEmergencyClaim().', () => {
-      expect(Escrow.encodeInitiateEmergencyClaim(validRequest, wallet)).toBe(
+      expect(Escrow.encodeInitiateEmergencyClaim(validRequest)).toBe(
         `0x3a322d4500000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000008${values.paymentReference}000000000000000000000000000000000000000000000000`,
       );
     });
     it('Should encode data to execute completeEmergencyClaim().', () => {
-      expect(Escrow.encodeCompleteEmergencyClaim(validRequest, wallet)).toBe(
+      expect(Escrow.encodeCompleteEmergencyClaim(validRequest)).toBe(
         `0x6662e1e000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000008${values.paymentReference}000000000000000000000000000000000000000000000000`,
       );
     });
     it('Should encode data to execute revertEmergencyClaim().', () => {
-      expect(Escrow.encodeRevertEmergencyClaim(validRequest, wallet)).toBe(
+      expect(Escrow.encodeRevertEmergencyClaim(validRequest)).toBe(
         `0x0797560800000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000008${values.paymentReference}000000000000000000000000000000000000000000000000`,
       );
     });
     it('Should encode data to execute refundFrozenFunds().', () => {
-      expect(Escrow.encodeRefundFrozenFunds(validRequest, wallet)).toBe(
+      expect(Escrow.encodeRefundFrozenFunds(validRequest)).toBe(
         `0x1a77f53a00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000008${values.paymentReference}000000000000000000000000000000000000000000000000`,
       );
     });


### PR DESCRIPTION
## Description of the changes
1. Exposing function for getting escrow contract deployment info. This was missing because Escrow is not a PN yet and has no separate PaymentDetector.
2. Exposing IPreparedTransaction to be used in Portal transaction builder.
3. Removed unnecessary requirement for provider in Escrow transaction encoding functions.