### PR TITLE
fix: superfluid balance error

### DIFF
--- a/packages/payment-detection/src/erc777/superfluid-retriever.ts
+++ b/packages/payment-detection/src/erc777/superfluid-retriever.ts
@@ -120,10 +120,12 @@ export class SuperFluidInfoRetriever {
         timestamp: streamEvents[index].timestamp,
       });
     }
-    const newLastParameters = paymentEvents[paymentEvents.length - 1].parameters;
-    if (lastEventOngoing && newLastParameters) {
-      newLastParameters.streamEventName = PaymentTypes.STREAM_EVENT_NAMES.START_STREAM;
-      paymentEvents[paymentEvents.length - 1].parameters = newLastParameters;
+    if (paymentEvents.length > 0) {
+      const newLastParameters = paymentEvents[paymentEvents.length - 1].parameters;
+      if (lastEventOngoing && newLastParameters) {
+        newLastParameters.streamEventName = PaymentTypes.STREAM_EVENT_NAMES.START_STREAM;
+        paymentEvents[paymentEvents.length - 1].parameters = newLastParameters;
+      }
     }
     return paymentEvents;
   }


### PR DESCRIPTION
## Description of the changes

An error occurred in the following situation:
-  No payment events associated to the request
-  Untagged events associated to the stream (`payerAddress`, `payeeAddress`, `paymentCurrency`)