### PR TITLE
fix: NEAR contracts addresses for conversion-native

### DIFF
--- a/packages/payment-detection/src/near/near-conversion-detector.ts
+++ b/packages/payment-detection/src/near/near-conversion-detector.ts
@@ -44,9 +44,8 @@ export class NearConversionNativeTokenPaymentDetector extends AnyToAnyDetector<
   }
 
   public static getContractName = (chainName: string, paymentNetworkVersion = '0.1.0'): string => {
-    const version = NearConversionNativeTokenPaymentDetector.getVersionOrThrow(
-      paymentNetworkVersion,
-    );
+    const version =
+      NearConversionNativeTokenPaymentDetector.getVersionOrThrow(paymentNetworkVersion);
     const versionMap: Record<string, Record<string, string>> = {
       aurora: { '0.1.0': 'native.conversion.reqnetwork.near' },
       'aurora-testnet': {

--- a/packages/payment-detection/src/near/near-conversion-detector.ts
+++ b/packages/payment-detection/src/near/near-conversion-detector.ts
@@ -44,12 +44,13 @@ export class NearConversionNativeTokenPaymentDetector extends AnyToAnyDetector<
   }
 
   public static getContractName = (chainName: string, paymentNetworkVersion = '0.1.0'): string => {
-    const version =
-      NearConversionNativeTokenPaymentDetector.getVersionOrThrow(paymentNetworkVersion);
+    const version = NearConversionNativeTokenPaymentDetector.getVersionOrThrow(
+      paymentNetworkVersion,
+    );
     const versionMap: Record<string, Record<string, string>> = {
-      aurora: { '0.1.0': 'requestnetwork.conversion.near' },
+      aurora: { '0.1.0': 'native.conversion.reqnetwork.near' },
       'aurora-testnet': {
-        '0.1.0': 'dev-xxxxxxx',
+        '0.1.0': 'native.conversion.reqnetwork.testnet',
       },
     };
     if (versionMap[chainName]?.[version]) {

--- a/packages/payment-detection/test/near/near-native-conversion.test.ts
+++ b/packages/payment-detection/test/near/near-native-conversion.test.ts
@@ -102,7 +102,7 @@ describe('Near payments detection', () => {
       requestCurrency,
       paymentReference,
       paymentAddress,
-      'requestnetwork.conversion.near',
+      'native.conversion.mock',
       PaymentTypes.EVENTS_NAMES.PAYMENT,
       'aurora',
     );


### PR DESCRIPTION
## Description of the changes

The NEAR contracts for conversion have been deployed, this PR updates their addresses for payment-detection.
