### PR TITLE
fix: escrow ci deployment

### DIFF
--- a/packages/smart-contracts/scripts/deploy-payments.ts
+++ b/packages/smart-contracts/scripts/deploy-payments.ts
@@ -297,14 +297,14 @@ export async function deployAllPaymentContracts(
 
     /*
      * Batch 6
-     *   - 5.a ERC20EscrowToPay
+     *   - 6.a ERC20EscrowToPay
+     *   - 6.b ERC20EscrowToPay.transferOwnership
      */
     const runDeploymentBatch_6 = async (erc20FeeProxyAddress: string) => {
-      // todo calculate
       const NONCE_BATCH_6 = 20;
       await jumpToNonce(args, hre, NONCE_BATCH_6);
 
-      // 5.a ERC20EscrowToPay(
+      // 6.a ERC20EscrowToPay(
       const erc20EscrowResult = await deployERC20EscrowToPay(
         {
           ...args,
@@ -315,7 +315,7 @@ export async function deployAllPaymentContracts(
       );
       addToResult(erc20EscrowResult);
 
-      // 5.b ERC20EscrowToPay.transferOwnership
+      // 6.b ERC20EscrowToPay.transferOwnership
       if (await nonceReady(NONCE_BATCH_6 + 1)) {
         if (erc20EscrowResult) {
           if (!process.env.ADMIN_WALLET_ADDRESS) {

--- a/packages/smart-contracts/scripts/escrow-proxy.ts
+++ b/packages/smart-contracts/scripts/escrow-proxy.ts
@@ -1,0 +1,33 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+// eslint-disable-next-line
+// @ts-ignore Cannot find module
+import { Erc20ConversionProxy } from '../src/types/Erc20ConversionProxy';
+import { erc20EscrowToPayArtifact } from '../src/lib';
+import { deployOne } from './deploy-one';
+
+export async function deployERC20EscrowToPay(
+  args: {
+    erc20FeeProxyAddress?: string;
+    nonceCondition?: number;
+    version?: string;
+  },
+  hre: HardhatRuntimeEnvironment,
+) {
+  const contractName = 'ERC20EscrowToPay';
+
+  if (!args.erc20FeeProxyAddress) {
+    // FIXME: should try to retrieve information from artifacts instead
+    console.error(`Missing ERC20FeeProxy on ${hre.network.name}, cannot deploy ${contractName}.`);
+    return undefined;
+  }
+
+  return deployOne<Erc20ConversionProxy>(args, hre, contractName, {
+    constructorArguments: [
+      args.erc20FeeProxyAddress,
+      process.env.ADMIN_WALLET_ADDRESS ?? (await (await hre.ethers.getSigners())[0].getAddress()),
+    ],
+    artifact: erc20EscrowToPayArtifact,
+    nonceCondition: args.nonceCondition,
+    version: args.version || '0.1.0',
+  });
+}

--- a/packages/smart-contracts/scripts/test-deploy-all.ts
+++ b/packages/smart-contracts/scripts/test-deploy-all.ts
@@ -11,7 +11,7 @@ export default async function deploy(_args: any, hre: HardhatRuntimeEnvironment)
   await deployRequest(_args, hre);
   const mainPaymentAddresses = await deployPayment(_args, hre);
   await deployConversion(_args, hre, mainPaymentAddresses);
-  await deployEscrow(hre);
+  await deployEscrow(hre, mainPaymentAddresses);
   await deployBatchPayment(_args, hre);
   await deploySuperFluid(hre);
 }

--- a/packages/smart-contracts/scripts/test-deploy-escrow-deployment.ts
+++ b/packages/smart-contracts/scripts/test-deploy-escrow-deployment.ts
@@ -4,15 +4,17 @@ import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { deployOne } from '../scripts/deploy-one';
 
 // Deploys, set up the contracts
-export async function deployEscrow(hre: HardhatRuntimeEnvironment): Promise<void> {
-  const erc20FeeProxyAddress = '0x75c35C980C0d37ef46DF04d31A140b65503c0eEd';
+export async function deployEscrow(
+  hre: HardhatRuntimeEnvironment,
+  mainPaymentAddresses: any,
+): Promise<void> {
   let deployer: Signer;
   try {
     [deployer] = await hre.ethers.getSigners();
     const deployerAddress = await deployer.getAddress();
     // Deploy Escrow contract
     const { address: erc20EscrowToPayAddress } = await deployOne({}, hre, 'ERC20EscrowToPay', {
-      constructorArguments: [erc20FeeProxyAddress, deployerAddress],
+      constructorArguments: [mainPaymentAddresses.ERC20FeeProxyAddress, deployerAddress],
     });
 
     // ----------------------------------


### PR DESCRIPTION
## Description of the changes
Was trying to add the Escrow contract to the request-contracts Docker image.
First I created new escrow deployment script that uses the old way for deployment in scripts/deploy-payments.ts
Then it turned out that test-deploy-all should be used, in there I made another fix, removed the hardcoded Erc20FeeProxy and I'm getting it as an argument.