### PR TITLE
feat: add streamEventName to streaming event parameters

### DIFF
--- a/packages/payment-detection/src/erc777/superfluid-retriever.ts
+++ b/packages/payment-detection/src/erc777/superfluid-retriever.ts
@@ -81,17 +81,14 @@ export class SuperFluidInfoRetriever {
     const TYPE_BEGIN = 0;
     // const TYPE_UPDATE = 1;
     const TYPE_END = 2;
-
+    const StreamEventMap: Record<number, PaymentTypes.STREAM_EVENT_NAMES> = {
+      0: PaymentTypes.STREAM_EVENT_NAMES.START_STREAM,
+      1: PaymentTypes.STREAM_EVENT_NAMES.UPDATE_STREAM,
+      2: PaymentTypes.STREAM_EVENT_NAMES.END_STREAM,
+    };
     const getEventName = (flowEvent: Partial<FlowUpdatedEvent>) => {
-      switch (flowEvent && flowEvent.type) {
-        case 0:
-          return PaymentTypes.STREAM_EVENT_NAMES.START_STREAM;
-        case 1:
-          return PaymentTypes.STREAM_EVENT_NAMES.UPDATE_STREAM;
-        case 2:
-          return PaymentTypes.STREAM_EVENT_NAMES.END_STREAM;
-        default:
-          return;
+      if (flowEvent.type) {
+        return StreamEventMap[flowEvent.type];
       }
     };
 

--- a/packages/payment-detection/src/erc777/superfluid-retriever.ts
+++ b/packages/payment-detection/src/erc777/superfluid-retriever.ts
@@ -44,7 +44,7 @@ export class SuperFluidInfoRetriever {
     };
   }
 
-  public async getStreamingEvents(): Promise<Partial<FlowUpdatedEvent>[]> {
+  public async getStreamingEvents(): Promise<PaymentTypes.ERC777StreamEventParameters[]> {
     const variables = this.getGraphVariables();
     const { flow, untagged } = await this.client.GetSuperFluidEvents(variables);
     // Chronological sorting of events having payment reference and closing events without payment reference
@@ -70,7 +70,7 @@ export class SuperFluidInfoRetriever {
         oldFlowRate: streamEvents[streamEvents.length - 1].flowRate,
         flowRate: 0,
         timestamp: Utils.getCurrentTimestampInSecond(),
-        blockNumber: parseInt(streamEvents[streamEvents.length - 1].blockNumber),
+        blockNumber: parseInt(streamEvents[streamEvents.length - 1].blockNumber.toString()),
         transactionHash: streamEvents[streamEvents.length - 1].transactionHash,
       } as FlowUpdatedEvent);
     }
@@ -99,7 +99,7 @@ export class SuperFluidInfoRetriever {
         name: this.eventName,
         parameters: {
           to: this.toAddress,
-          block: parseInt(streamEvents[index].blockNumber),
+          block: parseInt(streamEvents[index].blockNumber.toString()),
           txHash: streamEvents[index].transactionHash,
         },
         timestamp: streamEvents[index].timestamp,

--- a/packages/payment-detection/src/erc777/superfluid-retriever.ts
+++ b/packages/payment-detection/src/erc777/superfluid-retriever.ts
@@ -73,7 +73,7 @@ export class SuperFluidInfoRetriever {
         oldFlowRate: streamEvents[streamEvents.length - 1].flowRate,
         flowRate: 0,
         timestamp: Utils.getCurrentTimestampInSecond(),
-        blockNumber: parseInt(streamEvents[streamEvents.length - 1].blockNumber.toString()),
+        blockNumber: streamEvents[streamEvents.length - 1].blockNumber,
         transactionHash: streamEvents[streamEvents.length - 1].transactionHash,
       } as FlowUpdatedEvent);
     }
@@ -102,7 +102,7 @@ export class SuperFluidInfoRetriever {
         name: this.eventName,
         parameters: {
           to: this.toAddress,
-          block: parseInt(streamEvents[index].blockNumber.toString()),
+          block: streamEvents[index].blockNumber,
           txHash: streamEvents[index].transactionHash,
         },
         timestamp: streamEvents[index].timestamp,

--- a/packages/payment-detection/src/erc777/superfluid-retriever.ts
+++ b/packages/payment-detection/src/erc777/superfluid-retriever.ts
@@ -44,10 +44,13 @@ export class SuperFluidInfoRetriever {
     };
   }
 
+  /**
+   * Chronological sorting of events having payment reference and closing events without payment reference
+   * @returns List of streaming events
+   */
   public async getStreamingEvents(): Promise<PaymentTypes.ERC777StreamEventParameters[]> {
     const variables = this.getGraphVariables();
     const { flow, untagged } = await this.client.GetSuperFluidEvents(variables);
-    // Chronological sorting of events having payment reference and closing events without payment reference
     return flow.concat(untagged).sort((a, b) => a.timestamp - b.timestamp);
   }
 

--- a/packages/payment-detection/src/index.ts
+++ b/packages/payment-detection/src/index.ts
@@ -20,6 +20,7 @@ import { NearNativeTokenPaymentDetector } from './near-detector';
 import { FeeReferenceBasedDetector } from './fee-reference-based-detector';
 import { SuperFluidPaymentDetector } from './erc777/superfluid-detector';
 import { EscrowERC20InfoRetriever } from './erc20/escrow-info-retriever';
+import { SuperFluidInfoRetriever } from './erc777/superfluid-retriever';
 
 export type { TheGraphClient } from './thegraph';
 
@@ -37,6 +38,7 @@ export {
   SuperFluidPaymentDetector,
   NearNativeTokenPaymentDetector,
   EscrowERC20InfoRetriever,
+  SuperFluidInfoRetriever,
   setProviderFactory,
   initPaymentDetectionApiKeys,
   getDefaultProvider,

--- a/packages/payment-detection/test/erc777/superfluid-retriever.test.ts
+++ b/packages/payment-detection/test/erc777/superfluid-retriever.test.ts
@@ -93,6 +93,37 @@ const testSuiteWithDaix = (network: string, fDAIxToken: string) => {
         expect(transferEvents[0].parameters?.to).toEqual(paymentData.to);
       });
     });
+    it('should get streaming events', async () => {
+      const paymentData = {
+        reference: '64d8014e4f767c6b',
+        txHash: '0xe472ca1b52751b058fbdaeaffebd98c0cc43b45aa31794b3eb06834ede19f7be',
+        from: '0x9c040e2d6fd83a8b35069aa7154b69674961e0f7',
+        to: '0x186e7fE6c34Ea0ecA7F9C2Fd29651Fc0443e3F29',
+        network: network,
+        salt: '0ee84db293a752c6',
+        amount: '92592592592592000',
+        requestId: '0188791633ff0ec72a7dbdefb886d2db6cccfa98287320839c2f173c7a4e3ce7e1',
+        block: 9945543,
+        token: fDAIxTokenRinkeby,
+      };
+      graphql.request.mockResolvedValue(mockSuperfluidSubgraph[0]);
+      const graphRetriever = new SuperFluidInfoRetriever(
+        paymentData.reference,
+        paymentData.token,
+        paymentData.to,
+        PaymentTypes.EVENTS_NAMES.PAYMENT,
+        paymentData.network,
+      );
+      const streamEvents = await graphRetriever.getStreamingEvents();
+      expect(streamEvents).toHaveLength(16);
+      expect(streamEvents[0].transactionHash).toEqual(
+        '0x4e334bd4436ad812e30f74b358580cc3bed0407814133147edfb56ad6672bf75',
+      );
+      expect(streamEvents[3].type).toEqual(0);
+      expect(streamEvents[3].transactionHash).toEqual(
+        '0xc331a269515c27836051cc4618097f5f1a1c37f79dcb975361022fe3ecfb5cbf',
+      );
+    });
   });
 };
 

--- a/packages/payment-detection/test/erc777/superfluid-retriever.test.ts
+++ b/packages/payment-detection/test/erc777/superfluid-retriever.test.ts
@@ -54,6 +54,9 @@ const testSuiteWithDaix = (network: string, fDAIxToken: string) => {
         expect(transferEvents[2].amount).toEqual('40509259259259000');
         expect(transferEvents[0].parameters?.txHash).toEqual(paymentData.txHash);
         expect(transferEvents[0].parameters?.block).toEqual(paymentData.block);
+        expect(transferEvents[0].parameters?.streamEventName).toEqual(
+          PaymentTypes.STREAM_EVENT_NAMES.END_STREAM,
+        );
       });
     });
 
@@ -91,38 +94,10 @@ const testSuiteWithDaix = (network: string, fDAIxToken: string) => {
         expect(transferEvents[0].amount).toEqual(paymentData.amount);
         expect(transferEvents[0].name).toEqual('payment');
         expect(transferEvents[0].parameters?.to).toEqual(paymentData.to);
+        expect(transferEvents[0].parameters?.streamEventName).toEqual(
+          PaymentTypes.STREAM_EVENT_NAMES.END_STREAM,
+        );
       });
-    });
-    it('should get streaming events', async () => {
-      const paymentData = {
-        reference: '64d8014e4f767c6b',
-        txHash: '0xe472ca1b52751b058fbdaeaffebd98c0cc43b45aa31794b3eb06834ede19f7be',
-        from: '0x9c040e2d6fd83a8b35069aa7154b69674961e0f7',
-        to: '0x186e7fE6c34Ea0ecA7F9C2Fd29651Fc0443e3F29',
-        network: network,
-        salt: '0ee84db293a752c6',
-        amount: '92592592592592000',
-        requestId: '0188791633ff0ec72a7dbdefb886d2db6cccfa98287320839c2f173c7a4e3ce7e1',
-        block: 9945543,
-        token: fDAIxTokenRinkeby,
-      };
-      graphql.request.mockResolvedValue(mockSuperfluidSubgraph[0]);
-      const graphRetriever = new SuperFluidInfoRetriever(
-        paymentData.reference,
-        paymentData.token,
-        paymentData.to,
-        PaymentTypes.EVENTS_NAMES.PAYMENT,
-        paymentData.network,
-      );
-      const streamEvents = await graphRetriever.getStreamingEvents();
-      expect(streamEvents).toHaveLength(16);
-      expect(streamEvents[0].transactionHash).toEqual(
-        '0x4e334bd4436ad812e30f74b358580cc3bed0407814133147edfb56ad6672bf75',
-      );
-      expect(streamEvents[3].type).toEqual(0);
-      expect(streamEvents[3].transactionHash).toEqual(
-        '0xc331a269515c27836051cc4618097f5f1a1c37f79dcb975361022fe3ecfb5cbf',
-      );
     });
   });
 };

--- a/packages/types/src/payment-types.ts
+++ b/packages/types/src/payment-types.ts
@@ -138,12 +138,18 @@ export interface IPaymentNetworkBaseInfoRetriever<
  * ERC777 networks and events
  */
 
+export enum STREAM_EVENT_NAMES {
+  START_STREAM = 'start_stream',
+  END_STREAM = 'end_stream',
+  UPDATE_STREAM = 'update_stream',
+}
 /** Parameters for events of ERC777 payments */
 export interface IERC777PaymentEventParameters {
   from?: string;
   to: string;
   block?: number;
   txHash?: string;
+  streamEventName?: STREAM_EVENT_NAMES;
 }
 
 /** ERC777 Payment Network Event */
@@ -151,16 +157,6 @@ export type ERC777PaymentNetworkEvent = IPaymentNetworkEvent<IERC777PaymentEvent
 /** ERC777 BalanceWithEvents */
 export type ERC777BalanceWithEvents = IBalanceWithEvents<IERC777PaymentEventParameters>;
 
-/** Parameters for ERC777 streaming events */
-export interface ERC777StreamEventParameters {
-  transactionHash: string;
-  blockNumber: number;
-  timestamp: number;
-  sender: string;
-  flowRate: number;
-  oldFlowRate: number;
-  type: number;
-}
 /**
  * ERC20 networks and events
  */

--- a/packages/types/src/payment-types.ts
+++ b/packages/types/src/payment-types.ts
@@ -151,6 +151,16 @@ export type ERC777PaymentNetworkEvent = IPaymentNetworkEvent<IERC777PaymentEvent
 /** ERC777 BalanceWithEvents */
 export type ERC777BalanceWithEvents = IBalanceWithEvents<IERC777PaymentEventParameters>;
 
+/** Parameters for ERC777 streaming events */
+export interface ERC777StreamEventParameters {
+  transactionHash: string;
+  blockNumber: number;
+  timestamp: number;
+  sender: string;
+  flowRate: number;
+  oldFlowRate: number;
+  type: number;
+}
 /**
  * ERC20 networks and events
  */


### PR DESCRIPTION
## Description of the changes
Adding stream event names to streaming event parameters in the balance object.
The reason for this is that we need to be able to detect stream specific events like start and stop stream in portal for sending notifications and knowing when to stop updating the balance.