### PR TITLE
fix(ci): rollback ipfs docker image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ references:
   node_image: &node_image
     image: circleci/node:16
   ipfs_image: &ipfs_image
-    image: requestnetwork/request-ipfs
+    image: requestnetwork/request-ipfs:0.4.23-2
   ganache_image: &ganache_image
     image: trufflesuite/ganache-cli:v6.8.2
     command:


### PR DESCRIPTION
## Description of the changes

This PR fixes the version of the [request-ipfs](https://hub.docker.com/r/requestnetwork/request-ipfs/tags?page=1) docker image used in our CI tests. 