### PR TITLE
fix: fill block and txHash parameters in events

### DIFF
--- a/packages/payment-detection/src/erc777/superfluid-retriever.ts
+++ b/packages/payment-detection/src/erc777/superfluid-retriever.ts
@@ -66,8 +66,8 @@ export class SuperFluidInfoRetriever {
         oldFlowRate: streamEvents[streamEvents.length - 1].flowRate,
         flowRate: 0,
         timestamp: Utils.getCurrentTimestampInSecond(),
-        blockNumber: null,
-        transactionHash: null,
+        blockNumber: parseInt(streamEvents[streamEvents.length - 1].blockNumber),
+        transactionHash: streamEvents[streamEvents.length - 1].transactionHash,
       } as FlowUpdatedEvent);
     }
 
@@ -95,7 +95,7 @@ export class SuperFluidInfoRetriever {
         name: this.eventName,
         parameters: {
           to: this.toAddress,
-          block: streamEvents[index].blockNumber,
+          block: parseInt(streamEvents[index].blockNumber),
           txHash: streamEvents[index].transactionHash,
         },
         timestamp: streamEvents[index].timestamp,

--- a/packages/payment-detection/test/erc777/superfluid-retriever.test.ts
+++ b/packages/payment-detection/test/erc777/superfluid-retriever.test.ts
@@ -20,7 +20,7 @@ describe('api/erc777/superfluid-info-retriever', () => {
         salt: '0ee84db293a752c6',
         amount: '92592592592592000',
         requestId: '0188791633ff0ec72a7dbdefb886d2db6cccfa98287320839c2f173c7a4e3ce7e1',
-        block: '9945543',
+        block: 9945543,
         token: '0x745861aed1eee363b4aaa5f1994be40b1e05ff90', //fDAIx
       };
       graphql.request.mockResolvedValue(mockSuperfluidSubgraph[0]);
@@ -64,6 +64,8 @@ describe('api/erc777/superfluid-info-retriever', () => {
         // = (1642693617 - 1642692777 = 840 sec) x (385802469135800 - 3858024691358 = 381944444444442 Wei DAIx / sec)
         requestId: '0288792633ff0ec72a7dbdefb886d2db6cccfa98287320839c2f273c7a4e3ce7e2',
         token: '0x745861aed1eee363b4aaa5f1994be40b1e05ff90', //fDAIx
+        block: 10024811,
+        txHash: '0x0fefa02d90be46eb51a82f02b7a787084c35a895bd833a7c9f0560e315bb4061',
       };
       graphql.request.mockResolvedValue(mockSuperfluidSubgraph[1]);
 
@@ -86,6 +88,8 @@ describe('api/erc777/superfluid-info-retriever', () => {
       expect(transferEvents[0].amount).toEqual(paymentData.amount);
       expect(transferEvents[0].name).toEqual('payment');
       expect(transferEvents[0].parameters?.to).toEqual(paymentData.to);
+      expect(transferEvents[0].parameters?.txHash).toEqual(paymentData.txHash);
+      expect(transferEvents[0].parameters?.block).toEqual(paymentData.block);
     });
   });
 
@@ -101,6 +105,8 @@ describe('api/erc777/superfluid-info-retriever', () => {
         requestId: '0688792633ff0ec72a7dbdefb886d2db6cccfa98287320839c2f273c7a4e3ce7e2',
         token: '0x0f1d7c55a2b133e000ea10eec03c774e0d6796e8', //fUSDCx
         timestamp: 1643041225,
+        block: 10047970,
+        txHash: '0xdb44f35aa1490d2ddc8bbe7b82e0e3a370f3bf171a55da7a8a5886996e9c468d',
       };
       graphql.request.mockResolvedValue(mockSuperfluidSubgraph[2]);
 
@@ -125,6 +131,8 @@ describe('api/erc777/superfluid-info-retriever', () => {
       expect(transferEvents[0].amount).toEqual(timestamp.toString());
       expect(transferEvents[0].name).toEqual('payment');
       expect(transferEvents[0].parameters?.to).toEqual(paymentData.to);
+      expect(transferEvents[0].parameters?.txHash).toEqual(paymentData.txHash);
+      expect(transferEvents[0].parameters?.block).toEqual(paymentData.block);
     });
   });
 });


### PR DESCRIPTION
## Description of the changes
to fix the errors in sync-api due to the lack of block number in the payment detection for SuperFluid payment network.