### PR TITLE
fix(payment-processor): add reset approvals to run twice tests

### DIFF
--- a/packages/payment-processor/README.md
+++ b/packages/payment-processor/README.md
@@ -9,6 +9,7 @@ It contains client-side payment methods for:
 ### Test
 
 To run the payment-processor tests we need a local running ganache with all our smart contracts deployed. You can open two terminals and do:
+Do not define "NETWORK" variable in the smart-contracts .env file.
 
 ```
 # Terminal 1

--- a/packages/payment-processor/README.md
+++ b/packages/payment-processor/README.md
@@ -8,8 +8,9 @@ It contains client-side payment methods for:
 
 ### Test
 
-To run the payment-processor tests we need a local running ganache with all our smart contracts deployed. You can open two terminals and do:
+To run the payment-processor tests we need a local running ganache with all our smart contracts deployed.
 Do not define "NETWORK" variable in the smart-contracts .env file.
+You can open two terminals and do:
 
 ```
 # Terminal 1

--- a/packages/payment-processor/src/payment/utils.ts
+++ b/packages/payment-processor/src/payment/utils.ts
@@ -348,7 +348,7 @@ export function comparePnTypeAndVersion(
 }
 
 /**
- * set approval to 0 of a token from a user (as wallet address provider)
+ * Revoke ERC20 approval of a token for a given `spenderAddress`
  */
 export async function resetApproveErc20Utils(
   spenderAddress: string,

--- a/packages/payment-processor/src/payment/utils.ts
+++ b/packages/payment-processor/src/payment/utils.ts
@@ -350,7 +350,7 @@ export function comparePnTypeAndVersion(
 /**
  * Revoke ERC20 approval of a token for a given `spenderAddress`
  */
-export async function resetApproveErc20Utils(
+export async function revokeErc20Approval(
   spenderAddress: string,
   paymentTokenAddress: string,
   signerOrProvider: providers.Provider | Signer = getProvider(),

--- a/packages/payment-processor/test/payment/any-to-erc20-proxy.test.ts
+++ b/packages/payment-processor/test/payment/any-to-erc20-proxy.test.ts
@@ -16,6 +16,8 @@ import { ERC20__factory } from '@requestnetwork/smart-contracts/types';
 import { currencyManager } from './shared';
 import { IConversionPaymentSettings } from '../../src/index';
 import { UnsupportedCurrencyError } from '@requestnetwork/currency';
+import { AnyToERC20PaymentDetector } from '@requestnetwork/payment-detection';
+import { getProxyAddress, resetApproveErc20Utils } from '../../src/payment/utils';
 
 // Cf. ERC20Alpha in TestERC20.sol
 const erc20ContractAddress = '0x38cF23C52Bb4B13F051Aec09580a2dE845a7FA35';
@@ -81,6 +83,15 @@ const validEuroRequest: ClientTypes.IRequestData = {
 };
 
 describe('conversion-erc20-fee-proxy', () => {
+  beforeAll(async () => {
+    // reset approval
+    await resetApproveErc20Utils(
+      getProxyAddress(validEuroRequest, AnyToERC20PaymentDetector.getDeploymentInformation),
+      erc20ContractAddress,
+      wallet.provider,
+    );
+  });
+
   describe('error checking', () => {
     it('should throw an error if the token is not accepted', async () => {
       await expect(

--- a/packages/payment-processor/test/payment/any-to-erc20-proxy.test.ts
+++ b/packages/payment-processor/test/payment/any-to-erc20-proxy.test.ts
@@ -17,7 +17,7 @@ import { currencyManager } from './shared';
 import { IConversionPaymentSettings } from '../../src/index';
 import { UnsupportedCurrencyError } from '@requestnetwork/currency';
 import { AnyToERC20PaymentDetector } from '@requestnetwork/payment-detection';
-import { getProxyAddress, resetApproveErc20Utils } from '../../src/payment/utils';
+import { getProxyAddress, revokeErc20Approval } from '../../src/payment/utils';
 
 // Cf. ERC20Alpha in TestERC20.sol
 const erc20ContractAddress = '0x38cF23C52Bb4B13F051Aec09580a2dE845a7FA35';
@@ -85,7 +85,7 @@ const validEuroRequest: ClientTypes.IRequestData = {
 describe('conversion-erc20-fee-proxy', () => {
   beforeAll(async () => {
     // reset approval
-    await resetApproveErc20Utils(
+    await revokeErc20Approval(
       getProxyAddress(validEuroRequest, AnyToERC20PaymentDetector.getDeploymentInformation),
       erc20ContractAddress,
       wallet.provider,

--- a/packages/payment-processor/test/payment/encoder-approval.test.ts
+++ b/packages/payment-processor/test/payment/encoder-approval.test.ts
@@ -7,7 +7,7 @@ import {
   RequestLogicTypes,
 } from '@requestnetwork/types';
 import { encodeRequestErc20ApprovalIfNeeded } from '../../src';
-import { getProxyAddress, resetApproveErc20Utils } from '../../src/payment/utils';
+import { getProxyAddress, revokeErc20Approval } from '../../src/payment/utils';
 import { AnyToERC20PaymentDetector, Erc20PaymentNetwork } from '@requestnetwork/payment-detection';
 import { currencyManager } from './shared';
 import { IPreparedTransaction } from 'payment-processor/dist/payment/prepared-transaction';
@@ -232,29 +232,29 @@ beforeAll(async () => {
     baseValidRequest,
     Erc20PaymentNetwork.ERC20ProxyPaymentDetector.getDeploymentInformation,
   );
-  await resetApproveErc20Utils(proxyERC20, erc20ContractAddress, wallet);
+  await revokeErc20Approval(proxyERC20, erc20ContractAddress, wallet);
 
   proxyERC20Fee = getProxyAddress(
     validRequestERC20FeeProxy,
     Erc20PaymentNetwork.ERC20FeeProxyPaymentDetector.getDeploymentInformation,
   );
-  await resetApproveErc20Utils(proxyERC20Fee, erc20ContractAddress, wallet);
+  await revokeErc20Approval(proxyERC20Fee, erc20ContractAddress, wallet);
 
   proxyERC20Conv = getProxyAddress(
     validRequestERC20ConversionProxy,
     AnyToERC20PaymentDetector.getDeploymentInformation,
   );
-  await resetApproveErc20Utils(proxyERC20Conv, alphaContractAddress, wallet);
+  await revokeErc20Approval(proxyERC20Conv, alphaContractAddress, wallet);
 
   proxyERC20Swap = erc20SwapToPayArtifact.getAddress(
     validRequestERC20FeeProxy.currencyInfo.network!,
   );
-  await resetApproveErc20Utils(proxyERC20Swap, alphaContractAddress, wallet);
+  await revokeErc20Approval(proxyERC20Swap, alphaContractAddress, wallet);
 
   proxyERC20SwapConv = erc20SwapConversionArtifact.getAddress(
     validRequestERC20FeeProxy.currencyInfo.network!,
   );
-  await resetApproveErc20Utils(proxyERC20SwapConv, alphaContractAddress, wallet);
+  await revokeErc20Approval(proxyERC20SwapConv, alphaContractAddress, wallet);
 });
 
 describe('Approval encoder handles ERC20 Proxy', () => {

--- a/packages/payment-processor/test/payment/encoder-approval.test.ts
+++ b/packages/payment-processor/test/payment/encoder-approval.test.ts
@@ -7,7 +7,7 @@ import {
   RequestLogicTypes,
 } from '@requestnetwork/types';
 import { encodeRequestErc20ApprovalIfNeeded } from '../../src';
-import { getProxyAddress } from '../../src/payment/utils';
+import { getProxyAddress, resetApproveErc20Utils } from '../../src/payment/utils';
 import { AnyToERC20PaymentDetector, Erc20PaymentNetwork } from '@requestnetwork/payment-detection';
 import { currencyManager } from './shared';
 import { IPreparedTransaction } from 'payment-processor/dist/payment/prepared-transaction';
@@ -54,6 +54,12 @@ const erc20ApprovalData = (proxy: string) => {
     .slice(2)
     .toLowerCase()}ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff`;
 };
+
+let proxyERC20: string;
+let proxyERC20Fee: string;
+let proxyERC20Conv: string;
+let proxyERC20Swap: string;
+let proxyERC20SwapConv: string;
 
 const baseValidRequest: ClientTypes.IRequestData = {
   balance: {
@@ -215,11 +221,40 @@ const validRequestEthConversionProxy: ClientTypes.IRequestData = {
 beforeAll(async () => {
   const mainAddress = wallet.address;
   wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
-  wallet.sendTransaction({
+  await wallet.sendTransaction({
     to: mainAddress,
     value: BigNumber.from('1000000000000000000'),
   });
   wallet = Wallet.fromMnemonic(mnemonic, mnemonicPath).connect(provider);
+
+  // reset approvals
+  proxyERC20 = getProxyAddress(
+    baseValidRequest,
+    Erc20PaymentNetwork.ERC20ProxyPaymentDetector.getDeploymentInformation,
+  );
+  await resetApproveErc20Utils(proxyERC20, erc20ContractAddress, wallet);
+
+  proxyERC20Fee = getProxyAddress(
+    validRequestERC20FeeProxy,
+    Erc20PaymentNetwork.ERC20FeeProxyPaymentDetector.getDeploymentInformation,
+  );
+  await resetApproveErc20Utils(proxyERC20Fee, erc20ContractAddress, wallet);
+
+  proxyERC20Conv = getProxyAddress(
+    validRequestERC20ConversionProxy,
+    AnyToERC20PaymentDetector.getDeploymentInformation,
+  );
+  await resetApproveErc20Utils(proxyERC20Conv, alphaContractAddress, wallet);
+
+  proxyERC20Swap = erc20SwapToPayArtifact.getAddress(
+    validRequestERC20FeeProxy.currencyInfo.network!,
+  );
+  await resetApproveErc20Utils(proxyERC20Swap, alphaContractAddress, wallet);
+
+  proxyERC20SwapConv = erc20SwapConversionArtifact.getAddress(
+    validRequestERC20FeeProxy.currencyInfo.network!,
+  );
+  await resetApproveErc20Utils(proxyERC20SwapConv, alphaContractAddress, wallet);
 });
 
 describe('Approval encoder handles ERC20 Proxy', () => {
@@ -230,13 +265,8 @@ describe('Approval encoder handles ERC20 Proxy', () => {
       wallet.address,
     );
 
-    const proxyAddress = getProxyAddress(
-      baseValidRequest,
-      Erc20PaymentNetwork.ERC20ProxyPaymentDetector.getDeploymentInformation,
-    );
-
     expect(approvalTransaction).toEqual({
-      data: erc20ApprovalData(proxyAddress),
+      data: erc20ApprovalData(proxyERC20),
       to: erc20ContractAddress,
       value: 0,
     });
@@ -267,13 +297,8 @@ describe('Approval encoder handles ERC20 Fee Proxy', () => {
       wallet.address,
     );
 
-    const proxyAddress = getProxyAddress(
-      validRequestERC20FeeProxy,
-      Erc20PaymentNetwork.ERC20FeeProxyPaymentDetector.getDeploymentInformation,
-    );
-
     expect(approvalTransaction).toEqual({
-      data: erc20ApprovalData(proxyAddress),
+      data: erc20ApprovalData(proxyERC20Fee),
       to: erc20ContractAddress,
       value: 0,
     });
@@ -306,13 +331,8 @@ describe('Approval encoder handles ERC20 Conversion Proxy', () => {
       },
     );
 
-    const proxyAddress = getProxyAddress(
-      validRequestERC20ConversionProxy,
-      AnyToERC20PaymentDetector.getDeploymentInformation,
-    );
-
     expect(approvalTransaction).toEqual({
-      data: erc20ApprovalData(proxyAddress),
+      data: erc20ApprovalData(proxyERC20Conv),
       to: alphaContractAddress,
       value: 0,
     });
@@ -362,12 +382,8 @@ describe('Approval encoder handles ERC20 Swap Proxy', () => {
       },
     );
 
-    const proxyAddress = erc20SwapToPayArtifact.getAddress(
-      validRequestERC20FeeProxy.currencyInfo.network!,
-    );
-
     expect(approvalTransaction).toEqual({
-      data: erc20ApprovalData(proxyAddress),
+      data: erc20ApprovalData(proxyERC20Swap),
       to: alphaContractAddress,
       value: 0,
     });
@@ -408,12 +424,8 @@ describe('Approval encoder handles ERC20 Swap & Conversion Proxy', () => {
       },
     );
 
-    const proxyAddress = erc20SwapConversionArtifact.getAddress(
-      validRequestERC20FeeProxy.currencyInfo.network!,
-    );
-
     expect(approvalTransaction).toEqual({
-      data: erc20ApprovalData(proxyAddress),
+      data: erc20ApprovalData(proxyERC20SwapConv),
       to: erc20ContractAddress,
       value: 0,
     });


### PR DESCRIPTION
Tests cannot be run twice without restart Ganache, and then, deploy again smart contracts.
Solution: reset approvals for the 2 tests, using a new function in utils.

Also, update README regarding tests, preventing people being working on smart-contracts before to get weird error because of the Network.

Modifications impact only on tests.