### PR TITLE
feat: split data-access read and write for TheGraph

### DIFF
--- a/packages/request-client.js/src/api/request.ts
+++ b/packages/request-client.js/src/api/request.ts
@@ -382,7 +382,10 @@ export default class Request {
     }
 
     extensionsData.push(
-      declarativePaymentNetwork.createExtensionsDataForDeclareSentPayment({ amount, note }),
+      declarativePaymentNetwork.createExtensionsDataForDeclareSentPayment({
+        amount,
+        note,
+      }),
     );
 
     const parameters: RequestLogicTypes.IAddExtensionsDataParameters = {

--- a/packages/request-node/src/request/getChannelsByTopic.ts
+++ b/packages/request-node/src/request/getChannelsByTopic.ts
@@ -4,7 +4,7 @@ import { StatusCodes } from 'http-status-codes';
 
 const GET_CHANNELS_TIMEOUT = 600000;
 export default class GetChannelHandler {
-  constructor(private logger: LogTypes.ILogger, private dataAccess: DataAccessTypes.IDataAccess) {
+  constructor(private logger: LogTypes.ILogger, private dataAccess: DataAccessTypes.IDataRead) {
     this.handler = this.handler.bind(this);
   }
 

--- a/packages/request-node/src/request/getTransactionsByChannelId.ts
+++ b/packages/request-node/src/request/getTransactionsByChannelId.ts
@@ -5,7 +5,7 @@ import { StatusCodes } from 'http-status-codes';
 const GET_TRANSACTIONS_TIMEOUT = 600000;
 
 export default class GetTransactionsByChannelIdHandler {
-  constructor(private logger: LogTypes.ILogger, private dataAccess: DataAccessTypes.IDataAccess) {
+  constructor(private logger: LogTypes.ILogger, private dataAccess: DataAccessTypes.IDataRead) {
     this.handler = this.handler.bind(this);
   }
 

--- a/packages/request-node/src/request/persistTransaction.ts
+++ b/packages/request-node/src/request/persistTransaction.ts
@@ -15,7 +15,7 @@ export default class PersistTransactionHandler {
    */
   constructor(
     private confirmedTransactionStore: ConfirmedTransactionStore,
-    private dataAccess: DataAccessTypes.IDataAccess,
+    private dataAccess: DataAccessTypes.IDataWrite,
     private logger: LogTypes.ILogger,
   ) {
     this.handler = this.handler.bind(this);

--- a/packages/request-node/src/thegraph/CombinedDataAccess.ts
+++ b/packages/request-node/src/thegraph/CombinedDataAccess.ts
@@ -1,0 +1,44 @@
+import { DataAccessTypes } from '@requestnetwork/types';
+
+export abstract class CombinedDataAccess implements DataAccessTypes.IDataAccess {
+  constructor(
+    protected reader: DataAccessTypes.IDataRead,
+    protected writer: DataAccessTypes.IDataWrite,
+  ) {
+    this.getTransactionsByChannelId = this.reader.getTransactionsByChannelId.bind(this.reader);
+    this.getChannelsByTopic = this.reader.getChannelsByTopic.bind(this.reader);
+    this.getChannelsByMultipleTopics = this.reader.getChannelsByMultipleTopics.bind(this.reader);
+    this.persistTransaction = this.writer.persistTransaction.bind(this.writer);
+  }
+
+  async initialize(): Promise<void> {
+    await this.reader.initialize();
+    await this.writer.initialize();
+  }
+
+  async close(): Promise<void> {
+    await this.writer.close();
+    await this.reader.close();
+  }
+
+  getTransactionsByChannelId: (
+    channelId: string,
+    updatedBetween?: DataAccessTypes.ITimestampBoundaries | undefined,
+  ) => Promise<DataAccessTypes.IReturnGetTransactions>;
+
+  getChannelsByTopic: (
+    topic: string,
+    updatedBetween?: DataAccessTypes.ITimestampBoundaries | undefined,
+  ) => Promise<DataAccessTypes.IReturnGetChannelsByTopic>;
+  getChannelsByMultipleTopics: (
+    topics: string[],
+    updatedBetween?: DataAccessTypes.ITimestampBoundaries,
+  ) => Promise<DataAccessTypes.IReturnGetChannelsByTopic>;
+  persistTransaction: (
+    transactionData: DataAccessTypes.ITransaction,
+    channelId: string,
+    topics?: string[] | undefined,
+  ) => Promise<DataAccessTypes.IReturnPersistTransaction>;
+
+  abstract _getStatus(): Promise<any>;
+}

--- a/packages/request-node/src/thegraph/PendingStore.ts
+++ b/packages/request-node/src/thegraph/PendingStore.ts
@@ -4,6 +4,10 @@ type PendingItem = {
   transaction: DataAccessTypes.ITransaction;
   storageResult: StorageTypes.IAppendResult;
 };
+/**
+ * A simple in-memory store to share state between DataReader and DataWriter
+ * Useful to retrieve a transaction that was just emitted but is not confirmed yet
+ **/
 export class PendingStore {
   private pending: Record<string, PendingItem> = {};
 

--- a/packages/request-node/src/thegraph/PendingStore.ts
+++ b/packages/request-node/src/thegraph/PendingStore.ts
@@ -1,0 +1,26 @@
+import { DataAccessTypes, StorageTypes } from '@requestnetwork/types';
+
+type PendingItem = {
+  transaction: DataAccessTypes.ITransaction;
+  storageResult: StorageTypes.IAppendResult;
+};
+export class PendingStore {
+  private pending: Record<string, PendingItem> = {};
+
+  /** Gets a pending tx */
+  public get(channelId: string): PendingItem {
+    return this.pending[channelId];
+  }
+
+  public add(
+    channelId: string,
+    transaction: DataAccessTypes.ITransaction,
+    storageResult: StorageTypes.IAppendResult,
+  ): void {
+    this.pending[channelId] = { transaction, storageResult };
+  }
+
+  public remove(channelId: string): void {
+    delete this.pending[channelId];
+  }
+}

--- a/packages/request-node/src/thegraph/TheGraphDataAccess.ts
+++ b/packages/request-node/src/thegraph/TheGraphDataAccess.ts
@@ -317,6 +317,9 @@ export class TheGraphDataAccess extends CombinedDataAccess {
 
   constructor({ graphql, ...options }: TheGraphDataAccessOptions) {
     const { url, ...rest } = graphql;
+    if (!options.pendingStore) {
+      options.pendingStore = new PendingStore();
+    }
     const graphqlClient = new SubgraphClient(url, rest);
     const storage = new TheGraphStorage(options);
     const reader = new TheGraphDataRead(graphqlClient, options);

--- a/packages/request-node/src/thegraph/TheGraphDataAccess.ts
+++ b/packages/request-node/src/thegraph/TheGraphDataAccess.ts
@@ -10,6 +10,8 @@ import { DataAccessTypes, LogTypes, StorageTypes } from '@requestnetwork/types';
 import { Transaction } from './queries';
 import { SubgraphClient } from './subgraphClient';
 import { TheGraphStorage } from './TheGraphStorage';
+import { CombinedDataAccess } from './CombinedDataAccess';
+import { PendingStore } from './PendingStore';
 
 export type TheGraphDataAccessOptions = {
   ipfsStorage: StorageTypes.IIpfsStorage;
@@ -17,6 +19,7 @@ export type TheGraphDataAccessOptions = {
   signer: Signer;
   network: string;
   logger?: LogTypes.ILogger;
+  pendingStore?: PendingStore;
 };
 
 type DataAccessEventEmitter = TypedEmitter<{
@@ -24,49 +27,48 @@ type DataAccessEventEmitter = TypedEmitter<{
   error: (error: unknown) => void;
 }>;
 
-export class TheGraphDataAccess implements DataAccessTypes.IDataAccess {
+const getStorageMeta = (
+  result: Transaction,
+  lastBlockNumber: number,
+  network: string,
+): StorageTypes.IEntryMetadata => {
+  return {
+    ethereum: {
+      blockConfirmation: lastBlockNumber - result.blockNumber,
+      blockNumber: result.blockNumber,
+      blockTimestamp: result.blockTimestamp,
+      networkName: network,
+      smartContractAddress: result.smartContractAddress,
+      transactionHash: result.transactionHash,
+    },
+    ipfs: {
+      size: BigNumber.from(result.size).toNumber(),
+    },
+    state: StorageTypes.ContentState.CONFIRMED,
+    storageType: StorageTypes.StorageSystemType.ETHEREUM_IPFS,
+    timestamp: result.blockTimestamp,
+  };
+};
+
+export class TheGraphDataRead implements DataAccessTypes.IDataRead {
   private network: string;
 
-  private graphql: SubgraphClient;
-  private pending: Record<
-    string,
-    { transaction: DataAccessTypes.ITransaction; storageResult: StorageTypes.IAppendResult }
-  > = {};
-  protected storage: TheGraphStorage;
-  private logger: LogTypes.ILogger;
+  private pendingStore?: PendingStore;
 
-  constructor({ ipfsStorage, network, signer, graphql, logger }: TheGraphDataAccessOptions) {
-    this.logger = logger || new Utils.SimpleLogger();
-    const { url, ...options } = graphql;
-    this.graphql = new SubgraphClient(url, options);
+  constructor(
+    private readonly graphql: SubgraphClient,
+    { network, pendingStore }: Pick<TheGraphDataAccessOptions, 'network' | 'pendingStore'>,
+  ) {
     this.network = network;
-    this.storage = new TheGraphStorage({ network, signer, ipfsStorage, logger: this.logger });
+    this.pendingStore = pendingStore;
   }
 
   async initialize(): Promise<void> {
     await this.graphql.getBlockNumber();
-    await this.storage.initialize();
   }
 
   close(): Promise<void> {
     return Promise.resolve();
-  }
-
-  async persistTransaction(
-    transaction: DataAccessTypes.ITransaction,
-    channelId: string,
-    topics?: string[] | undefined,
-  ): Promise<DataAccessTypes.IReturnPersistTransaction> {
-    const updatedBlock = Block.pushTransaction(
-      Block.createEmptyBlock(),
-      transaction,
-      channelId,
-      topics,
-    );
-
-    const storageResult = await this.storage.append(JSON.stringify(updatedBlock));
-
-    return this.createPersistTransactionResult(channelId, transaction, storageResult, topics || []);
   }
 
   async getTransactionsByChannelId(
@@ -83,7 +85,7 @@ export class TheGraphDataAccess implements DataAccessTypes.IDataAccess {
           .map((x) => x.hash)
           .concat(pending.meta.transactionsStorageLocation),
         storageMeta: result.transactions.map((tx) =>
-          this.getStorageMeta(tx, result._meta.block.number),
+          getStorageMeta(tx, result._meta.block.number, this.network),
         ),
       },
       result: {
@@ -120,7 +122,7 @@ export class TheGraphDataAccess implements DataAccessTypes.IDataAccess {
     return {
       meta: {
         storageMeta: filteredTxs.reduce((acc, tx) => {
-          acc[tx.channelId] = [this.getStorageMeta(tx, result._meta.block.number)];
+          acc[tx.channelId] = [getStorageMeta(tx, result._meta.block.number, this.network)];
           return acc;
         }, {} as Record<string, StorageTypes.IEntryMetadata[]>),
         transactionsStorageLocation: filteredTxs.reduce((prev, curr) => {
@@ -143,26 +145,6 @@ export class TheGraphDataAccess implements DataAccessTypes.IDataAccess {
     };
   }
 
-  async _getStatus(): Promise<any> {
-    return {
-      lastBlock: await this.graphql.getBlockNumber(),
-      endpoint: this.graphql.endpoint,
-      storage: await this.storage._getStatus(),
-    };
-  }
-
-  private addPending(
-    channelId: string,
-    transaction: DataAccessTypes.ITransaction,
-    storageResult: StorageTypes.IAppendResult,
-  ) {
-    this.pending[channelId] = { transaction, storageResult };
-  }
-
-  private deletePending(channelId: string) {
-    delete this.pending[channelId];
-  }
-
   private async getPending(channelId: string): Promise<DataAccessTypes.IReturnGetTransactions> {
     const emptyResult = {
       meta: {
@@ -173,18 +155,17 @@ export class TheGraphDataAccess implements DataAccessTypes.IDataAccess {
         transactions: [],
       },
     };
-    if (!this.pending[channelId]) {
+    const pending = this.pendingStore?.get(channelId);
+    if (!pending) {
       return emptyResult;
     }
-    const { storageResult, transaction } = this.pending[channelId];
+    const { storageResult, transaction } = pending;
 
-    const { transactions } = await this.graphql.getTransactionsByHash(
-      this.pending[channelId].storageResult.id,
-    );
+    const { transactions } = await this.graphql.getTransactionsByHash(storageResult.id);
 
     // if the pending tx is found, remove its state and fetch the real data
     if (transactions.length > 0) {
-      this.deletePending(channelId);
+      this.pendingStore?.remove(channelId);
       return emptyResult;
     }
 
@@ -202,80 +183,6 @@ export class TheGraphDataAccess implements DataAccessTypes.IDataAccess {
           },
         ],
       },
-    };
-  }
-
-  protected createPersistTransactionResult(
-    channelId: string,
-    transaction: DataAccessTypes.ITransaction,
-    storageResult: StorageTypes.IAppendResult,
-    topics: string[],
-  ): DataAccessTypes.IReturnPersistTransaction {
-    const eventEmitter = new EventEmitter() as DataAccessEventEmitter;
-    this.addPending(channelId, transaction, storageResult);
-
-    const result: DataAccessTypes.IReturnPersistTransactionRaw = {
-      meta: {
-        transactionStorageLocation: this.pending[channelId].storageResult.id,
-        storageMeta: this.pending[channelId].storageResult.meta,
-        topics,
-      },
-      result: {},
-    };
-
-    storageResult.on('confirmed', () => {
-      Utils.retry(
-        async () => {
-          const response = await this.graphql.getTransactionsByHash(storageResult.id);
-          if (response.transactions.length === 0) {
-            throw Error('no transactions');
-          }
-          this.logger.debug(`Hash ${storageResult.id} found in subgraph.`);
-          return response;
-        },
-        { maxRetries: 100, retryDelay: 1000 },
-      )()
-        .then((response) => {
-          this.deletePending(channelId);
-          eventEmitter.emit('confirmed', {
-            ...result,
-            meta: {
-              ...result.meta,
-              storageMeta: this.getStorageMeta(
-                response.transactions[0],
-                response._meta.block.number,
-              ),
-            },
-          });
-        })
-        .catch((error) => {
-          this.deletePending(channelId);
-          eventEmitter.emit('error', error);
-        });
-    });
-
-    return Object.assign(eventEmitter, result);
-  }
-
-  private getStorageMeta(
-    result: Transaction,
-    lastBlockNumber: number,
-  ): StorageTypes.IEntryMetadata {
-    return {
-      ethereum: {
-        blockConfirmation: lastBlockNumber - result.blockNumber,
-        blockNumber: result.blockNumber,
-        blockTimestamp: result.blockTimestamp,
-        networkName: this.network,
-        smartContractAddress: result.smartContractAddress,
-        transactionHash: result.transactionHash,
-      },
-      ipfs: {
-        size: BigNumber.from(result.size).toNumber(),
-      },
-      state: StorageTypes.ContentState.CONFIRMED,
-      storageType: StorageTypes.StorageSystemType.ETHEREUM_IPFS,
-      timestamp: result.blockTimestamp,
     };
   }
 
@@ -297,6 +204,133 @@ export class TheGraphDataAccess implements DataAccessTypes.IDataAccess {
           {},
         ),
       },
+    };
+  }
+}
+
+export class TheGraphDataWrite implements DataAccessTypes.IDataWrite {
+  private logger: LogTypes.ILogger;
+  private network: string;
+  private pendingStore?: PendingStore;
+
+  constructor(
+    protected storage: TheGraphStorage,
+    private readonly graphql: SubgraphClient,
+    {
+      network,
+
+      logger,
+      pendingStore,
+    }: Pick<
+      TheGraphDataAccessOptions,
+      'ipfsStorage' | 'network' | 'signer' | 'logger' | 'pendingStore'
+    >,
+  ) {
+    this.logger = logger || new Utils.SimpleLogger();
+    this.network = network;
+    this.pendingStore = pendingStore;
+  }
+
+  async initialize(): Promise<void> {
+    await this.graphql.getBlockNumber();
+    await this.storage.initialize();
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async persistTransaction(
+    transaction: DataAccessTypes.ITransaction,
+    channelId: string,
+    topics?: string[] | undefined,
+  ): Promise<DataAccessTypes.IReturnPersistTransaction> {
+    const updatedBlock = Block.pushTransaction(
+      Block.createEmptyBlock(),
+      transaction,
+      channelId,
+      topics,
+    );
+
+    const storageResult = await this.storage.append(JSON.stringify(updatedBlock));
+
+    return this.createPersistTransactionResult(channelId, transaction, storageResult, topics || []);
+  }
+
+  protected createPersistTransactionResult(
+    channelId: string,
+    transaction: DataAccessTypes.ITransaction,
+    storageResult: StorageTypes.IAppendResult,
+    topics: string[],
+  ): DataAccessTypes.IReturnPersistTransaction {
+    const eventEmitter = new EventEmitter() as DataAccessEventEmitter;
+    this.pendingStore?.add(channelId, transaction, storageResult);
+
+    const result: DataAccessTypes.IReturnPersistTransactionRaw = {
+      meta: {
+        transactionStorageLocation: storageResult.id,
+        storageMeta: storageResult.meta,
+        topics,
+      },
+      result: {},
+    };
+
+    storageResult.on('confirmed', () => {
+      Utils.retry(
+        async () => {
+          const response = await this.graphql.getTransactionsByHash(storageResult.id);
+          if (response.transactions.length === 0) {
+            throw Error('no transactions');
+          }
+          this.logger.debug(`Hash ${storageResult.id} found in subgraph.`);
+          return response;
+        },
+        { maxRetries: 100, retryDelay: 1000 },
+      )()
+        .then((response) => {
+          this.pendingStore?.remove(channelId);
+          eventEmitter.emit('confirmed', {
+            ...result,
+            meta: {
+              ...result.meta,
+              storageMeta: getStorageMeta(
+                response.transactions[0],
+                response._meta.block.number,
+                this.network,
+              ),
+            },
+          });
+        })
+        .catch((error) => {
+          this.pendingStore?.remove(channelId);
+          eventEmitter.emit('error', error);
+        });
+    });
+
+    return Object.assign(eventEmitter, result);
+  }
+}
+
+export class TheGraphDataAccess extends CombinedDataAccess {
+  private readonly graphql: SubgraphClient;
+  private readonly storage: TheGraphStorage;
+
+  constructor({ graphql, ...options }: TheGraphDataAccessOptions) {
+    const { url, ...rest } = graphql;
+    const graphqlClient = new SubgraphClient(url, rest);
+    const storage = new TheGraphStorage(options);
+    const reader = new TheGraphDataRead(graphqlClient, options);
+    const writer = new TheGraphDataWrite(storage, graphqlClient, options);
+    super(reader, writer);
+    this.graphql = graphqlClient;
+    this.storage = storage;
+  }
+
+  async _getStatus(): Promise<any> {
+    return {
+      lastBlock: await this.graphql.getBlockNumber(),
+      endpoint: this.graphql.endpoint,
+      storage: await this.storage._getStatus(),
     };
   }
 }

--- a/packages/request-node/src/thegraph/TheGraphDataAccess.ts
+++ b/packages/request-node/src/thegraph/TheGraphDataAccess.ts
@@ -218,7 +218,6 @@ export class TheGraphDataWrite implements DataAccessTypes.IDataWrite {
     private readonly graphql: SubgraphClient,
     {
       network,
-
       logger,
       pendingStore,
     }: Pick<

--- a/packages/request-node/src/thegraph/index.ts
+++ b/packages/request-node/src/thegraph/index.ts
@@ -1,1 +1,12 @@
 export { TheGraphRequestNode } from './TheGraphRequestNode';
+export { CombinedDataAccess } from './CombinedDataAccess';
+export {
+  TheGraphDataAccess,
+  TheGraphDataRead,
+  TheGraphDataWrite,
+  TheGraphDataAccessOptions,
+} from './TheGraphDataAccess';
+export { PendingStore } from './PendingStore';
+export { TheGraphStorage } from './TheGraphStorage';
+export { SubgraphClient } from './subgraphClient';
+export * as queries from './queries';

--- a/packages/types/src/data-access-types.ts
+++ b/packages/types/src/data-access-types.ts
@@ -2,14 +2,10 @@ import { EventEmitter } from 'events';
 import * as StorageTypes from './storage-types';
 
 /** Data Access Layer */
-export interface IDataAccess {
+export interface IDataRead {
   initialize: () => Promise<void>;
   close: () => Promise<void>;
-  persistTransaction: (
-    transactionData: ITransaction,
-    channelId: string,
-    topics?: string[],
-  ) => Promise<IReturnPersistTransaction>;
+
   getTransactionsByChannelId: (
     channelId: string,
     timestampBoundaries?: ITimestampBoundaries,
@@ -22,6 +18,20 @@ export interface IDataAccess {
     topics: string[],
     updatedBetween?: ITimestampBoundaries,
   ): Promise<IReturnGetChannelsByTopic>;
+}
+
+export interface IDataWrite {
+  initialize: () => Promise<void>;
+  close: () => Promise<void>;
+
+  persistTransaction: (
+    transactionData: ITransaction,
+    channelId: string,
+    topics?: string[],
+  ) => Promise<IReturnPersistTransaction>;
+}
+
+export interface IDataAccess extends IDataRead, IDataWrite {
   _getStatus(detailed?: boolean): Promise<IDataAccessStatus>;
 }
 


### PR DESCRIPTION
This enables relying on the request-node to persist the transaction, and on the graph-node to confirm it