### PR TITLE
fix(payment-processor): within tests - revoke some approvals and use equalTo instead of eq

### DIFF
--- a/packages/payment-processor/test/payment/erc20-batch-proxy.test.ts
+++ b/packages/payment-processor/test/payment/erc20-batch-proxy.test.ts
@@ -264,28 +264,21 @@ const testSuite = (
           const balanceErc20After2 = await getErc20Balance(request2, wallet.address, provider);
           const feeBalanceErc20After2 = await getErc20Balance(request2, feeAddress, provider);
           // compare request 2 balances
-          expect(
-            BigNumber.from(balanceErc20After2).eq(
-              BigNumber.from(balanceErc20Before2).sub(amount + (2 + 10)),
-            ),
+          expect(BigNumber.from(balanceErc20After2)).toEqual(
+            BigNumber.from(balanceErc20Before2).sub(amount + (2 + 10)),
           );
-          expect(
-            BigNumber.from(feeBalanceErc20After2).eq(
-              BigNumber.from(feeBalanceErc20Before2).add(2 + 10),
-            ),
+
+          expect(BigNumber.from(feeBalanceErc20After2)).toEqual(
+            BigNumber.from(feeBalanceErc20Before2).add(2 + 10),
           );
         }
 
         // compare request 1 balances
-        expect(
-          BigNumber.from(balanceErc20After).eq(
-            BigNumber.from(balanceErc20Before).sub(amount + feeAmount),
-          ),
+        expect(BigNumber.from(balanceErc20After)).toEqual(
+          BigNumber.from(balanceErc20Before).sub(amount + feeAmount),
         );
-        expect(
-          BigNumber.from(feeBalanceErc20After).eq(
-            BigNumber.from(feeBalanceErc20Before).add(feeAmount),
-          ),
+        expect(BigNumber.from(feeBalanceErc20After)).toEqual(
+          BigNumber.from(feeBalanceErc20Before).add(feeAmount),
         );
       });
     });

--- a/packages/payment-processor/test/payment/erc20-escrow-payment.test.ts
+++ b/packages/payment-processor/test/payment/erc20-escrow-payment.test.ts
@@ -194,11 +194,15 @@ describe('erc20-escrow-payment tests:', () => {
         const feeAfterBalance = await getErc20Balance(request, feeAddress);
 
         // Expect payer ERC20 balance should be lower.
-        expect(BigNumber.from(payerAfterBalance).eq(BigNumber.from(payerBeforeBalance).sub(102)));
+        expect(BigNumber.from(payerAfterBalance)).toEqual(
+          BigNumber.from(payerBeforeBalance).sub(102),
+        );
         // Expect fee ERC20 balance should be higher.
-        expect(BigNumber.from(feeAfterBalance).eq(BigNumber.from(feeBeforeBalance).add(2)));
+        expect(BigNumber.from(feeAfterBalance)).toEqual(BigNumber.from(feeBeforeBalance).add(2));
         // Expect escrow Erc20 balance should be higher.
-        expect(BigNumber.from(escrowAfterBalance).eq(BigNumber.from(escrowBeforeBalance).add(100)));
+        expect(BigNumber.from(escrowAfterBalance)).toEqual(
+          BigNumber.from(escrowBeforeBalance).add(100),
+        );
       });
       it('Should withdraw funds and pay funds from escrow to payee', async () => {
         // Set a new requestID to test independent unit-tests.
@@ -219,9 +223,13 @@ describe('erc20-escrow-payment tests:', () => {
         const escrowAfterBalance = await getErc20Balance(request, escrowAddress);
 
         // Expect escrow Erc20 balance should be lower.
-        expect(BigNumber.from(escrowAfterBalance).eq(BigNumber.from(escrowBeforeBalance).sub(100)));
+        expect(BigNumber.from(escrowAfterBalance)).toEqual(
+          BigNumber.from(escrowBeforeBalance).sub(100),
+        );
         // Expect payee ERC20 balance should be higher.
-        expect(BigNumber.from(payeeAfterBalance).eq(BigNumber.from(payeeBeforeBalance).add(100)));
+        expect(BigNumber.from(payeeAfterBalance)).toEqual(
+          BigNumber.from(payeeBeforeBalance).add(100),
+        );
       });
     });
 

--- a/packages/payment-processor/test/payment/erc20.test.ts
+++ b/packages/payment-processor/test/payment/erc20.test.ts
@@ -14,15 +14,24 @@ import {
   hasErc20Approval,
   checkErc20Allowance,
 } from '../../src/payment/erc20';
+import {
+  getProxyAddress,
+  revokeErc20Approval,
+} from '@requestnetwork/payment-processor/src/payment/utils';
+import { Erc20PaymentNetwork } from '@requestnetwork/payment-detection';
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 const erc20ContractAddress = '0x9FBDa871d559710256a2502A2517b794B482Db40';
 const paymentAddress = '0xf17f52151EbEF6C7334FAD080c5704D77216b732';
 const feeAddress = '0xC5fdf4076b8F3A5357c5E395ab970B5B54098Fef';
+const feeProxyAddress = erc20FeeProxyArtifact.getAddress('private');
 const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
 const provider = new providers.JsonRpcProvider('http://localhost:8545');
 const wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
+const otherWallet = new Wallet(
+  '0x8d5366123cb560bb606379f90a0bfd4769eecc0557f1b362dcae9012b548b1e5',
+).connect(provider);
 
 const erc20FeeProxyRequest: ClientTypes.IRequestData = {
   balance: {
@@ -111,6 +120,19 @@ const erc20ProxyRequest: ClientTypes.IRequestData = {
 };
 
 describe('hasErc20approval & approveErc20', () => {
+  beforeAll(async () => {
+    // revoke erc20FeeProxy approval
+    await revokeErc20Approval(feeProxyAddress, erc20ContractAddress, otherWallet);
+    // revoke erc20Proxy approval
+    await revokeErc20Approval(
+      getProxyAddress(
+        erc20ProxyRequest,
+        Erc20PaymentNetwork.ERC20ProxyPaymentDetector.getDeploymentInformation,
+      ),
+      erc20ContractAddress,
+      otherWallet,
+    );
+  });
   describe('ERC20 fee proxy payment network', () => {
     it('should consider override parameters', async () => {
       const spy = jest.fn();
@@ -128,19 +150,12 @@ describe('hasErc20approval & approveErc20', () => {
       wallet.sendTransaction = originalSendTransaction;
     });
     it('can check and approve', async () => {
-      // use another address so it doesn't mess with other tests.
-      const otherWallet = new Wallet(
-        '0x8d5366123cb560bb606379f90a0bfd4769eecc0557f1b362dcae9012b548b1e5',
-      ).connect(provider);
-      const feeProxyAddres = erc20FeeProxyArtifact.getAddress('private');
       let hasApproval = await hasErc20Approval(erc20FeeProxyRequest, otherWallet.address, provider);
-      // Warning: this test can run only once!
-      // 'already has approval'
       expect(hasApproval).toBe(false);
       expect(
         await checkErc20Allowance(
           otherWallet.address,
-          feeProxyAddres,
+          feeProxyAddress,
           provider,
           erc20ContractAddress,
           1,
@@ -153,7 +168,7 @@ describe('hasErc20approval & approveErc20', () => {
       expect(
         await checkErc20Allowance(
           otherWallet.address,
-          feeProxyAddres,
+          feeProxyAddress,
           provider,
           erc20ContractAddress,
           1,
@@ -179,13 +194,7 @@ describe('hasErc20approval & approveErc20', () => {
       wallet.sendTransaction = originalSendTransaction;
     });
     it('can check and approve', async () => {
-      // use another address so it doesn't mess with other tests.
-      const otherWallet = new Wallet(
-        '0x8d5366123cb560bb606379f90a0bfd4769eecc0557f1b362dcae9012b548b1e5',
-      ).connect(provider);
       let hasApproval = await hasErc20Approval(erc20ProxyRequest, otherWallet.address, provider);
-      // Warning: this test can run only once!
-      // 'already has approval'
       expect(hasApproval).toBe(false);
       await approveErc20(erc20ProxyRequest, otherWallet);
       hasApproval = await hasErc20Approval(erc20ProxyRequest, otherWallet.address, provider);

--- a/packages/payment-processor/test/payment/erc20.test.ts
+++ b/packages/payment-processor/test/payment/erc20.test.ts
@@ -14,10 +14,7 @@ import {
   hasErc20Approval,
   checkErc20Allowance,
 } from '../../src/payment/erc20';
-import {
-  getProxyAddress,
-  revokeErc20Approval,
-} from '@requestnetwork/payment-processor/src/payment/utils';
+import { getProxyAddress, revokeErc20Approval } from '../../src/payment/utils';
 import { Erc20PaymentNetwork } from '@requestnetwork/payment-detection';
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */

--- a/packages/payment-processor/test/payment/eth-input-data.test.ts
+++ b/packages/payment-processor/test/payment/eth-input-data.test.ts
@@ -124,7 +124,12 @@ describe('payEthInputDataRequest', () => {
     expect(confirmedTx.status).toBe(1);
     // new_balance = old_balance + amount + fees
     expect(balanceAfter).toEqual(
-      balanceBefore.sub(validRequest.expectedAmount).sub(confirmedTx.gasUsed || 0),
+      balanceBefore
+        .sub(validRequest.expectedAmount)
+        .sub(confirmedTx.gasUsed.mul(2 * 10 ** 10) || 0),
+    );
+    expect(
+      balanceAfter.eq(balanceBefore.sub(validRequest.expectedAmount).sub(confirmedTx.gasUsed || 0)),
     );
   });
 });

--- a/packages/payment-processor/test/payment/eth-input-data.test.ts
+++ b/packages/payment-processor/test/payment/eth-input-data.test.ts
@@ -123,8 +123,8 @@ describe('payEthInputDataRequest', () => {
     const balanceAfter = await wallet.getBalance();
     expect(confirmedTx.status).toBe(1);
     // new_balance = old_balance + amount + fees
-    expect(
-      balanceAfter.eq(balanceBefore.sub(validRequest.expectedAmount).sub(confirmedTx.gasUsed || 0)),
+    expect(balanceAfter).toEqual(
+      balanceBefore.sub(validRequest.expectedAmount).sub(confirmedTx.gasUsed || 0),
     );
   });
 });

--- a/packages/payment-processor/test/payment/swap-erc20-fee-proxy.test.ts
+++ b/packages/payment-processor/test/payment/swap-erc20-fee-proxy.test.ts
@@ -13,6 +13,8 @@ import { getErc20Balance } from '../../src/payment/erc20';
 import { approveErc20ForSwapToPayIfNeeded } from '../../src/payment/swap-erc20';
 import { ERC20__factory } from '@requestnetwork/smart-contracts/types';
 import { ISwapSettings, swapErc20FeeProxyRequest } from '../../src/payment/swap-erc20-fee-proxy';
+import { erc20SwapToPayArtifact } from '@requestnetwork/smart-contracts';
+import { revokeErc20Approval } from '@requestnetwork/payment-processor/src/payment/utils';
 
 /* eslint-disable no-magic-numbers */
 /* eslint-disable @typescript-eslint/no-unused-expressions */
@@ -78,6 +80,14 @@ const validSwapSettings: ISwapSettings = {
 
 describe('swap-erc20-fee-proxy', () => {
   describe('encodeSwapErc20FeeRequest', () => {
+    beforeAll(async () => {
+      // revoke erc20SwapToPay approval
+      await revokeErc20Approval(
+        erc20SwapToPayArtifact.getAddress(validRequest.currencyInfo.network!),
+        alphaErc20Address,
+        wallet.provider,
+      );
+    });
     it('should throw an error if the request is not erc20', async () => {
       const request = Utils.deepCopy(validRequest) as ClientTypes.IRequestData;
       request.currencyInfo.type = RequestLogicTypes.CURRENCY.ETH;

--- a/packages/payment-processor/test/payment/swap-erc20-fee-proxy.test.ts
+++ b/packages/payment-processor/test/payment/swap-erc20-fee-proxy.test.ts
@@ -14,7 +14,7 @@ import { approveErc20ForSwapToPayIfNeeded } from '../../src/payment/swap-erc20';
 import { ERC20__factory } from '@requestnetwork/smart-contracts/types';
 import { ISwapSettings, swapErc20FeeProxyRequest } from '../../src/payment/swap-erc20-fee-proxy';
 import { erc20SwapToPayArtifact } from '@requestnetwork/smart-contracts';
-import { revokeErc20Approval } from '@requestnetwork/payment-processor/src/payment/utils';
+import { revokeErc20Approval } from '../../src/payment/utils';
 
 /* eslint-disable no-magic-numbers */
 /* eslint-disable @typescript-eslint/no-unused-expressions */


### PR DESCRIPTION
- revoke approvals for two old tests
- use .equalTo instead of .eq -> the tests were not working (correct one test also)