### PR TITLE
chore: replaced references to chainlink with aggregators

### DIFF
--- a/packages/currency/src/currencyManager.ts
+++ b/packages/currency/src/currencyManager.ts
@@ -15,7 +15,7 @@ import {
   LegacyTokenMap,
   NativeCurrencyType,
 } from './types';
-import { chainlinkCurrencyPairs, CurrencyPairs, getPath } from './chainlink-path-aggregators';
+import { defaultConversionPairs, AggregatorsMap, getPath } from './conversion-aggregators';
 import { isValidNearAddress } from './currency-utils';
 
 const { BTC, ERC20, ERC777, ETH, ISO4217 } = RequestLogicTypes.CURRENCY;
@@ -26,17 +26,18 @@ const { BTC, ERC20, ERC777, ETH, ISO4217 } = RequestLogicTypes.CURRENCY;
 export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta> {
   private readonly knownCurrencies: CurrencyDefinition<TMeta>[];
   private readonly legacyTokens: LegacyTokenMap;
-  private readonly conversionPairs: Record<string, CurrencyPairs>;
+  private readonly conversionPairs: AggregatorsMap;
 
   /**
    *
    * @param inputCurrencies The list of currencies known by the Manager.
    * @param legacyTokens A mapping of legacy currency name or network name, in the format { "chainName": {"TOKEN": ["NEW_TOKEN","NEW_CHAIN"]}}
+   * @param conversionPairs A mapping of possible conversions by network (network => currencyFrom => currencyTo => cost)
    */
   constructor(
     inputCurrencies: (CurrencyInput & { id?: string; meta?: TMeta })[],
     legacyTokens?: LegacyTokenMap,
-    conversionPairs?: Record<string, CurrencyPairs>,
+    conversionPairs?: AggregatorsMap,
   ) {
     this.knownCurrencies = [];
     for (const input of inputCurrencies) {
@@ -294,8 +295,8 @@ export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta>
     };
   }
 
-  static getDefaultConversionPairs(): Record<string, CurrencyPairs> {
-    return chainlinkCurrencyPairs;
+  static getDefaultConversionPairs(): AggregatorsMap {
+    return defaultConversionPairs;
   }
 
   /**

--- a/packages/currency/src/index.ts
+++ b/packages/currency/src/index.ts
@@ -1,9 +1,6 @@
 export { getSupportedERC20Tokens } from './erc20';
 export { getSupportedERC777Tokens } from './erc777';
-export {
-  chainlinkSupportedNetworks as conversionSupportedNetworks,
-  CurrencyPairs,
-} from './chainlink-path-aggregators';
+export { conversionSupportedNetworks, CurrencyPairs } from './conversion-aggregators';
 export { getHash as getCurrencyHash } from './getHash';
 export { CurrencyManager } from './currencyManager';
 export * from './types';

--- a/packages/currency/test/chainlink-path-aggregators.test.ts
+++ b/packages/currency/test/chainlink-path-aggregators.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { CurrencyPairs, getPath } from '../src/chainlink-path-aggregators';
+import { CurrencyPairs, getPath } from '../src/conversion-aggregators';
 import { CurrencyManager } from '../src';
 const currencyManager = CurrencyManager.getDefault();
 const USD = currencyManager.from('USD')!;

--- a/packages/toolbox/src/chainlinkConversionPathTools.ts
+++ b/packages/toolbox/src/chainlinkConversionPathTools.ts
@@ -178,7 +178,7 @@ export const listAggregators = async (options?: IOptions): Promise<void> => {
   // enables this usage:  yarn -s chainlinkPath mainnet  | clip
   console.error('#####################################################################');
   console.error('All aggregators nodes (currency) :');
-  console.error('../currency/src/chainlink-path-aggregators.ts');
+  console.error('../currency/src/conversion-aggregators.ts');
   console.log(JSON.stringify(aggregatorsNodesForDijkstra, null, 2));
 };
 

--- a/packages/toolbox/src/commands/chainlink/addAggregators.ts
+++ b/packages/toolbox/src/commands/chainlink/addAggregators.ts
@@ -75,8 +75,8 @@ export const handler = async (args: Options): Promise<void> => {
 
   if (!conversionSupportedNetworks.includes(network)) {
     console.warn(
-      `WARNING: ${network} is missing in chainlinkSupportedNetworks from the Currency package.`,
-      `Add '${network}: {}' to chainlinkCurrencyPairs, in currency/src/chainlink-path-aggregators.ts.`,
+      `WARNING: ${network} is missing in conversionSupportedNetworks from the Currency package.`,
+      `Add '${network}: {}' to chainlinkCurrencyPairs, in currency/src/conversion-aggregators.ts.`,
     );
   }
 


### PR DESCRIPTION
## Description of the changes

There were references to Chainlink where we support other aggregation providers (Flux Oracles).