### PR TITLE
feat: sf advanced logic subsequent request

### DIFF
--- a/packages/advanced-logic/src/extensions/payment-network/erc777/stream.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc777/stream.ts
@@ -1,7 +1,6 @@
-import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
+import { ExtensionTypes, RequestLogicTypes, TypesUtils } from '@requestnetwork/types';
 import ReferenceBasedPaymentNetwork from '../reference-based';
 import Utils from '@requestnetwork/utils';
-
 const CURRENT_VERSION = '0.1.0';
 
 /**
@@ -36,14 +35,17 @@ export default class Erc777StreamPaymentNetwork<
   public createCreationAction(
     creationParameters: TCreationParameters,
   ): ExtensionTypes.IAction<TCreationParameters> {
-    /* Master Request Creation */
     if (
-      !(
-        creationParameters.masterRequestId ||
-        creationParameters.previousRequestId ||
-        creationParameters.recurrenceNumber
-      )
+      !TypesUtils.isMasterRequestCreationParameters(creationParameters) &&
+      !TypesUtils.isSubsequentRequestCreationParameters(creationParameters)
     ) {
+      throw Error(
+        'masterRequestId, previousRequestId and recurrenceNumber must be all empty or all filled',
+      );
+    }
+
+    /* Master Request Creation */
+    if (TypesUtils.isMasterRequestCreationParameters(creationParameters)) {
       if (!creationParameters.expectedFlowRate) {
         throw Error('expectedFlowRate should not be empty');
       }
@@ -57,38 +59,23 @@ export default class Erc777StreamPaymentNetwork<
       ) as ExtensionTypes.IAction<TCreationParameters>;
     }
 
-    /* Subsequent Request Creation */
-    if (
-      creationParameters.masterRequestId &&
-      creationParameters.previousRequestId &&
-      creationParameters.recurrenceNumber
-    ) {
-      if (
-        (creationParameters.masterRequestId === creationParameters.previousRequestId &&
-          creationParameters.recurrenceNumber !== 1) ||
-        (creationParameters.recurrenceNumber === 1 &&
-          creationParameters.masterRequestId !== creationParameters.previousRequestId)
-      ) {
-        throw Error(
-          'recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa',
-        );
-      }
-
-      return {
-        action: 'create',
-        id: this.extensionId,
-        parameters: {
-          previousRequestId: creationParameters.previousRequestId,
-          masterRequestId: creationParameters.masterRequestId,
-          recurrenceNumber: creationParameters.recurrenceNumber,
-        },
-        version: this.currentVersion,
-      } as ExtensionTypes.IAction<TCreationParameters>;
+    /* Subsequent request Creation */
+    if (!this.isSubsequentRequestParametersValid(creationParameters)) {
+      throw Error(
+        'recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa',
+      );
     }
 
-    throw Error(
-      'masterRequestId, previousRequestId and recurrenceNumber must be all empty or all filled',
-    );
+    return {
+      action: ExtensionTypes.PnFeeReferenceBased.ACTION.CREATE,
+      id: this.extensionId,
+      parameters: {
+        previousRequestId: creationParameters.previousRequestId,
+        masterRequestId: creationParameters.masterRequestId,
+        recurrenceNumber: creationParameters.recurrenceNumber,
+      },
+      version: this.currentVersion,
+    } as ExtensionTypes.IAction<TCreationParameters>;
   }
 
   /**
@@ -103,46 +90,41 @@ export default class Erc777StreamPaymentNetwork<
     extensionAction: ExtensionTypes.IAction,
     timestamp: number,
   ): ExtensionTypes.IState {
-    /* Master request Creation */
     if (
-      !(
-        extensionAction.parameters.masterRequestId ||
-        extensionAction.parameters.previousRequestId ||
-        extensionAction.parameters.recurrenceNumber
-      )
+      !TypesUtils.isMasterRequestCreationParameters(extensionAction.parameters) &&
+      !TypesUtils.isSubsequentRequestCreationParameters(extensionAction.parameters)
     ) {
-      if (!extensionAction.parameters.expectedStartDate) {
-        throw Error('expectedStartDate should not be empty');
-      }
-      if (!extensionAction.parameters.expectedFlowRate) {
-        throw Error('expectedFlowRate should not be empty');
-      }
+      throw Error(
+        'masterRequestId, previousRequestId and recurrenceNumber must be all empty or all filled',
+      );
+    }
+
+    /* Master request Creation */
+    if (TypesUtils.isMasterRequestCreationParameters(extensionAction.parameters)) {
       if (
-        extensionAction.parameters.expectedStartDate &&
-        !Utils.amount.isValid(extensionAction.parameters.expectedStartDate)
+        !extensionAction.parameters.expectedStartDate ||
+        (extensionAction.parameters.expectedStartDate &&
+          !Utils.amount.isValid(extensionAction.parameters.expectedStartDate))
       ) {
-        throw Error('expectedStartDate is not a valid amount');
+        throw Error('expectedStartDate is empty or invalid');
       }
+
       if (
-        extensionAction.parameters.expectedFlowRate &&
-        !Utils.amount.isValid(extensionAction.parameters.expectedFlowRate)
+        !extensionAction.parameters.expectedFlowRate ||
+        (extensionAction.parameters.expectedFlowRate &&
+          !Utils.amount.isValid(extensionAction.parameters.expectedFlowRate))
       ) {
-        throw Error('expectedFlowRate is not a valid amount');
+        throw Error('expectedFlowRate is empty or invalid');
       }
+
       const proxyPNCreationAction = super.applyCreation(extensionAction, timestamp);
 
       return {
         ...proxyPNCreationAction,
         events: [
           {
-            name: 'create',
-            parameters: {
-              expectedStartDate: extensionAction.parameters.expectedStartDate,
-              expectedFlowRate: extensionAction.parameters.expectedFlowRate,
-              paymentAddress: extensionAction.parameters.paymentAddress,
-              refundAddress: extensionAction.parameters.refundAddress,
-              salt: extensionAction.parameters.salt,
-            },
+            name: ExtensionTypes.PnFeeReferenceBased.ACTION.CREATE,
+            parameters: extensionAction.parameters,
             timestamp,
           },
         ],
@@ -155,52 +137,58 @@ export default class Erc777StreamPaymentNetwork<
     }
 
     /* Subsequent Request Creation */
-    if (
-      extensionAction.parameters.masterRequestId &&
-      extensionAction.parameters.previousRequestId &&
-      extensionAction.parameters.recurrenceNumber
-    ) {
-      if (
-        (extensionAction.parameters.masterRequestId ===
-          extensionAction.parameters.previousRequestId &&
-          extensionAction.parameters.recurrenceNumber !== 1) ||
-        (extensionAction.parameters.recurrenceNumber === 1 &&
-          extensionAction.parameters.masterRequestId !==
-            extensionAction.parameters.previousRequestId)
-      ) {
-        throw Error(
-          'recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa',
-        );
-      }
-
-      if (!extensionAction.version) {
-        throw Error('version is required at creation');
-      }
-
-      return {
-        events: [
-          {
-            name: 'create',
-            parameters: {
-              previousRequestId: extensionAction.parameters.previousRequestId,
-              masterRequestId: extensionAction.parameters.masterRequestId,
-              recurrenceNumber: extensionAction.parameters.recurrenceNumber,
-            },
-            timestamp,
-          },
-        ],
-        id: extensionAction.id,
-        type: this.extensionType,
-        values: {
-          previousRequestId: extensionAction.parameters.previousRequestId,
-          masterRequestId: extensionAction.parameters.masterRequestId,
-          recurrenceNumber: extensionAction.parameters.recurrenceNumber,
-        },
-        version: extensionAction.version,
-      };
+    if (!extensionAction.parameters.masterRequestId) {
+      throw Error('masterRequestId is empty');
     }
-    throw Error(
-      'masterRequestId, previousRequestId and recurrenceNumber must be all empty or all filled',
+
+    if (!extensionAction.parameters.previousRequestId) {
+      throw Error('previousRequestId is empty');
+    }
+
+    if (!extensionAction.parameters.recurrenceNumber) {
+      throw Error('recurrenceNumber is empty');
+    }
+
+    if (!extensionAction.version) {
+      throw Error('version is required at creation');
+    }
+
+    if (!this.isSubsequentRequestParametersValid(extensionAction.parameters)) {
+      throw Error(
+        'recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa',
+      );
+    }
+
+    return {
+      events: [
+        {
+          name: ExtensionTypes.PnFeeReferenceBased.ACTION.CREATE,
+          parameters: extensionAction.parameters,
+          timestamp,
+        },
+      ],
+      id: extensionAction.id,
+      type: this.extensionType,
+      values: extensionAction.parameters,
+      version: extensionAction.version,
+    };
+  }
+
+  /**
+   * Verifies the consistency between the different parameters of the create action for subsequent requests
+   *
+   * @param parameters extension parameters to check
+   *
+   * @returns a boolean
+   */
+  protected isSubsequentRequestParametersValid(
+    parameters: ExtensionTypes.PnStreamReferenceBased.ISubsequentRequestCreationParameters,
+  ): boolean {
+    return (
+      (parameters.masterRequestId === parameters.previousRequestId &&
+        parameters.recurrenceNumber === 1) ||
+      (parameters.recurrenceNumber !== 1 &&
+        parameters.masterRequestId !== parameters.previousRequestId)
     );
   }
 }

--- a/packages/advanced-logic/src/extensions/payment-network/erc777/stream.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc777/stream.ts
@@ -150,9 +150,6 @@ export default class Erc777StreamPaymentNetwork<
           ...proxyPNCreationAction.values,
           expectedStartDate: extensionAction.parameters.expectedStartDate,
           expectedFlowRate: extensionAction.parameters.expectedFlowRate,
-          previousRequestId: extensionAction.parameters.previousRequestId,
-          masterRequestId: extensionAction.parameters.masterRequestId,
-          recurrenceNumber: extensionAction.parameters.recurrenceNumber,
         },
       };
     }

--- a/packages/advanced-logic/src/extensions/payment-network/erc777/stream.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc777/stream.ts
@@ -65,8 +65,8 @@ export default class Erc777StreamPaymentNetwork<
     ) {
       if (
         (creationParameters.masterRequestId === creationParameters.previousRequestId &&
-          creationParameters.recurrenceNumber !== '1') ||
-        (creationParameters.recurrenceNumber === '1' &&
+          creationParameters.recurrenceNumber !== 1) ||
+        (creationParameters.recurrenceNumber === 1 &&
           creationParameters.masterRequestId !== creationParameters.previousRequestId)
       ) {
         throw Error(
@@ -166,8 +166,8 @@ export default class Erc777StreamPaymentNetwork<
       if (
         (extensionAction.parameters.masterRequestId ===
           extensionAction.parameters.previousRequestId &&
-          extensionAction.parameters.recurrenceNumber !== '1') ||
-        (extensionAction.parameters.recurrenceNumber === '1' &&
+          extensionAction.parameters.recurrenceNumber !== 1) ||
+        (extensionAction.parameters.recurrenceNumber === 1 &&
           extensionAction.parameters.masterRequestId !==
             extensionAction.parameters.previousRequestId)
       ) {

--- a/packages/advanced-logic/test/extensions/payment-network/erc777/stream.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/erc777/stream.test.ts
@@ -422,7 +422,7 @@ describe('extensions/payment-network/erc777/stream', () => {
           });
         });
 
-        it(`Can not create a the first subsequent request with invalid parameters - 1`, () => {
+        it(`Can not create a subsequent request with invalid parameters - 1`, () => {
           expect(() =>
             erc777StreamPaymentNetwork.createCreationAction({
               masterRequestId: 'abcd',
@@ -434,7 +434,7 @@ describe('extensions/payment-network/erc777/stream', () => {
           );
         });
 
-        it(`Can not create a the first subsequent request with invalid parameters - 2`, () => {
+        it(`Can not create a subsequent request with invalid parameters - 2`, () => {
           expect(() =>
             erc777StreamPaymentNetwork.createCreationAction({
               masterRequestId: 'abcd',
@@ -504,7 +504,7 @@ describe('extensions/payment-network/erc777/stream', () => {
           );
         });
 
-        it(`Can not create a the first subsequent request with invalid parameters - 2`, () => {
+        it(`Can not create a subsequent request with invalid parameters - 2`, () => {
           const badActionCreation = {
             ...DataERC777StreamCreate.actionCreationFullSubsequent,
             parameters: {

--- a/packages/advanced-logic/test/extensions/payment-network/erc777/stream.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/erc777/stream.test.ts
@@ -408,7 +408,7 @@ describe('extensions/payment-network/erc777/stream', () => {
             erc777StreamPaymentNetwork.createCreationAction({
               masterRequestId: 'abcd',
               previousRequestId: 'efgh',
-              recurrenceNumber: '2',
+              recurrenceNumber: 2,
             }),
           ).toEqual({
             action: 'create',
@@ -416,7 +416,7 @@ describe('extensions/payment-network/erc777/stream', () => {
             parameters: {
               masterRequestId: 'abcd',
               previousRequestId: 'efgh',
-              recurrenceNumber: '2',
+              recurrenceNumber: 2,
             },
             version: '0.1.0',
           });
@@ -427,7 +427,7 @@ describe('extensions/payment-network/erc777/stream', () => {
               erc777StreamPaymentNetwork.createCreationAction({
                 masterRequestId: invalidCase === 'masterRequestId' ? undefined : 'abcd',
                 previousRequestId: invalidCase === 'previousRequestId' ? undefined : 'efgh',
-                recurrenceNumber: invalidCase === 'recurrenceNumber' ? undefined : '2',
+                recurrenceNumber: invalidCase === 'recurrenceNumber' ? undefined : 2,
               }),
             ).toThrowError(
               'masterRequestId, previousRequestId and recurrenceNumber must be all empty or all filled',
@@ -440,7 +440,7 @@ describe('extensions/payment-network/erc777/stream', () => {
             erc777StreamPaymentNetwork.createCreationAction({
               masterRequestId: 'abcd',
               previousRequestId: 'abcd',
-              recurrenceNumber: '2',
+              recurrenceNumber: 2,
             }),
           ).toThrowError(
             'recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa',
@@ -452,7 +452,7 @@ describe('extensions/payment-network/erc777/stream', () => {
             erc777StreamPaymentNetwork.createCreationAction({
               masterRequestId: 'abcd',
               previousRequestId: 'efgh',
-              recurrenceNumber: '1',
+              recurrenceNumber: 1,
             }),
           ).toThrowError(
             'recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa',
@@ -480,7 +480,7 @@ describe('extensions/payment-network/erc777/stream', () => {
               parameters: {
                 masterRequestId: invalidCase === 'masterRequestId' ? undefined : 'abcd',
                 previousRequestId: invalidCase === 'previousRequestId' ? undefined : 'efgh',
-                recurrenceNumber: invalidCase === 'recurrenceNumber' ? undefined : '2',
+                recurrenceNumber: invalidCase === 'recurrenceNumber' ? undefined : 2,
               },
             };
             expect(() =>
@@ -503,7 +503,7 @@ describe('extensions/payment-network/erc777/stream', () => {
             parameters: {
               masterRequestId: 'abcd',
               previousRequestId: 'abcd',
-              recurrenceNumber: '2',
+              recurrenceNumber: 2,
             },
           };
           expect(() =>
@@ -525,7 +525,7 @@ describe('extensions/payment-network/erc777/stream', () => {
             parameters: {
               masterRequestId: 'abcd',
               previousRequestId: 'efgh',
-              recurrenceNumber: '1',
+              recurrenceNumber: 1,
             },
           };
           expect(() =>

--- a/packages/advanced-logic/test/extensions/payment-network/erc777/stream.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/erc777/stream.test.ts
@@ -399,5 +399,152 @@ describe('extensions/payment-network/erc777/stream', () => {
         });
       });
     });
+
+    describe('Subsequent Request creation',  () => {
+      const invalidCases = ["masterRequestId", "previousRequestId", "recurrenceNumber"];
+      describe('createCreateAction', () => {
+        it('Can create a create action for a subsequent request of a serie', () => {
+          expect(
+            erc777StreamPaymentNetwork.createCreationAction({
+              masterRequestId: 'abcd',
+              previousRequestId: 'efgh',
+              recurrenceNumber: '2',
+            }),
+          ).toEqual({
+            action: 'create',
+            id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,
+            parameters: {
+              masterRequestId: 'abcd',
+              previousRequestId: 'efgh',
+              recurrenceNumber: '2',
+            },
+            version: '0.1.0',
+          });
+        })
+        invalidCases.forEach((invalidCase) => {
+          it(`Can not create a subsequent request with missing ${invalidCase}.`, () => {
+            expect(() =>
+              erc777StreamPaymentNetwork.createCreationAction({
+                masterRequestId: invalidCase === 'masterRequestId' ? undefined : 'abcd',
+                previousRequestId: invalidCase === 'previousRequestId' ? undefined : 'efgh',
+                recurrenceNumber: invalidCase === 'recurrenceNumber' ? undefined : '2',
+              }),
+            ).toThrowError('masterRequestId, previousRequestId and recurrenceNumber must be all empty or all filled');
+          })
+        })
+  
+        it(`Can not create a the first subsequent request with invalid parameters - 1`, () => {
+          expect(() =>
+            erc777StreamPaymentNetwork.createCreationAction({
+              masterRequestId: 'abcd',
+              previousRequestId: 'abcd',
+              recurrenceNumber: '2',
+            }),
+          ).toThrowError('recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa');
+        })
+  
+        it(`Can not create a the first subsequent request with invalid parameters - 2`, () => {
+          expect(() =>
+            erc777StreamPaymentNetwork.createCreationAction({
+              masterRequestId: 'abcd',
+              previousRequestId: 'efgh',
+              recurrenceNumber: '1',
+            }),
+          ).toThrowError('recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa');
+        })
+      })
+
+      describe('applyCreateAction', () => {
+        it('can applyActionToExtensions of creation', () => {
+          expect(
+            erc777StreamPaymentNetwork.applyActionToExtension(
+              DataERC777StreamCreate.requestStateNoExtensions.extensions,
+              DataERC777StreamCreate.actionCreationFullSubsequent,
+              DataERC777StreamCreate.requestStateNoExtensions,
+              TestData.otherIdRaw.identity,
+              TestData.arbitraryTimestamp,
+            ),
+          ).toEqual(DataERC777StreamCreate.extensionFullStateSubsequent);
+        });
+
+        invalidCases.forEach((invalidCase) => {
+          it(`Can not create a subsequent request with missing ${invalidCase}.`, () => {
+            const badActionCreation = {
+              ...DataERC777StreamCreate.actionCreationFullSubsequent,
+              parameters: {
+                masterRequestId: invalidCase === 'masterRequestId' ? undefined : 'abcd',
+                previousRequestId: invalidCase === 'previousRequestId' ? undefined : 'efgh',
+                recurrenceNumber: invalidCase === 'recurrenceNumber' ? undefined : '2',
+              }
+            }
+            expect(() =>
+              erc777StreamPaymentNetwork.applyActionToExtension(
+                DataERC777StreamCreate.requestStateNoExtensions.extensions,
+                badActionCreation,
+                DataERC777StreamCreate.requestStateNoExtensions,
+                TestData.otherIdRaw.identity,
+                TestData.arbitraryTimestamp,
+              ),
+            ).toThrowError('masterRequestId, previousRequestId and recurrenceNumber must be all empty or all filled');
+          })
+        })
+  
+        it(`Can not create a the first subsequent request with invalid parameters - 1`, () => {
+          const badActionCreation = {
+            ...DataERC777StreamCreate.actionCreationFullSubsequent,
+            parameters: {
+              masterRequestId: 'abcd',
+              previousRequestId: 'abcd',
+              recurrenceNumber: '2',
+            }
+          }
+          expect(() =>
+            erc777StreamPaymentNetwork.applyActionToExtension(
+              DataERC777StreamCreate.requestStateNoExtensions.extensions,
+              badActionCreation,
+              DataERC777StreamCreate.requestStateNoExtensions,
+              TestData.otherIdRaw.identity,
+              TestData.arbitraryTimestamp,
+            ),
+          ).toThrowError('recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa');
+        })
+  
+        it(`Can not create a the first subsequent request with invalid parameters - 2`, () => {
+          const badActionCreation = {
+            ...DataERC777StreamCreate.actionCreationFullSubsequent,
+            parameters: {
+              masterRequestId: 'abcd',
+              previousRequestId: 'efgh',
+              recurrenceNumber: '1',
+            }
+          }
+          expect(() =>
+            erc777StreamPaymentNetwork.applyActionToExtension(
+              DataERC777StreamCreate.requestStateNoExtensions.extensions,
+              badActionCreation,
+              DataERC777StreamCreate.requestStateNoExtensions,
+              TestData.otherIdRaw.identity,
+              TestData.arbitraryTimestamp,
+            ),
+          ).toThrowError('recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa');
+        })
+
+        it('requires a version at creation', () => {
+          const badActionCreation = {
+            ...DataERC777StreamCreate.actionCreationFullSubsequent,
+            version: undefined,
+          }
+          expect(() => {
+            erc777StreamPaymentNetwork.applyActionToExtension(
+              DataERC777StreamCreate.requestStateNoExtensions.extensions,
+              badActionCreation,
+              DataERC777StreamCreate.requestStateNoExtensions,
+              TestData.otherIdRaw.identity,
+              TestData.arbitraryTimestamp,
+            );
+          }).toThrowError('version is required at creation');
+        });
+      })
+    })
   });
 });

--- a/packages/advanced-logic/test/extensions/payment-network/erc777/stream.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/erc777/stream.test.ts
@@ -421,19 +421,6 @@ describe('extensions/payment-network/erc777/stream', () => {
             version: '0.1.0',
           });
         });
-        invalidCases.forEach((invalidCase) => {
-          it(`Can not create a subsequent request with missing ${invalidCase}.`, () => {
-            expect(() =>
-              erc777StreamPaymentNetwork.createCreationAction({
-                masterRequestId: invalidCase === 'masterRequestId' ? undefined : 'abcd',
-                previousRequestId: invalidCase === 'previousRequestId' ? undefined : 'efgh',
-                recurrenceNumber: invalidCase === 'recurrenceNumber' ? undefined : 2,
-              }),
-            ).toThrowError(
-              'masterRequestId, previousRequestId and recurrenceNumber must be all empty or all filled',
-            );
-          });
-        });
 
         it(`Can not create a the first subsequent request with invalid parameters - 1`, () => {
           expect(() =>
@@ -491,9 +478,7 @@ describe('extensions/payment-network/erc777/stream', () => {
                 TestData.otherIdRaw.identity,
                 TestData.arbitraryTimestamp,
               ),
-            ).toThrowError(
-              'masterRequestId, previousRequestId and recurrenceNumber must be all empty or all filled',
-            );
+            ).toThrowError(`${invalidCase} is empty`);
           });
         });
 

--- a/packages/advanced-logic/test/extensions/payment-network/erc777/stream.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/erc777/stream.test.ts
@@ -400,8 +400,8 @@ describe('extensions/payment-network/erc777/stream', () => {
       });
     });
 
-    describe('Subsequent Request creation',  () => {
-      const invalidCases = ["masterRequestId", "previousRequestId", "recurrenceNumber"];
+    describe('Subsequent Request creation', () => {
+      const invalidCases = ['masterRequestId', 'previousRequestId', 'recurrenceNumber'];
       describe('createCreateAction', () => {
         it('Can create a create action for a subsequent request of a serie', () => {
           expect(
@@ -420,7 +420,7 @@ describe('extensions/payment-network/erc777/stream', () => {
             },
             version: '0.1.0',
           });
-        })
+        });
         invalidCases.forEach((invalidCase) => {
           it(`Can not create a subsequent request with missing ${invalidCase}.`, () => {
             expect(() =>
@@ -429,10 +429,12 @@ describe('extensions/payment-network/erc777/stream', () => {
                 previousRequestId: invalidCase === 'previousRequestId' ? undefined : 'efgh',
                 recurrenceNumber: invalidCase === 'recurrenceNumber' ? undefined : '2',
               }),
-            ).toThrowError('masterRequestId, previousRequestId and recurrenceNumber must be all empty or all filled');
-          })
-        })
-  
+            ).toThrowError(
+              'masterRequestId, previousRequestId and recurrenceNumber must be all empty or all filled',
+            );
+          });
+        });
+
         it(`Can not create a the first subsequent request with invalid parameters - 1`, () => {
           expect(() =>
             erc777StreamPaymentNetwork.createCreationAction({
@@ -440,9 +442,11 @@ describe('extensions/payment-network/erc777/stream', () => {
               previousRequestId: 'abcd',
               recurrenceNumber: '2',
             }),
-          ).toThrowError('recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa');
-        })
-  
+          ).toThrowError(
+            'recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa',
+          );
+        });
+
         it(`Can not create a the first subsequent request with invalid parameters - 2`, () => {
           expect(() =>
             erc777StreamPaymentNetwork.createCreationAction({
@@ -450,9 +454,11 @@ describe('extensions/payment-network/erc777/stream', () => {
               previousRequestId: 'efgh',
               recurrenceNumber: '1',
             }),
-          ).toThrowError('recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa');
-        })
-      })
+          ).toThrowError(
+            'recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa',
+          );
+        });
+      });
 
       describe('applyCreateAction', () => {
         it('can applyActionToExtensions of creation', () => {
@@ -475,8 +481,8 @@ describe('extensions/payment-network/erc777/stream', () => {
                 masterRequestId: invalidCase === 'masterRequestId' ? undefined : 'abcd',
                 previousRequestId: invalidCase === 'previousRequestId' ? undefined : 'efgh',
                 recurrenceNumber: invalidCase === 'recurrenceNumber' ? undefined : '2',
-              }
-            }
+              },
+            };
             expect(() =>
               erc777StreamPaymentNetwork.applyActionToExtension(
                 DataERC777StreamCreate.requestStateNoExtensions.extensions,
@@ -485,10 +491,12 @@ describe('extensions/payment-network/erc777/stream', () => {
                 TestData.otherIdRaw.identity,
                 TestData.arbitraryTimestamp,
               ),
-            ).toThrowError('masterRequestId, previousRequestId and recurrenceNumber must be all empty or all filled');
-          })
-        })
-  
+            ).toThrowError(
+              'masterRequestId, previousRequestId and recurrenceNumber must be all empty or all filled',
+            );
+          });
+        });
+
         it(`Can not create a the first subsequent request with invalid parameters - 1`, () => {
           const badActionCreation = {
             ...DataERC777StreamCreate.actionCreationFullSubsequent,
@@ -496,8 +504,8 @@ describe('extensions/payment-network/erc777/stream', () => {
               masterRequestId: 'abcd',
               previousRequestId: 'abcd',
               recurrenceNumber: '2',
-            }
-          }
+            },
+          };
           expect(() =>
             erc777StreamPaymentNetwork.applyActionToExtension(
               DataERC777StreamCreate.requestStateNoExtensions.extensions,
@@ -506,9 +514,11 @@ describe('extensions/payment-network/erc777/stream', () => {
               TestData.otherIdRaw.identity,
               TestData.arbitraryTimestamp,
             ),
-          ).toThrowError('recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa');
-        })
-  
+          ).toThrowError(
+            'recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa',
+          );
+        });
+
         it(`Can not create a the first subsequent request with invalid parameters - 2`, () => {
           const badActionCreation = {
             ...DataERC777StreamCreate.actionCreationFullSubsequent,
@@ -516,8 +526,8 @@ describe('extensions/payment-network/erc777/stream', () => {
               masterRequestId: 'abcd',
               previousRequestId: 'efgh',
               recurrenceNumber: '1',
-            }
-          }
+            },
+          };
           expect(() =>
             erc777StreamPaymentNetwork.applyActionToExtension(
               DataERC777StreamCreate.requestStateNoExtensions.extensions,
@@ -526,14 +536,16 @@ describe('extensions/payment-network/erc777/stream', () => {
               TestData.otherIdRaw.identity,
               TestData.arbitraryTimestamp,
             ),
-          ).toThrowError('recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa');
-        })
+          ).toThrowError(
+            'recurrenceNumber must be 1 if masterRequestId and previousRequestId are equal and vice versa',
+          );
+        });
 
         it('requires a version at creation', () => {
           const badActionCreation = {
             ...DataERC777StreamCreate.actionCreationFullSubsequent,
             version: undefined,
-          }
+          };
           expect(() => {
             erc777StreamPaymentNetwork.applyActionToExtension(
               DataERC777StreamCreate.requestStateNoExtensions.extensions,
@@ -544,7 +556,7 @@ describe('extensions/payment-network/erc777/stream', () => {
             );
           }).toThrowError('version is required at creation');
         });
-      })
-    })
+      });
+    });
   });
 });

--- a/packages/advanced-logic/test/utils/payment-network/erc777/stream-create-data-generator.ts
+++ b/packages/advanced-logic/test/utils/payment-network/erc777/stream-create-data-generator.ts
@@ -11,9 +11,9 @@ export const refundAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
 export const expectedFlowRate = '381944444444442';
 export const expectedStartDate = '1643041225';
 export const invalidAddress = '0x not and address';
-export const masterRequestId = "abcd";
-export const previousRequestId = "efgh";
-export const recurrenceNumber = "2";
+export const masterRequestId = 'abcd';
+export const previousRequestId = 'efgh';
+export const recurrenceNumber = '2';
 
 // ---------------------------------------------------------------------
 export const salt = 'ea3bc7caf64110ca';
@@ -39,7 +39,7 @@ export const actionCreationFullSubsequent = {
     recurrenceNumber,
   },
   version: '0.1.0',
-}
+};
 export const actionCreationOnlyPayment = {
   action: 'create',
   id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,
@@ -233,7 +233,6 @@ export const requestFullStateCreated: RequestLogicTypes.IRequest = {
   timestamp: TestData.arbitraryTimestamp,
   version: '0.1.0',
 };
-
 
 export const subsequentRequestFullStateCreated: RequestLogicTypes.IRequest = {
   creator: {

--- a/packages/advanced-logic/test/utils/payment-network/erc777/stream-create-data-generator.ts
+++ b/packages/advanced-logic/test/utils/payment-network/erc777/stream-create-data-generator.ts
@@ -11,6 +11,10 @@ export const refundAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
 export const expectedFlowRate = '381944444444442';
 export const expectedStartDate = '1643041225';
 export const invalidAddress = '0x not and address';
+export const masterRequestId = "abcd";
+export const previousRequestId = "efgh";
+export const recurrenceNumber = "2";
+
 // ---------------------------------------------------------------------
 export const salt = 'ea3bc7caf64110ca';
 // actions
@@ -26,6 +30,16 @@ export const actionCreationFull = {
   },
   version: '0.1.0',
 };
+export const actionCreationFullSubsequent = {
+  action: 'create',
+  id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,
+  parameters: {
+    masterRequestId,
+    previousRequestId,
+    recurrenceNumber,
+  },
+  version: '0.1.0',
+}
 export const actionCreationOnlyPayment = {
   action: 'create',
   id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,
@@ -91,6 +105,29 @@ export const extensionFullState = {
       refundInfo: undefined,
       sentPaymentAmount: '0',
       sentRefundAmount: '0',
+    },
+    version: '0.1.0',
+  },
+};
+export const extensionFullStateSubsequent = {
+  [ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM as string]: {
+    events: [
+      {
+        name: 'create',
+        parameters: {
+          masterRequestId,
+          previousRequestId,
+          recurrenceNumber,
+        },
+        timestamp: arbitraryTimestamp,
+      },
+    ],
+    id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,
+    type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+    values: {
+      masterRequestId,
+      previousRequestId,
+      recurrenceNumber,
     },
     version: '0.1.0',
   },
@@ -182,6 +219,49 @@ export const requestFullStateCreated: RequestLogicTypes.IRequest = {
   ],
   expectedAmount: TestData.arbitraryExpectedAmount,
   extensions: extensionFullState,
+  extensionsData: [actionCreationFull],
+  payee: {
+    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
+    value: TestData.payeeRaw.address,
+  },
+  payer: {
+    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
+    value: TestData.payerRaw.address,
+  },
+  requestId: TestData.requestIdMock,
+  state: RequestLogicTypes.STATE.CREATED,
+  timestamp: TestData.arbitraryTimestamp,
+  version: '0.1.0',
+};
+
+
+export const subsequentRequestFullStateCreated: RequestLogicTypes.IRequest = {
+  creator: {
+    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
+    value: TestData.payeeRaw.address,
+  },
+  currency: {
+    network: 'rinkeby',
+    type: RequestLogicTypes.CURRENCY.ERC777,
+    value: '0x745861aed1eee363b4aaa5f1994be40b1e05ff90', //fDAIx
+  },
+  events: [
+    {
+      actionSigner: {
+        type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
+        value: TestData.payeeRaw.address,
+      },
+      name: RequestLogicTypes.ACTION_NAME.CREATE,
+      parameters: {
+        expectedAmount: '123400000000000000',
+        extensionsDataLength: 1,
+        isSignedRequest: false,
+      },
+      timestamp: arbitraryTimestamp,
+    },
+  ],
+  expectedAmount: TestData.arbitraryExpectedAmount,
+  extensions: extensionFullStateSubsequent,
   extensionsData: [actionCreationFull],
   payee: {
     type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,

--- a/packages/advanced-logic/test/utils/payment-network/erc777/stream-create-data-generator.ts
+++ b/packages/advanced-logic/test/utils/payment-network/erc777/stream-create-data-generator.ts
@@ -13,7 +13,7 @@ export const expectedStartDate = '1643041225';
 export const invalidAddress = '0x not and address';
 export const masterRequestId = 'abcd';
 export const previousRequestId = 'efgh';
-export const recurrenceNumber = '2';
+export const recurrenceNumber = 2;
 
 // ---------------------------------------------------------------------
 export const salt = 'ea3bc7caf64110ca';

--- a/packages/advanced-logic/test/utils/payment-network/erc777/stream-create-data-generator.ts
+++ b/packages/advanced-logic/test/utils/payment-network/erc777/stream-create-data-generator.ts
@@ -15,11 +15,15 @@ export const masterRequestId = 'abcd';
 export const previousRequestId = 'efgh';
 export const recurrenceNumber = 2;
 
+const version = '0.1.0';
+const fDAIx = '0x745861aed1eee363b4aaa5f1994be40b1e05ff90';
+const network = 'rinkeby';
+
 // ---------------------------------------------------------------------
 export const salt = 'ea3bc7caf64110ca';
 // actions
 export const actionCreationFull = {
-  action: 'create',
+  action: RequestLogicTypes.ACTION_NAME.CREATE,
   id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,
   parameters: {
     expectedFlowRate,
@@ -28,57 +32,57 @@ export const actionCreationFull = {
     refundAddress,
     salt,
   },
-  version: '0.1.0',
+  version,
 };
 export const actionCreationFullSubsequent = {
-  action: 'create',
+  action: RequestLogicTypes.ACTION_NAME.CREATE,
   id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,
   parameters: {
     masterRequestId,
     previousRequestId,
     recurrenceNumber,
   },
-  version: '0.1.0',
+  version,
 };
 export const actionCreationOnlyPayment = {
-  action: 'create',
+  action: RequestLogicTypes.ACTION_NAME.CREATE,
   id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,
   parameters: {
     paymentAddress,
   },
-  version: '0.1.0',
+  version,
 };
 export const actionCreationOnlyRefund = {
-  action: 'create',
+  action: RequestLogicTypes.ACTION_NAME.CREATE,
   id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,
   parameters: {
     refundAddress,
   },
-  version: '0.1.0',
+  version,
 };
 export const actionCreationOnlyFlow = {
-  action: 'create',
+  action: RequestLogicTypes.ACTION_NAME.CREATE,
   id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,
   parameters: {
     expectedFlowRate,
     expectedStartDate,
   },
-  version: '0.1.0',
+  version,
 };
 export const actionCreationEmpty = {
-  action: 'create',
+  action: RequestLogicTypes.ACTION_NAME.CREATE,
   id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,
   parameters: {},
-  version: '0.1.0',
+  version,
 };
 
 // ---------------------------------------------------------------------
 // extensions states
-export const extensionFullState = {
+export const extensionFullState: RequestLogicTypes.IExtensionStates = {
   [ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM as string]: {
     events: [
       {
-        name: 'create',
+        name: RequestLogicTypes.ACTION_NAME.CREATE,
         parameters: {
           expectedFlowRate,
           expectedStartDate,
@@ -106,14 +110,14 @@ export const extensionFullState = {
       sentPaymentAmount: '0',
       sentRefundAmount: '0',
     },
-    version: '0.1.0',
+    version,
   },
 };
-export const extensionFullStateSubsequent = {
+export const extensionFullStateSubsequent: RequestLogicTypes.IExtensionStates = {
   [ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM as string]: {
     events: [
       {
-        name: 'create',
+        name: RequestLogicTypes.ACTION_NAME.CREATE,
         parameters: {
           masterRequestId,
           previousRequestId,
@@ -129,14 +133,14 @@ export const extensionFullStateSubsequent = {
       previousRequestId,
       recurrenceNumber,
     },
-    version: '0.1.0',
+    version,
   },
 };
 export const extensionStateCreatedEmpty = {
   [ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM as string]: {
     events: [
       {
-        name: 'create',
+        name: RequestLogicTypes.ACTION_NAME.CREATE,
         parameters: {},
         timestamp: arbitraryTimestamp,
       },
@@ -144,40 +148,22 @@ export const extensionStateCreatedEmpty = {
     id: ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,
     type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
     values: {},
-    version: '0.1.0',
+    version,
   },
 };
 
 // ---------------------------------------------------------------------
 // request states
-export const requestStateNoExtensions: RequestLogicTypes.IRequest = {
+const baseRequestState = {
   creator: {
     type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
     value: TestData.payeeRaw.address,
   },
   currency: {
-    network: 'rinkeby',
+    network: network,
     type: RequestLogicTypes.CURRENCY.ERC777,
-    value: '0x745861aed1eee363b4aaa5f1994be40b1e05ff90', //fDAIx
+    value: fDAIx,
   },
-  events: [
-    {
-      actionSigner: {
-        type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
-        value: TestData.payeeRaw.address,
-      },
-      name: RequestLogicTypes.ACTION_NAME.CREATE,
-      parameters: {
-        expectedAmount: '123400000000000000',
-        extensionsDataLength: 0,
-        isSignedRequest: false,
-      },
-      timestamp: arbitraryTimestamp,
-    },
-  ],
-  expectedAmount: TestData.arbitraryExpectedAmount,
-  extensions: {},
-  extensionsData: [],
   payee: {
     type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
     value: TestData.payeeRaw.address,
@@ -186,134 +172,64 @@ export const requestStateNoExtensions: RequestLogicTypes.IRequest = {
     type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
     value: TestData.payerRaw.address,
   },
+  expectedAmount: TestData.arbitraryExpectedAmount,
   requestId: TestData.requestIdMock,
   state: RequestLogicTypes.STATE.CREATED,
   timestamp: TestData.arbitraryTimestamp,
-  version: '0.1.0',
+  version,
+};
+
+const baseRequestEvent = {
+  actionSigner: {
+    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
+    value: TestData.payeeRaw.address,
+  },
+  name: RequestLogicTypes.ACTION_NAME.CREATE,
+  parameters: {
+    expectedAmount: '123400000000000000',
+    extensionsDataLength: 0,
+    isSignedRequest: false,
+  },
+  timestamp: arbitraryTimestamp,
+};
+
+export const requestStateNoExtensions: RequestLogicTypes.IRequest = {
+  ...baseRequestState,
+  events: [
+    {
+      ...baseRequestEvent,
+    },
+  ],
+  extensions: {},
+  extensionsData: [],
 };
 
 export const requestFullStateCreated: RequestLogicTypes.IRequest = {
-  creator: {
-    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
-    value: TestData.payeeRaw.address,
-  },
-  currency: {
-    network: 'rinkeby',
-    type: RequestLogicTypes.CURRENCY.ERC777,
-    value: '0x745861aed1eee363b4aaa5f1994be40b1e05ff90', //fDAIx
-  },
+  ...baseRequestState,
   events: [
     {
-      actionSigner: {
-        type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
-        value: TestData.payeeRaw.address,
-      },
-      name: RequestLogicTypes.ACTION_NAME.CREATE,
+      ...baseRequestEvent,
       parameters: {
-        expectedAmount: '123400000000000000',
+        ...baseRequestEvent.parameters,
         extensionsDataLength: 1,
-        isSignedRequest: false,
       },
-      timestamp: arbitraryTimestamp,
     },
   ],
-  expectedAmount: TestData.arbitraryExpectedAmount,
   extensions: extensionFullState,
   extensionsData: [actionCreationFull],
-  payee: {
-    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
-    value: TestData.payeeRaw.address,
-  },
-  payer: {
-    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
-    value: TestData.payerRaw.address,
-  },
-  requestId: TestData.requestIdMock,
-  state: RequestLogicTypes.STATE.CREATED,
-  timestamp: TestData.arbitraryTimestamp,
-  version: '0.1.0',
-};
-
-export const subsequentRequestFullStateCreated: RequestLogicTypes.IRequest = {
-  creator: {
-    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
-    value: TestData.payeeRaw.address,
-  },
-  currency: {
-    network: 'rinkeby',
-    type: RequestLogicTypes.CURRENCY.ERC777,
-    value: '0x745861aed1eee363b4aaa5f1994be40b1e05ff90', //fDAIx
-  },
-  events: [
-    {
-      actionSigner: {
-        type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
-        value: TestData.payeeRaw.address,
-      },
-      name: RequestLogicTypes.ACTION_NAME.CREATE,
-      parameters: {
-        expectedAmount: '123400000000000000',
-        extensionsDataLength: 1,
-        isSignedRequest: false,
-      },
-      timestamp: arbitraryTimestamp,
-    },
-  ],
-  expectedAmount: TestData.arbitraryExpectedAmount,
-  extensions: extensionFullStateSubsequent,
-  extensionsData: [actionCreationFull],
-  payee: {
-    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
-    value: TestData.payeeRaw.address,
-  },
-  payer: {
-    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
-    value: TestData.payerRaw.address,
-  },
-  requestId: TestData.requestIdMock,
-  state: RequestLogicTypes.STATE.CREATED,
-  timestamp: TestData.arbitraryTimestamp,
-  version: '0.1.0',
 };
 
 export const requestStateCreatedEmpty: RequestLogicTypes.IRequest = {
-  creator: {
-    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
-    value: TestData.payeeRaw.address,
-  },
-  currency: {
-    network: 'rinkeby',
-    type: RequestLogicTypes.CURRENCY.ERC777,
-    value: '0x745861aed1eee363b4aaa5f1994be40b1e05ff90', //fDAIx
-  },
+  ...baseRequestState,
   events: [
     {
-      actionSigner: {
-        type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
-        value: TestData.payeeRaw.address,
-      },
-      name: RequestLogicTypes.ACTION_NAME.CREATE,
+      ...baseRequestEvent,
       parameters: {
-        expectedAmount: '123400000000000000',
+        ...baseRequestEvent.parameters,
         extensionsDataLength: 1,
-        isSignedRequest: false,
       },
-      timestamp: arbitraryTimestamp,
     },
   ],
-  expectedAmount: TestData.arbitraryExpectedAmount,
   extensions: extensionStateCreatedEmpty,
   extensionsData: [actionCreationEmpty],
-  payee: {
-    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
-    value: TestData.payeeRaw.address,
-  },
-  payer: {
-    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
-    value: TestData.payerRaw.address,
-  },
-  requestId: TestData.requestIdMock,
-  state: RequestLogicTypes.STATE.CREATED,
-  timestamp: TestData.arbitraryTimestamp,
-  version: '0.1.0',
 };

--- a/packages/types/src/extensions/pn-any-stream-reference-based-types.ts
+++ b/packages/types/src/extensions/pn-any-stream-reference-based-types.ts
@@ -6,10 +6,23 @@ export {
 } from './pn-any-reference-based-types';
 
 /** Parameters for the creation action */
-export interface ICreationParameters extends Partial<PnReferenceBased.ICreationParameters> {
-  expectedFlowRate?: string;
-  expectedStartDate?: string;
-  previousRequestId?: string;
-  masterRequestId?: string;
-  recurrenceNumber?: number;
+export type ICreationParameters =
+  | IMasterRequestCreationParameters
+  | ISubsequentRequestCreationParameters;
+
+/** Parameters for the creation action of the first request of a series */
+export interface IMasterRequestCreationParameters extends PnReferenceBased.ICreationParameters {
+  expectedFlowRate: string;
+  expectedStartDate: string;
+}
+
+/** Parameters for the creation action of other requests of a series */
+export interface ISubsequentRequestCreationParameters
+  extends Partial<PnReferenceBased.ICreationParameters> {
+  /* requestId of the previous request in the series */
+  previousRequestId: string;
+  /* requestId of the first request of the series */
+  masterRequestId: string;
+  /* rank of the request in the series */
+  recurrenceNumber: number;
 }

--- a/packages/types/src/extensions/pn-any-stream-reference-based-types.ts
+++ b/packages/types/src/extensions/pn-any-stream-reference-based-types.ts
@@ -6,7 +6,10 @@ export {
 } from './pn-any-reference-based-types';
 
 /** Parameters for the creation action */
-export interface ICreationParameters extends PnReferenceBased.ICreationParameters {
-  expectedFlowRate: string;
-  expectedStartDate: string;
+export interface ICreationParameters extends Partial<PnReferenceBased.ICreationParameters> {
+  expectedFlowRate?: string;
+  expectedStartDate?: string;
+  previousRequestId?: string;
+  masterRequestId?: string;
+  recurrenceNumber?: string;
 }

--- a/packages/types/src/extensions/pn-any-stream-reference-based-types.ts
+++ b/packages/types/src/extensions/pn-any-stream-reference-based-types.ts
@@ -11,5 +11,5 @@ export interface ICreationParameters extends Partial<PnReferenceBased.ICreationP
   expectedStartDate?: string;
   previousRequestId?: string;
   masterRequestId?: string;
-  recurrenceNumber?: string;
+  recurrenceNumber?: number;
 }

--- a/packages/types/src/utils.ts
+++ b/packages/types/src/utils.ts
@@ -1,4 +1,9 @@
 import { PaymentTypes } from '.';
+import {
+  ICreationParameters,
+  IMasterRequestCreationParameters,
+  ISubsequentRequestCreationParameters,
+} from './extensions/pn-any-stream-reference-based-types';
 
 /**
  * Types a value like ExtensionType into a paymentNetworkID enum element if possible
@@ -13,3 +18,23 @@ export function isPaymentNetworkId(value: any): value is PaymentTypes.PAYMENT_NE
 
   return false;
 }
+
+/**
+ * Types the creation parameters as IMasterRequestCreationParameters if it satisfies the condition
+ * @param parameters to test
+ */
+export const isMasterRequestCreationParameters = (
+  parameters: ICreationParameters,
+): parameters is IMasterRequestCreationParameters => {
+  return Object.keys(parameters).includes('expectedFlowRate');
+};
+
+/**
+ * Types the creation parameters as ISubsequentRequestCreationParameters if it satisfies the condition
+ * @param parameters to test
+ */
+export const isSubsequentRequestCreationParameters = (
+  parameters: ICreationParameters,
+): parameters is ISubsequentRequestCreationParameters => {
+  return Object.keys(parameters).includes('masterRequestId');
+};


### PR DESCRIPTION
This PR manages the creation of subsequent requests. 

The parameters for a subsequent request are:
- The `requestId` of the master request,
- The `requestId` of the previous request,
- The rank of the request in the series.

[Miro board associated](https://miro.com/app/board/uXjVOgVrEzY=/)

_Terminology:_
**master request**: first request of a series.
**subsequent request**: other requests of a series.