### PR TITLE
chore(currency): export AggregatorsMap

### DIFF
--- a/packages/currency/src/index.ts
+++ b/packages/currency/src/index.ts
@@ -1,6 +1,10 @@
 export { getSupportedERC20Tokens } from './erc20';
 export { getSupportedERC777Tokens } from './erc777';
-export { conversionSupportedNetworks, CurrencyPairs } from './conversion-aggregators';
+export {
+  conversionSupportedNetworks,
+  CurrencyPairs,
+  AggregatorsMap,
+} from './conversion-aggregators';
 export { getHash as getCurrencyHash } from './getHash';
 export { CurrencyManager } from './currencyManager';
 export * from './types';

--- a/packages/currency/test/chainlink-path-aggregators.test.ts
+++ b/packages/currency/test/chainlink-path-aggregators.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { CurrencyPairs, getPath } from '../src/conversion-aggregators';
+import { AggregatorsMap, getPath } from '../src/conversion-aggregators';
 import { CurrencyManager } from '../src';
 const currencyManager = CurrencyManager.getDefault();
 const USD = currencyManager.from('USD')!;
@@ -8,7 +8,7 @@ const EUR = currencyManager.from('EUR')!;
 const fakeDAI = { hash: '0x38cf23c52bb4b13f051aec09580a2de845a7fa35' };
 
 describe('getPath', () => {
-  const mockAggregatorPaths: Record<string, CurrencyPairs> = {
+  const mockAggregatorPaths: AggregatorsMap = {
     private: {
       [fakeDAI.hash]: {
         [USD.hash]: 1,

--- a/packages/toolbox/src/commands/chainlink/aggregatorsUtils.ts
+++ b/packages/toolbox/src/commands/chainlink/aggregatorsUtils.ts
@@ -1,4 +1,4 @@
-import { CurrencyManager, CurrencyInput, CurrencyPairs } from '@requestnetwork/currency';
+import { CurrencyManager, CurrencyInput, AggregatorsMap } from '@requestnetwork/currency';
 import axios from 'axios';
 import { RequestLogicTypes } from '@requestnetwork/types';
 
@@ -93,7 +93,7 @@ const loadCurrencyApi = async <T>(path: string): Promise<T> => {
 };
 
 export const getCurrencyManager = async (list?: string): Promise<CurrencyManager> => {
-  const aggregators = await loadCurrencyApi<Record<string, CurrencyPairs>>('/aggregators');
+  const aggregators = await loadCurrencyApi<AggregatorsMap>('/aggregators');
   const currencyList = list
     ? await loadCurrencyApi<CurrencyInput[]>(`/list/${list}`)
     : CurrencyManager.getDefaultList();


### PR DESCRIPTION
## Description of the changes
AggregatorsMap is used by CurrencyManager constructor, so it should be exported.