### PR TITLE
feat: pull gas info field from subgraph

### DIFF
--- a/packages/payment-detection/src/erc20/thegraph-info-retriever.ts
+++ b/packages/payment-detection/src/erc20/thegraph-info-retriever.ts
@@ -47,7 +47,6 @@ export class TheGraphInfoRetriever {
     PaymentTypes.AllNetworkEvents<PaymentTypes.IERC20FeePaymentEventParameters>
   > {
     const variables = this.getGraphVariables();
-    console.log('variables >>> ', variables);
     const paymentsAndEscrows = await this.client.GetPaymentsAndEscrowState(variables);
     const paymentEvents = paymentsAndEscrows.payments.map((p) => ({
       amount: p.amount,
@@ -76,11 +75,6 @@ export class TheGraphInfoRetriever {
       },
       timestamp: p.timestamp,
     }));
-
-    console.log('payload >>> ', {
-      paymentEvents: paymentEvents,
-      escrowEvents: escrowEvents,
-    });
 
     return {
       paymentEvents: paymentEvents,

--- a/packages/payment-detection/src/erc20/thegraph-info-retriever.ts
+++ b/packages/payment-detection/src/erc20/thegraph-info-retriever.ts
@@ -47,6 +47,7 @@ export class TheGraphInfoRetriever {
     PaymentTypes.AllNetworkEvents<PaymentTypes.IERC20FeePaymentEventParameters>
   > {
     const variables = this.getGraphVariables();
+    console.log('variables >>> ', variables);
     const paymentsAndEscrows = await this.client.GetPaymentsAndEscrowState(variables);
     const paymentEvents = paymentsAndEscrows.payments.map((p) => ({
       amount: p.amount,
@@ -57,6 +58,8 @@ export class TheGraphInfoRetriever {
         block: p.block,
         feeAddress: p.feeAddress ? utils.getAddress(p.feeAddress) : undefined,
         feeAmount: p.feeAmount || undefined,
+        gasUsed: p.gasUsed,
+        gasPrice: p.gasPrice,
       },
       timestamp: p.timestamp,
     }));
@@ -68,9 +71,17 @@ export class TheGraphInfoRetriever {
         txHash: p.txHash,
         block: p.block,
         eventName: p.eventName,
+        gasUsed: p.gasUsed,
+        gasPrice: p.gasPrice,
       },
       timestamp: p.timestamp,
     }));
+
+    console.log('payload >>> ', {
+      paymentEvents: paymentEvents,
+      escrowEvents: escrowEvents,
+    });
+
     return {
       paymentEvents: paymentEvents,
       escrowEvents: escrowEvents,

--- a/packages/payment-detection/src/thegraph/queries/GetPaymentsAndEscrowState.graphql
+++ b/packages/payment-detection/src/thegraph/queries/GetPaymentsAndEscrowState.graphql
@@ -20,6 +20,8 @@ query GetPaymentsAndEscrowState(
     feeAmount
     feeAddress
     from
+    gasUsed
+    gasPrice
     timestamp
   }
   escrowEvents(where: { reference: $reference }, orderBy: timestamp, orderDirection: asc) {
@@ -28,5 +30,7 @@ query GetPaymentsAndEscrowState(
     from
     timestamp
     block
+    gasUsed
+    gasPrice
   }
 }

--- a/packages/payment-detection/test/erc20/fee-proxy-contract.test.ts
+++ b/packages/payment-detection/test/erc20/fee-proxy-contract.test.ts
@@ -331,6 +331,31 @@ describe('api/erc20/fee-proxy-contract', () => {
       currencyManager,
     });
 
+    const mockExtractEvents = (eventName: any) => {
+      if (eventName !== 'payment') return Promise.resolve({ paymentEvents: [] });
+
+      return Promise.resolve({
+        paymentEvents: [
+          {
+            amount: '1000000000000000000',
+            name: 'payment',
+            parameters: {
+              to: '0x6d69c636c825263Aa71a3D86D32D0E4897a7a580',
+              txHash: '0xb3355cf69d9ef047b73ca13eb7aeb06ce5e5b8658a1baac9b2bc743190e65fda',
+              block: 10897333,
+              feeAddress: '0x35d0e078755Cd84D3E0656cAaB417Dee1d7939c7',
+              feeAmount: '1000000000000000',
+              gasUsed: '79220',
+              gasPrice: '1500000011',
+            },
+            timestamp: 1655912433,
+          },
+        ],
+        escrowEvents: [],
+      });
+    };
+    jest.spyOn(erc20FeeProxyContract as any, 'extractEvents').mockImplementation(mockExtractEvents);
+
     const balance = await erc20FeeProxyContract.getBalance(mockRequest);
 
     expect(balance.error).toBeUndefined();

--- a/packages/payment-detection/test/erc20/fee-proxy-contract.test.ts
+++ b/packages/payment-detection/test/erc20/fee-proxy-contract.test.ts
@@ -310,7 +310,6 @@ describe('api/erc20/fee-proxy-contract', () => {
           id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT,
           type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
           values: {
-            // refundAddress: '0xrefundAddress',
             feeAddress: '0x35d0e078755Cd84D3E0656cAaB417Dee1d7939c7',
             feeAmount: '1000000000000000',
             paymentAddress: '0x6d69c636c825263Aa71a3D86D32D0E4897a7a580',


### PR DESCRIPTION
## Description of the changes

ticket: https://app.asana.com/0/1187210138355031/1202055267731943/f

- pull `gasUsed` & `gasPrice` field from updated payment subgraph graphql query
- store fields into request object