### PR TITLE
feat: always return approval and payment transactions

### DIFF
--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -17,7 +17,7 @@ import { payAnyToEthProxyRequest } from './any-to-eth-proxy';
 import { WalletConnection } from 'near-api-js';
 import { isNearNetwork, isNearAccountSolvent } from './utils-near';
 import { ICurrencyManager } from '@requestnetwork/currency';
-import { encodeRequestErc20ApprovalIfNeeded } from './encoder-approval';
+import { encodeRequestErc20Approval } from './encoder-approval';
 import { encodeRequestPayment } from './encoder-payment';
 import { IPreparedTransaction } from './prepared-transaction';
 import { IRequestPaymentOptions } from './settings';
@@ -130,28 +130,18 @@ export async function payRequest(
  * Encode the transactions associated to a request
  * @param request the request to pay.
  * @param signerOrProvider the Web3 provider, or signer. Defaults to window.ethereum.
- * @param from The address which will send the transaction.
  * @param options encoding options
  * @returns
  */
 export async function encodeRequestApprovalAndPayment(
   request: ClientTypes.IRequestData,
   signerOrProvider: providers.Provider,
-  from?: string,
   options?: IRequestPaymentOptions,
 ): Promise<IPreparedTransaction[]> {
   const preparedTransactions: IPreparedTransaction[] = [];
-
-  if (from) {
-    const approvalTx = await encodeRequestErc20ApprovalIfNeeded(
-      request,
-      signerOrProvider,
-      from,
-      options,
-    );
-    if (approvalTx) {
-      preparedTransactions.push(approvalTx);
-    }
+  const approvalTx = await encodeRequestErc20Approval(request, signerOrProvider, options);
+  if (approvalTx) {
+    preparedTransactions.push(approvalTx);
   }
   preparedTransactions.push(encodeRequestPayment(request, signerOrProvider, options));
   return preparedTransactions;

--- a/packages/payment-processor/test/payment/encoder.test.ts
+++ b/packages/payment-processor/test/payment/encoder.test.ts
@@ -225,11 +225,7 @@ beforeAll(async () => {
 
 describe('Encoder', () => {
   it('Should handle ERC20 Proxy request', async () => {
-    const encodedTransactions = await encodeRequestApprovalAndPayment(
-      baseValidRequest,
-      provider,
-      wallet.address,
-    );
+    const encodedTransactions = await encodeRequestApprovalAndPayment(baseValidRequest, provider);
 
     let tx = await wallet.sendTransaction(encodedTransactions[0]);
     let confirmedTx = await tx.wait(1);
@@ -246,7 +242,6 @@ describe('Encoder', () => {
     const encodedTransactions = await encodeRequestApprovalAndPayment(
       validRequestERC20FeeProxy,
       provider,
-      wallet.address,
     );
 
     let tx = await wallet.sendTransaction(encodedTransactions[0]);
@@ -264,7 +259,6 @@ describe('Encoder', () => {
     let encodedTransactions = await encodeRequestApprovalAndPayment(
       validRequestERC20ConversionProxy,
       provider,
-      wallet.address,
       {
         conversion: alphaConversionSettings,
       },
@@ -285,7 +279,6 @@ describe('Encoder', () => {
     let encodedTransactions = await encodeRequestApprovalAndPayment(
       validRequestERC20FeeProxy,
       provider,
-      wallet.address,
       {
         swap: alphaSwapSettings,
       },
@@ -306,7 +299,6 @@ describe('Encoder', () => {
     let encodedTransactions = await encodeRequestApprovalAndPayment(
       validRequestERC20ConversionProxy,
       provider,
-      wallet.address,
       {
         swap: alphaSwapConversionSettings,
         conversion: alphaConversionSettings,
@@ -325,11 +317,7 @@ describe('Encoder', () => {
   });
 
   it('Should handle Eth Proxy request', async () => {
-    let encodedTransactions = await encodeRequestApprovalAndPayment(
-      validRequestEthProxy,
-      provider,
-      wallet.address,
-    );
+    let encodedTransactions = await encodeRequestApprovalAndPayment(validRequestEthProxy, provider);
 
     let tx = await wallet.sendTransaction(encodedTransactions[0]);
     let confirmedTx = await tx.wait(1);
@@ -341,7 +329,6 @@ describe('Encoder', () => {
     let encodedTransactions = await encodeRequestApprovalAndPayment(
       validRequestEthFeeProxy,
       provider,
-      wallet.address,
     );
 
     let tx = await wallet.sendTransaction(encodedTransactions[0]);
@@ -354,7 +341,6 @@ describe('Encoder', () => {
     let encodedTransactions = await encodeRequestApprovalAndPayment(
       validRequestEthConversionProxy,
       provider,
-      wallet.address,
       {
         conversion: ethConversionSettings,
       },


### PR DESCRIPTION
Transaction builder now always returns both approval and payment, without checking for allowance

