### PR TITLE
chore: correcting Near network naming

### DIFF
--- a/packages/advanced-logic/package.json
+++ b/packages/advanced-logic/package.json
@@ -44,8 +44,8 @@
     "@requestnetwork/utils": "0.35.0",
     "@types/node": "14.14.16",
     "lodash": "4.17.21",
-    "tslib": "2.3.1",
-    "semver": "5.6.0"
+    "semver": "5.6.0",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
     "@types/jest": "26.0.13",

--- a/packages/advanced-logic/package.json
+++ b/packages/advanced-logic/package.json
@@ -44,7 +44,8 @@
     "@requestnetwork/utils": "0.35.0",
     "@types/node": "14.14.16",
     "lodash": "4.17.21",
-    "tslib": "2.3.1"
+    "tslib": "2.3.1",
+    "semver": "5.6.0"
   },
   "devDependencies": {
     "@types/jest": "26.0.13",

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-near.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-near.ts
@@ -4,7 +4,7 @@ import { UnsupportedNetworkError } from './address-based';
 import AnyToNativeTokenPaymentNetwork from './any-to-native';
 import * as Semver from 'semver';
 
-const CURRENT_VERSION = '0.2.0';
+const CURRENT_VERSION = '0.1.0';
 const supportedNetworksLegacy = ['aurora', 'aurora-testnet'];
 const supportedNetworks = ['near', 'near-testnet'];
 
@@ -14,10 +14,11 @@ export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetw
     extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_NATIVE_TOKEN,
     currentVersion: string = CURRENT_VERSION,
   ) {
-    const supportedNetworksForVersion = Semver.lt(currentVersion, CURRENT_VERSION)
-      ? supportedNetworksLegacy
-      : supportedNetworks;
-    super(extensionId, currentVersion, supportedNetworksForVersion);
+    super(
+      extensionId,
+      currentVersion,
+      Semver.lt(currentVersion, '0.2.0') ? supportedNetworksLegacy : supportedNetworks,
+    );
   }
 
   /**

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-near.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-near.ts
@@ -2,9 +2,11 @@ import { ICurrencyManager, UnsupportedCurrencyError } from '@requestnetwork/curr
 import { ExtensionTypes, IdentityTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { UnsupportedNetworkError } from './address-based';
 import AnyToNativeTokenPaymentNetwork from './any-to-native';
+import * as Semver from 'semver';
 
-const CURRENT_VERSION = '0.1.0';
-const supportedNetworks = ['aurora', 'aurora-testnet'];
+const CURRENT_VERSION = '0.2.0';
+const supportedNetworksLegacy = ['aurora', 'aurora-testnet'];
+const supportedNetworks = ['near', 'near-testnet'];
 
 export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetwork {
   public constructor(
@@ -12,7 +14,10 @@ export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetw
     extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_NATIVE_TOKEN,
     currentVersion: string = CURRENT_VERSION,
   ) {
-    super(extensionId, currentVersion, supportedNetworks);
+    const supportedNetworksForVersion = Semver.lt(currentVersion, CURRENT_VERSION)
+      ? supportedNetworksLegacy
+      : supportedNetworks;
+    super(extensionId, currentVersion, supportedNetworksForVersion);
   }
 
   /**
@@ -24,8 +29,10 @@ export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetw
   protected isValidAddress(address: string, networkName?: string): boolean {
     switch (networkName) {
       case 'aurora':
+      case 'near':
         return this.isValidMainnetAddress(address);
       case 'aurora-testnet':
+      case 'near-testnet':
         return this.isValidTestnetAddress(address);
       case undefined:
         return this.isValidMainnetAddress(address) || this.isValidTestnetAddress(address);
@@ -35,11 +42,11 @@ export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetw
   }
 
   private isValidMainnetAddress(address: string): boolean {
-    return this.isValidAddressForSymbolAndNetwork(address, 'NEAR', 'aurora');
+    return this.isValidAddressForSymbolAndNetwork(address, 'NEAR', 'near');
   }
 
   private isValidTestnetAddress(address: string): boolean {
-    return this.isValidAddressForSymbolAndNetwork(address, 'NEAR-testnet', 'aurora-testnet');
+    return this.isValidAddressForSymbolAndNetwork(address, 'NEAR-testnet', 'near-testnet');
   }
 
   /**

--- a/packages/advanced-logic/src/extensions/payment-network/near-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/near-native.ts
@@ -1,9 +1,11 @@
 import { ExtensionTypes } from '@requestnetwork/types';
 import { UnsupportedNetworkError } from './address-based';
 import NativeTokenPaymentNetwork from './native-token';
+import * as Semver from 'semver';
 
-const CURRENT_VERSION = '0.2.0';
-const supportedNetworks = ['aurora', 'aurora-testnet'];
+const CURRENT_VERSION = '0.3.0';
+const supportedNetworks_0_2_0 = ['aurora', 'aurora-testnet'];
+const supportedNetworks = ['near', 'near-testnet'];
 
 /**
  * Implementation of the payment network to pay in Near based on input data.
@@ -13,7 +15,10 @@ export default class NearNativePaymentNetwork extends NativeTokenPaymentNetwork 
     extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_NATIVE_TOKEN,
     currentVersion: string = CURRENT_VERSION,
   ) {
-    super(extensionId, currentVersion, supportedNetworks);
+    const supportedNetworksForVersion = Semver.lt(currentVersion, '0.3.0')
+      ? supportedNetworks_0_2_0
+      : supportedNetworks;
+    super(extensionId, currentVersion, supportedNetworksForVersion);
   }
 
   /**
@@ -25,8 +30,10 @@ export default class NearNativePaymentNetwork extends NativeTokenPaymentNetwork 
   protected isValidAddress(address: string, networkName?: string): boolean {
     switch (networkName) {
       case 'aurora':
+      case 'near':
         return this.isValidMainnetAddress(address);
       case 'aurora-testnet':
+      case 'near-testnet':
         return this.isValidTestnetAddress(address);
       case undefined:
         return this.isValidMainnetAddress(address) || this.isValidTestnetAddress(address);
@@ -36,10 +43,10 @@ export default class NearNativePaymentNetwork extends NativeTokenPaymentNetwork 
   }
 
   private isValidMainnetAddress(address: string): boolean {
-    return this.isValidAddressForSymbolAndNetwork(address, 'NEAR', 'aurora');
+    return this.isValidAddressForSymbolAndNetwork(address, 'NEAR', 'near');
   }
 
   private isValidTestnetAddress(address: string): boolean {
-    return this.isValidAddressForSymbolAndNetwork(address, 'NEAR-testnet', 'aurora-testnet');
+    return this.isValidAddressForSymbolAndNetwork(address, 'NEAR-testnet', 'near-testnet');
   }
 }

--- a/packages/advanced-logic/src/extensions/payment-network/near-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/near-native.ts
@@ -15,7 +15,7 @@ export default class NearNativePaymentNetwork extends NativeTokenPaymentNetwork 
     extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_NATIVE_TOKEN,
     currentVersion: string = CURRENT_VERSION,
   ) {
-    const supportedNetworksForVersion = Semver.lt(currentVersion, '0.3.0')
+    const supportedNetworksForVersion = Semver.lt(currentVersion, CURRENT_VERSION)
       ? supportedNetworksLegacy
       : supportedNetworks;
     super(extensionId, currentVersion, supportedNetworksForVersion);

--- a/packages/advanced-logic/src/extensions/payment-network/near-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/near-native.ts
@@ -4,7 +4,7 @@ import NativeTokenPaymentNetwork from './native-token';
 import * as Semver from 'semver';
 
 const CURRENT_VERSION = '0.3.0';
-const supportedNetworks_0_2_0 = ['aurora', 'aurora-testnet'];
+const supportedNetworksLegacy = ['aurora', 'aurora-testnet'];
 const supportedNetworks = ['near', 'near-testnet'];
 
 /**
@@ -16,7 +16,7 @@ export default class NearNativePaymentNetwork extends NativeTokenPaymentNetwork 
     currentVersion: string = CURRENT_VERSION,
   ) {
     const supportedNetworksForVersion = Semver.lt(currentVersion, '0.3.0')
-      ? supportedNetworks_0_2_0
+      ? supportedNetworksLegacy
       : supportedNetworks;
     super(extensionId, currentVersion, supportedNetworksForVersion);
   }

--- a/packages/advanced-logic/src/extensions/payment-network/near-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/near-native.ts
@@ -3,7 +3,7 @@ import { UnsupportedNetworkError } from './address-based';
 import NativeTokenPaymentNetwork from './native-token';
 import * as Semver from 'semver';
 
-const CURRENT_VERSION = '0.3.0';
+const CURRENT_VERSION = '0.2.0';
 const supportedNetworksLegacy = ['aurora', 'aurora-testnet'];
 const supportedNetworks = ['near', 'near-testnet'];
 
@@ -15,7 +15,7 @@ export default class NearNativePaymentNetwork extends NativeTokenPaymentNetwork 
     extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_NATIVE_TOKEN,
     currentVersion: string = CURRENT_VERSION,
   ) {
-    const supportedNetworksForVersion = Semver.lt(currentVersion, CURRENT_VERSION)
+    const supportedNetworksForVersion = Semver.lt(currentVersion, '0.3.0')
       ? supportedNetworksLegacy
       : supportedNetworks;
     super(extensionId, currentVersion, supportedNetworksForVersion);

--- a/packages/advanced-logic/test/extensions/payment-network/any-to-near.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/any-to-near.test.ts
@@ -34,8 +34,8 @@ describe('extensions/payment-network/any-to-native-token', () => {
       ) as AnyToNativeTokenPaymentNetwork,
       suffix: 'near',
       wrongSuffix: 'testnet',
-      network: 'aurora',
-      wrongNetwork: 'aurora-testnet',
+      network: 'near',
+      wrongNetwork: 'near-testnet',
       maxRateTimespan: 100000,
       feeAmount: '100',
     },
@@ -46,8 +46,8 @@ describe('extensions/payment-network/any-to-native-token', () => {
       ) as AnyToNativeTokenPaymentNetwork,
       suffix: 'testnet',
       wrongSuffix: 'near',
-      network: 'aurora-testnet',
-      wrongNetwork: 'aurora',
+      network: 'near-testnet',
+      wrongNetwork: 'near',
       maxRateTimespan: 100000,
       feeAmount: '100',
     },
@@ -186,7 +186,7 @@ describe('extensions/payment-network/any-to-native-token', () => {
                 network: 'another-chain',
               });
             }).toThrowError(
-              `Payment network 'another-chain' is not supported by this extension (only aurora, aurora-testnet)`,
+              `Payment network 'another-chain' is not supported by this extension (only near, near-testnet)`,
             );
           });
           it('throws when payment network is missing', () => {
@@ -406,7 +406,7 @@ describe('extensions/payment-network/any-to-native-token', () => {
           validRequestState.extensions,
           anyToNearPn.createCreationAction({
             salt,
-            network: 'aurora',
+            network: 'near',
             refundAddress: 'refund.near',
             feeAddress: 'fee.near',
             feeAmount: '100',
@@ -440,7 +440,7 @@ describe('extensions/payment-network/any-to-native-token', () => {
           validRequestState.extensions,
           anyToNearPn.createCreationAction({
             salt,
-            network: 'aurora',
+            network: 'near',
             refundAddress: 'refund.near',
             feeAddress: 'fee.near',
             feeAmount: '100',
@@ -475,7 +475,7 @@ describe('extensions/payment-network/any-to-native-token', () => {
           anyToNearPn.createCreationAction({
             salt,
             paymentAddress: 'pay.near',
-            network: 'aurora',
+            network: 'near',
             refundAddress: 'refund.near',
             maxRateTimespan: 1000000,
           }),
@@ -506,7 +506,7 @@ describe('extensions/payment-network/any-to-native-token', () => {
           validRequestState.extensions,
           anyToNearPn.createCreationAction({
             salt,
-            network: 'aurora',
+            network: 'near',
             refundAddress: 'refund.near',
             maxRateTimespan: 1000000,
           }),
@@ -541,7 +541,7 @@ describe('extensions/payment-network/any-to-native-token', () => {
           validRequestState.extensions,
           anyToNearPn.createCreationAction({
             salt,
-            network: 'aurora',
+            network: 'near',
             refundAddress: 'refund.near',
             maxRateTimespan: 1000000,
           }),
@@ -576,7 +576,7 @@ describe('extensions/payment-network/any-to-native-token', () => {
           validRequestState.extensions,
           anyToNearPn.createCreationAction({
             salt,
-            network: 'aurora',
+            network: 'near',
             refundAddress: 'refund.near',
             feeAddress: 'fee.near',
             feeAmount: '100',
@@ -613,7 +613,7 @@ describe('extensions/payment-network/any-to-native-token', () => {
           validRequestState.extensions,
           anyToNearPn.createCreationAction({
             salt,
-            network: 'aurora',
+            network: 'near',
             refundAddress: 'refund.near',
             maxRateTimespan: 1000000,
           }),

--- a/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
@@ -45,6 +45,24 @@ describe('extensions/payment-network/native-token', () => {
       currency: nearTestnetCurrency,
       wrongCurrency: nearCurrency,
     },
+    {
+      name: 'Near',
+      paymentNetwork: new NearNativePaymentNetwork() as NativeTokenPaymentNetwork,
+      networkName: 'near',
+      suffix: 'near',
+      wrongSuffix: 'testnet',
+      currency: nearCurrency,
+      wrongCurrency: nearTestnetCurrency,
+    },
+    {
+      name: 'Near testnet',
+      paymentNetwork: new NearNativePaymentNetwork() as NativeTokenPaymentNetwork,
+      networkName: 'near-testnet',
+      suffix: 'testnet',
+      wrongSuffix: 'near',
+      currency: nearTestnetCurrency,
+      wrongCurrency: nearCurrency,
+    },
   ];
 
   nativeTokenTestCases.forEach((testCase) => {
@@ -149,6 +167,7 @@ describe('extensions/payment-network/native-token', () => {
   });
 
   describe('AdvancedLogic.applyActionToExtension', () => {
+    // TODO replace 0 with Near but also test retrocompatibility where relevant
     const mainnetTestCase = nativeTokenTestCases[0];
     it('works with state and action on the same network', () => {
       const advancedLogic = new AdvancedLogic();
@@ -247,13 +266,13 @@ describe('extensions/payment-network/native-token', () => {
       expect(() => {
         advancedLogic.applyActionToExtensions(
           requestState.extensions,
-          nearPn.createCreationAction({ salt, paymentNetworkName: 'aurora-testnet' }),
+          nearPn.createCreationAction({ salt, paymentNetworkName: 'near-testnet' }),
           requestState,
           payeeRaw.identity,
           arbitraryTimestamp,
         );
       }).toThrowError(
-        'Cannot apply action for network aurora-testnet on state with payment network: aurora',
+        'Cannot apply action for network near-testnet on state with payment network: near',
       );
     });
     it('throws when adding a payment address a different network', () => {
@@ -267,7 +286,7 @@ describe('extensions/payment-network/native-token', () => {
 
       const intermediateExtensionState = advancedLogic.applyActionToExtensions(
         requestState.extensions,
-        nearPn.createCreationAction({ salt, paymentNetworkName: 'aurora' }),
+        nearPn.createCreationAction({ salt, paymentNetworkName: 'near' }),
         requestState,
         payeeRaw.identity,
         arbitraryTimestamp,

--- a/packages/currency/src/currency-utils.ts
+++ b/packages/currency/src/currency-utils.ts
@@ -13,7 +13,7 @@ import { RequestLogicTypes } from '@requestnetwork/types';
  */
 export const isValidNearAddress = (address: string, network?: string): boolean => {
   if (!network) {
-    return isValidNearAddress(address, 'aurora') || isValidNearAddress(address, 'aurora-testnet');
+    return isValidNearAddress(address, 'near') || isValidNearAddress(address, 'near-testnet');
   }
   // see link bellow for NEAR address specification
   // https://nomicon.io/DataStructures/Account.html
@@ -32,8 +32,10 @@ export const isValidNearAddress = (address: string, network?: string): boolean =
   // see link bellow for details about top level accounts on mainnet and testnet
   // https://docs.near.org/docs/videos/accounts-keys
   switch (network) {
+    case 'near':
     case 'aurora':
       return !!address.match(/\.near$/);
+    case 'near-testnet':
     case 'aurora-testnet':
       return !!address.match(/\.testnet$/);
     default:

--- a/packages/currency/src/currencyManager.ts
+++ b/packages/currency/src/currencyManager.ts
@@ -290,7 +290,7 @@ export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta>
   static getDefaultLegacyTokens(): LegacyTokenMap {
     return {
       near: {
-        NEAR: ['NEAR', 'aurora'],
+        NEAR: ['NEAR', 'near'],
       },
     };
   }

--- a/packages/currency/src/native.ts
+++ b/packages/currency/src/native.ts
@@ -73,13 +73,13 @@ export const nativeCurrencies: Record<NativeCurrencyType, (NativeCurrency & { na
       symbol: 'NEAR',
       decimals: 24,
       name: 'Near',
-      network: 'aurora',
+      network: 'near',
     },
     {
       symbol: 'NEAR-testnet',
       decimals: 24,
       name: 'Near Testnet',
-      network: 'aurora-testnet',
+      network: 'near-testnet',
     },
     {
       symbol: 'ARETH',

--- a/packages/currency/test/currencyManager.test.ts
+++ b/packages/currency/test/currencyManager.test.ts
@@ -454,8 +454,8 @@ describe('CurrencyManager', () => {
     };
 
     const nearAddresses: Record<string, string> = {
-      aurora: 'requestnetwork.near',
-      'aurora-testnet': 'requestnetwork.testnet',
+      near: 'requestnetwork.near',
+      'near-testnet': 'requestnetwork.testnet',
     };
 
     const eip55Addresses: string[] = [
@@ -477,16 +477,16 @@ describe('CurrencyManager', () => {
       Record<string, Partial<CurrencyDefinition>>
     > = {
       ...testCasesPerNetwork,
-      aurora: {
+      near: {
         NEAR: {
           type: RequestLogicTypes.CURRENCY.ETH,
           symbol: 'NEAR',
-          network: 'aurora',
+          network: 'near',
         },
         'NEAR-testnet': {
           type: RequestLogicTypes.CURRENCY.ETH,
           symbol: 'NEAR-testnet',
-          network: 'aurora-testnet',
+          network: 'near-testnet',
         },
       },
     };

--- a/packages/integration-test/test/scheduled/native-token.test.ts
+++ b/packages/integration-test/test/scheduled/native-token.test.ts
@@ -10,7 +10,7 @@ const advancedLogic = new AdvancedLogic();
 const createCreationActionParams: PnReferenceBased.ICreationParameters = {
   paymentAddress: 'payment.testnet',
   salt: 'a1a2a3a4a5a6a7a8',
-  paymentNetworkName: 'aurora-testnet',
+  paymentNetworkName: 'near-testnet',
 };
 
 describe('PaymentNetworkFactory and createExtensionsDataForCreation', () => {
@@ -22,17 +22,17 @@ describe('PaymentNetworkFactory and createExtensionsDataForCreation', () => {
     const paymentNetwork = paymentNetworkFactory.createPaymentNetwork(
       PaymentTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN,
       RequestLogicTypes.CURRENCY.ETH,
-      'aurora-testnet',
+      'near-testnet',
     );
     const action = await paymentNetwork.createExtensionsDataForCreation(createCreationActionParams);
     expect(action.parameters.paymentAddress).toEqual('payment.testnet');
-    expect(action.parameters.paymentNetworkName).toEqual('aurora-testnet');
+    expect(action.parameters.paymentNetworkName).toEqual('near-testnet');
   });
   it('throws without a payment network name', async () => {
     const paymentNetwork = paymentNetworkFactory.createPaymentNetwork(
       PaymentTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN,
       RequestLogicTypes.CURRENCY.ETH,
-      'aurora-testnet',
+      'near-testnet',
     );
     await expect(async () => {
       await paymentNetwork.createExtensionsDataForCreation(

--- a/packages/payment-detection/src/near/near-detector.ts
+++ b/packages/payment-detection/src/near/near-detector.ts
@@ -17,6 +17,7 @@ interface IProxyContractVersion {
 const CONTRACT_ADDRESS_MAP: IProxyContractVersion = {
   ['0.1.0']: '0.1.0',
   ['0.2.0']: '0.2.0',
+  ['0.3.0']: '0.3.0',
 };
 
 /**
@@ -33,9 +34,13 @@ export class NearNativeTokenPaymentDetector extends ReferenceBasedDetector<
     super(PaymentTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN, advancedLogic.extensions.nativeToken[0]);
   }
 
-  public static getContractName = (chainName: string, paymentNetworkVersion = '0.2.0'): string => {
+  public static getContractName = (chainName: string, paymentNetworkVersion = '0.3.0'): string => {
     const version = NearNativeTokenPaymentDetector.getVersionOrThrow(paymentNetworkVersion);
     const versionMap: Record<string, Record<string, string>> = {
+      near: { '0.3.0': 'requestnetwork.near' },
+      'near-testnet': {
+        '0.3.0': 'dev-1631521265288-35171138540673',
+      },
       aurora: { '0.1.0': 'requestnetwork.near', '0.2.0': 'requestnetwork.near' },
       'aurora-testnet': {
         '0.1.0': 'dev-1626339335241-5544297',
@@ -82,6 +87,18 @@ export class NearNativeTokenPaymentDetector extends ReferenceBasedDetector<
     return {
       paymentEvents,
     };
+  }
+
+  /**
+   * Get the network of the payment
+   * @returns The network of payment
+   */
+  protected getPaymentChain(request: RequestLogicTypes.IRequest): string {
+    const network = request.currency.network;
+    if (!network) {
+      throw Error(`request.currency.network must be defined for ${this.paymentNetworkId}`);
+    }
+    return network.replace('aurora', 'near');
   }
 
   protected static getVersionOrThrow = (paymentNetworkVersion: string): string => {

--- a/packages/payment-detection/src/near/retrievers/near-info-retriever.ts
+++ b/packages/payment-detection/src/near/retrievers/near-info-retriever.ts
@@ -14,6 +14,7 @@ export class NearInfoRetriever {
   /**
    * @param paymentReference The reference to identify the payment
    * @param toAddress Address to check
+   * @param proxyContractName: The contract expected to process the payment
    * @param eventName Indicate if it is an address for payment or refund
    * @param network The id of network we want to check
    *
@@ -25,10 +26,10 @@ export class NearInfoRetriever {
     protected eventName: PaymentTypes.EVENTS_NAMES,
     protected network: string,
   ) {
-    if (this.network !== 'aurora' && this.network !== 'aurora-testnet') {
+    this.network = this.network.replace('aurora', 'near');
+    if (this.network !== 'near' && this.network !== 'near-testnet') {
       throw new Error('Near input data info-retriever only works with Near mainnet and testnet');
     }
-    this.network = this.network.replace('aurora', 'near');
     this.client = getTheGraphNearClient(this.network as 'near' | 'near-testnet');
   }
 

--- a/packages/payment-detection/src/payment-network-factory.ts
+++ b/packages/payment-detection/src/payment-network-factory.ts
@@ -40,6 +40,11 @@ const supportedPaymentNetwork: ISupportedPaymentNetworkByCurrency = {
     },
   },
   ETH: {
+    near: { [PN_ID.NATIVE_TOKEN]: NearNativeTokenPaymentDetector },
+    'near-testnet': {
+      [PN_ID.NATIVE_TOKEN]: NearNativeTokenPaymentDetector,
+    },
+    // Aurora is not supported but was mistakenly used as a Near alias
     aurora: { [PN_ID.NATIVE_TOKEN]: NearNativeTokenPaymentDetector },
     'aurora-testnet': {
       [PN_ID.NATIVE_TOKEN]: NearNativeTokenPaymentDetector,

--- a/packages/payment-detection/test/near/near-native.test.ts
+++ b/packages/payment-detection/test/near/near-native.test.ts
@@ -11,7 +11,7 @@ import { NearNativeTokenPaymentDetector, NearInfoRetriever } from '../../src/nea
 import { deepCopy } from 'ethers/lib/utils';
 
 const mockNearPaymentNetwork = {
-  supportedNetworks: ['aurora', 'aurora-testnet'],
+  supportedNetworks: ['near', 'near-testnet'],
 };
 const currencyManager = CurrencyManager.getDefault();
 
@@ -26,7 +26,7 @@ const paymentAddress = 'gus.near';
 const request: any = {
   requestId: '01c9190b6d015b3a0b2bbd0e492b9474b0734ca19a16f2fda8f7adec10d0fa3e7a',
   currency: {
-    network: 'aurora',
+    network: 'near',
     type: RequestLogicTypes.CURRENCY.ETH,
     value: 'NEAR',
   },
@@ -58,7 +58,7 @@ describe('Near payments detection', () => {
       'gus.near',
       'requestnetwork.near',
       PaymentTypes.EVENTS_NAMES.PAYMENT,
-      'aurora',
+      'near',
     );
     const events = await infoRetriever.getTransferEvents();
     expect(events).toHaveLength(1);
@@ -80,7 +80,7 @@ describe('Near payments detection', () => {
     expect(
       paymentNetworkFactory.getPaymentNetworkFromRequest({
         ...request,
-        currency: { ...request.currency, network: 'aurora' },
+        currency: { ...request.currency, network: 'near' },
       }),
     ).toBeInstanceOf(NearNativeTokenPaymentDetector);
   });
@@ -131,7 +131,7 @@ describe('Near payments detection', () => {
         error: {
           code: 2,
           message:
-            'Payment network unknown-network not supported by pn-native-token payment detection. Supported networks: aurora, aurora-testnet',
+            'Payment network unknown-network not supported by pn-native-token payment detection. Supported networks: near, near-testnet',
         },
         events: [],
       });

--- a/packages/payment-processor/package.json
+++ b/packages/payment-processor/package.json
@@ -47,6 +47,7 @@
     "@superfluid-finance/sdk-core": "0.3.2",
     "ethers": "5.5.1",
     "near-api-js": "0.42.0",
+    "semver": "5.6.0",
     "tslib": "2.3.1"
   },
   "devDependencies": {

--- a/packages/payment-processor/src/payment/utils-near.ts
+++ b/packages/payment-processor/src/payment/utils-near.ts
@@ -5,6 +5,7 @@ import {
   NearNativeTokenPaymentDetector,
   NearConversionNativeTokenPaymentDetector,
 } from '@requestnetwork/payment-detection';
+import * as Semver from 'semver';
 
 export const isValidNearAddress = async (nearNetwork: Near, address: string): Promise<boolean> => {
   try {
@@ -47,14 +48,9 @@ export const processNearPayment = async (
   amount: BigNumberish,
   to: string,
   paymentReference: string,
-  version = '0.2.0',
+  version = '0.3.0',
 ): Promise<void> => {
-  if (version !== '0.2.0') {
-    if (version === '0.1.0') {
-      throw new Error(
-        'Native Token payments on Near with extension v0.1.0 are not supported anymore',
-      );
-    }
+  if (Semver.lt(version, '0.2.0')) {
     throw new Error('Native Token payments on Near only support extensions starting at 0.2.0');
   }
   if (!(await isValidNearAddress(walletConnection._near, to))) {

--- a/packages/payment-processor/src/payment/utils-near.ts
+++ b/packages/payment-processor/src/payment/utils-near.ts
@@ -16,7 +16,11 @@ export const isValidNearAddress = async (nearNetwork: Near, address: string): Pr
 };
 
 export const isNearNetwork = (network?: string): boolean => {
-  return !!network && (network === 'aurora-testnet' || network === 'aurora');
+  if (network === 'aurora-testnet' || network === 'aurora') {
+    console.warn(`Using ${network} as an alias for Near will be deprecated`);
+    return true;
+  }
+  return !!network && (network === 'near-testnet' || network === 'near');
 };
 
 export const isNearAccountSolvent = (
@@ -51,7 +55,7 @@ export const processNearPayment = async (
         'Native Token payments on Near with extension v0.1.0 are not supported anymore',
       );
     }
-    throw new Error('Native Token payments on Near only support v0.2.0 extensions');
+    throw new Error('Native Token payments on Near only support extensions starting at 0.2.0');
   }
   if (!(await isValidNearAddress(walletConnection._near, to))) {
     throw new Error(`Invalid NEAR payment address: ${to}`);

--- a/packages/payment-processor/test/payment/index.test.ts
+++ b/packages/payment-processor/test/payment/index.test.ts
@@ -288,7 +288,7 @@ describe('swapToPayRequest', () => {
   it('cannot swap to pay a non-EVM request currency', async () => {
     const request: any = {
       currencyInfo: {
-        network: 'aurora',
+        network: 'near',
       },
       extensions: {
         [PaymentTypes.PAYMENT_NETWORK_ID.ETH_INPUT_DATA]: {
@@ -301,7 +301,7 @@ describe('swapToPayRequest', () => {
       },
     };
     await expect(swapToPayRequest(request, swapSettings, wallet)).rejects.toThrowError(
-      'Payment currency network aurora is not supported',
+      'Payment currency network near is not supported',
     );
   });
 


### PR DESCRIPTION
## Description of the changes
Context: we initially thought aurora was the network ID for Near, but it's not, it's the name of the EVM-compatible NEAR sidechain.

Remove as many references as possible to aurora, keep just enough for retro-compatibility. Ideally, we'd replace aurora naming on request parsing only, on storage, so most libraries can ignore it.