### PR TITLE
refactor: payment network factory

### DIFF
--- a/packages/data-access/src/data-access.ts
+++ b/packages/data-access/src/data-access.ts
@@ -57,8 +57,7 @@ const emptyChannelsWithTopics: DataAccessTypes.IReturnGetChannelsByTopic = {
  */
 export default class DataAccess implements DataAccessTypes.IDataAccess {
   // Transaction index, that allows storing and retrieving transactions by channel or topic, with time boundaries.
-  // public for test purpose
-  public transactionIndex: DataAccessTypes.ITransactionIndex;
+  private transactionIndex: DataAccessTypes.ITransactionIndex;
 
   // boolean to store the initialization state
   protected isInitialized = false;

--- a/packages/data-access/test/data-access.test.ts
+++ b/packages/data-access/test/data-access.test.ts
@@ -4,6 +4,7 @@ import { DataAccessTypes, StorageTypes } from '@requestnetwork/types';
 
 import RequestDataAccessBlock from '../src/block';
 import DataAccess from '../src/data-access';
+import TransactionIndex from '../src/transaction-index';
 
 // We use this function to flush the call stack
 // If we don't use this function, the fake timer will be increased before the interval function being called
@@ -637,10 +638,10 @@ describe('data-access', () => {
       readMany: jest.fn(),
     };
 
-    const dataAccess = new DataAccess(fakeStorageWithNotJsonData);
+    const transactionIndex = new TransactionIndex();
+    const dataAccess = new DataAccess(fakeStorageWithNotJsonData, { transactionIndex });
+    const spy = jest.spyOn(transactionIndex, 'addTransaction').mockImplementation();
     await dataAccess.initialize();
-    const spy = jest.fn();
-    dataAccess.transactionIndex.addTransaction = spy;
     await dataAccess.synchronizeNewDataIds();
 
     expect(spy).not.toHaveBeenCalled();

--- a/packages/integration-test/test/native-token.test.ts
+++ b/packages/integration-test/test/native-token.test.ts
@@ -5,11 +5,7 @@ import { AdvancedLogic } from '@requestnetwork/advanced-logic';
 import { CurrencyManager } from '@requestnetwork/currency';
 
 const advancedLogic = new AdvancedLogic();
-const currency = {
-  network: 'aurora-testnet',
-  type: RequestLogicTypes.CURRENCY.ETH,
-  value: 'NEAR',
-};
+
 const createCreationActionParams: PnReferenceBased.ICreationParameters = {
   paymentAddress: 'payment.testnet',
   salt: 'a1a2a3a4a5a6a7a8',
@@ -17,30 +13,26 @@ const createCreationActionParams: PnReferenceBased.ICreationParameters = {
 };
 
 describe('PaymentNetworkFactory and createExtensionsDataForCreation', () => {
+  const paymentNetworkFactory = new PaymentNetworkFactory(
+    advancedLogic,
+    CurrencyManager.getDefault(),
+  );
   it('PaymentNetworkFactory can createPaymentNetwork (mainnet)', async () => {
-    const paymentNetwork = PaymentNetworkFactory.createPaymentNetwork({
-      advancedLogic,
-      currency: { ...currency, network: 'aurora-testnet' },
-      paymentNetworkCreationParameters: {
-        id: PaymentTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN,
-        parameters: createCreationActionParams,
-      },
-      currencyManager: CurrencyManager.getDefault(),
-    });
+    const paymentNetwork = paymentNetworkFactory.createPaymentNetwork(
+      PaymentTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN,
+      RequestLogicTypes.CURRENCY.ETH,
+      'aurora-testnet',
+    );
     const action = await paymentNetwork.createExtensionsDataForCreation(createCreationActionParams);
     expect(action.parameters.paymentAddress).toEqual('payment.testnet');
     expect(action.parameters.paymentNetworkName).toEqual('aurora-testnet');
   });
   it('throws without a payment network name', async () => {
-    const paymentNetwork = PaymentNetworkFactory.createPaymentNetwork({
-      advancedLogic,
-      currency: { ...currency, network: 'aurora-testnet' },
-      paymentNetworkCreationParameters: {
-        id: PaymentTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN,
-        parameters: { ...createCreationActionParams, paymentNetworkName: undefined },
-      },
-      currencyManager: CurrencyManager.getDefault(),
-    });
+    const paymentNetwork = paymentNetworkFactory.createPaymentNetwork(
+      PaymentTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN,
+      RequestLogicTypes.CURRENCY.ETH,
+      'aurora-testnet',
+    );
     await expect(async () => {
       await paymentNetwork.createExtensionsDataForCreation(createCreationActionParams);
     }).rejects.toThrowError(

--- a/packages/integration-test/test/node-client.test.ts
+++ b/packages/integration-test/test/node-client.test.ts
@@ -415,7 +415,7 @@ describe('Request client using a request node', () => {
 
     await fetchedRequest.refresh();
     expect(fetchedRequest.getData().expectedAmount).toBe('0');
-  });
+  }, 60000);
 
   it('create an encrypted and unencrypted request with the same content', async () => {
     const requestNetwork = new RequestNetwork({

--- a/packages/integration-test/test/scheduled/btc-test-data.ts
+++ b/packages/integration-test/test/scheduled/btc-test-data.ts
@@ -40,6 +40,7 @@ export const requestData = {
   currency: {
     type: RequestLogicTypes.CURRENCY.BTC,
     value: 'BTC',
+    network: 'mainnet',
   },
   expectedAmount: '100000000000',
   payee: payee.identity,

--- a/packages/integration-test/test/scheduled/escrow-detector.test.ts
+++ b/packages/integration-test/test/scheduled/escrow-detector.test.ts
@@ -1,4 +1,4 @@
-import { Erc20PaymentNetwork } from '../../../payment-detection/dist';
+import { Erc20PaymentNetwork } from '@requestnetwork/payment-detection';
 import { CurrencyManager } from '@requestnetwork/currency';
 import { createMockErc20FeeRequest } from '../utils';
 import { mockAdvancedLogic } from './mocks';

--- a/packages/integration-test/test/scheduled/native-token.test.ts
+++ b/packages/integration-test/test/scheduled/native-token.test.ts
@@ -3,6 +3,7 @@ import { PaymentTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { PnReferenceBased } from '@requestnetwork/types/dist/extension-types';
 import { AdvancedLogic } from '@requestnetwork/advanced-logic';
 import { CurrencyManager } from '@requestnetwork/currency';
+import { omit } from 'lodash';
 
 const advancedLogic = new AdvancedLogic();
 
@@ -34,7 +35,9 @@ describe('PaymentNetworkFactory and createExtensionsDataForCreation', () => {
       'aurora-testnet',
     );
     await expect(async () => {
-      await paymentNetwork.createExtensionsDataForCreation(createCreationActionParams);
+      await paymentNetwork.createExtensionsDataForCreation(
+        omit(createCreationActionParams, 'paymentNetworkName'),
+      );
     }).rejects.toThrowError(
       'The network name is mandatory for the creation of the extension pn-native-token.',
     );

--- a/packages/payment-detection/src/index.ts
+++ b/packages/payment-detection/src/index.ts
@@ -1,4 +1,4 @@
-import PaymentNetworkFactory from './payment-network-factory';
+import { PaymentNetworkFactory, PaymentNetworkOptions } from './payment-network-factory';
 import PaymentReferenceCalculator from './payment-reference-calculator';
 
 import * as BtcPaymentNetwork from './btc';
@@ -26,6 +26,7 @@ export type { TheGraphClient } from './thegraph';
 
 export {
   PaymentNetworkFactory,
+  PaymentNetworkOptions,
   PaymentReferenceCalculator,
   BtcPaymentNetwork,
   DeclarativePaymentDetector,

--- a/packages/payment-detection/test/near/near-native-conversion.test.ts
+++ b/packages/payment-detection/test/near/near-native-conversion.test.ts
@@ -5,7 +5,7 @@ import {
   RequestLogicTypes,
 } from '@requestnetwork/types';
 import { CurrencyDefinition, CurrencyManager } from '@requestnetwork/currency';
-import PaymentNetworkFactory from '../../src/payment-network-factory';
+import { PaymentNetworkFactory } from '../../src/payment-network-factory';
 import PaymentReferenceCalculator from '../../src/payment-reference-calculator';
 import {
   NearConversionNativeTokenPaymentDetector,
@@ -75,6 +75,7 @@ const graphPaymentEvent = {
   gasPrice: '2425000017',
 };
 
+const paymentNetworkFactory = new PaymentNetworkFactory(mockAdvancedLogic, currencyManager);
 describe('Near payments detection', () => {
   beforeAll(() => {
     graphql.request.mockResolvedValue({
@@ -121,21 +122,16 @@ describe('Near payments detection', () => {
   });
 
   it('PaymentNetworkFactory can get the detector (testnet)', async () => {
-    expect(
-      PaymentNetworkFactory.getPaymentNetworkFromRequest({
-        advancedLogic: mockAdvancedLogic,
-        request,
-        currencyManager,
-      }),
-    ).toBeInstanceOf(NearConversionNativeTokenPaymentDetector);
+    expect(paymentNetworkFactory.getPaymentNetworkFromRequest(request)).toBeInstanceOf(
+      NearConversionNativeTokenPaymentDetector,
+    );
   });
 
   it('PaymentNetworkFactory can get the detector (mainnet)', async () => {
     expect(
-      PaymentNetworkFactory.getPaymentNetworkFromRequest({
-        advancedLogic: mockAdvancedLogic,
-        request: { ...request, currency: { ...request.currency, network: 'aurora' } },
-        currencyManager,
+      paymentNetworkFactory.getPaymentNetworkFromRequest({
+        ...request,
+        currency: { ...request.currency, network: 'aurora' },
       }),
     ).toBeInstanceOf(NearConversionNativeTokenPaymentDetector);
   });

--- a/packages/payment-detection/test/near/near-native.test.ts
+++ b/packages/payment-detection/test/near/near-native.test.ts
@@ -5,7 +5,7 @@ import {
   RequestLogicTypes,
 } from '@requestnetwork/types';
 import { CurrencyManager } from '@requestnetwork/currency';
-import PaymentNetworkFactory from '../../src/payment-network-factory';
+import { PaymentNetworkFactory } from '../../src/payment-network-factory';
 import PaymentReferenceCalculator from '../../src/payment-reference-calculator';
 import { NearNativeTokenPaymentDetector, NearInfoRetriever } from '../../src/near';
 import { deepCopy } from 'ethers/lib/utils';
@@ -43,6 +43,8 @@ const request: any = {
   },
 };
 
+const paymentNetworkFactory = new PaymentNetworkFactory(mockAdvancedLogic, currencyManager);
+
 describe('Near payments detection', () => {
   it('NearInfoRetriever can retrieve a NEAR payment', async () => {
     const paymentReference = PaymentReferenceCalculator.calculate(
@@ -69,21 +71,16 @@ describe('Near payments detection', () => {
   });
 
   it('PaymentNetworkFactory can get the detector (testnet)', async () => {
-    expect(
-      PaymentNetworkFactory.getPaymentNetworkFromRequest({
-        advancedLogic: mockAdvancedLogic,
-        request,
-        currencyManager,
-      }),
-    ).toBeInstanceOf(NearNativeTokenPaymentDetector);
+    expect(paymentNetworkFactory.getPaymentNetworkFromRequest(request)).toBeInstanceOf(
+      NearNativeTokenPaymentDetector,
+    );
   });
 
   it('PaymentNetworkFactory can get the detector (mainnet)', async () => {
     expect(
-      PaymentNetworkFactory.getPaymentNetworkFromRequest({
-        advancedLogic: mockAdvancedLogic,
-        request: { ...request, currency: { ...request.currency, network: 'aurora' } },
-        currencyManager,
+      paymentNetworkFactory.getPaymentNetworkFromRequest({
+        ...request,
+        currency: { ...request.currency, network: 'aurora' },
       }),
     ).toBeInstanceOf(NearNativeTokenPaymentDetector);
   });

--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -44,7 +44,6 @@ export default class RequestNetwork {
    * @param dataAccess instance of data-access layer
    * @param signatureProvider module in charge of the signatures
    * @param decryptionProvider module in charge of the decryption
-   * @param bitcoinDetectionProvider bitcoin detection provider
    * @param currencyManager
    */
   public constructor({

--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -16,7 +16,6 @@ import {
 } from '@requestnetwork/types';
 import Utils from '@requestnetwork/utils';
 import {
-  CurrencyInput,
   CurrencyManager,
   ICurrencyManager,
   UnsupportedCurrencyError,
@@ -56,7 +55,6 @@ export default class RequestNetwork {
     dataAccess: DataAccessTypes.IDataAccess;
     signatureProvider?: SignatureProviderTypes.ISignatureProvider;
     decryptionProvider?: DecryptionProviderTypes.IDecryptionProvider;
-    currencies?: CurrencyInput[];
     currencyManager?: ICurrencyManager;
     paymentOptions?: PaymentNetworkOptions;
   }) {

--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -1,6 +1,6 @@
 import { utils as ethersUtils } from 'ethers';
 import { AdvancedLogic } from '@requestnetwork/advanced-logic';
-import { PaymentNetworkFactory } from '@requestnetwork/payment-detection';
+import { PaymentNetworkFactory, PaymentNetworkOptions } from '@requestnetwork/payment-detection';
 import { RequestLogic } from '@requestnetwork/request-logic';
 import { TransactionManager } from '@requestnetwork/transaction-manager';
 import {
@@ -30,7 +30,7 @@ import localUtils from './utils';
  * Entry point of the request-client.js library. Create requests, get requests, manipulate requests.
  */
 export default class RequestNetwork {
-  public bitcoinDetectionProvider?: PaymentTypes.IBitcoinDetectionProvider;
+  public paymentNetworkFactory: PaymentNetworkFactory;
   public supportedIdentities: IdentityTypes.TYPE[] = Utils.identity.supportedIdentities;
 
   private requestLogic: RequestLogicTypes.IRequestLogic;
@@ -51,22 +51,26 @@ export default class RequestNetwork {
     dataAccess,
     signatureProvider,
     decryptionProvider,
-    bitcoinDetectionProvider,
     currencyManager,
+    paymentOptions,
   }: {
     dataAccess: DataAccessTypes.IDataAccess;
     signatureProvider?: SignatureProviderTypes.ISignatureProvider;
     decryptionProvider?: DecryptionProviderTypes.IDecryptionProvider;
-    bitcoinDetectionProvider?: PaymentTypes.IBitcoinDetectionProvider;
     currencies?: CurrencyInput[];
     currencyManager?: ICurrencyManager;
+    paymentOptions?: PaymentNetworkOptions;
   }) {
     this.currencyManager = currencyManager || CurrencyManager.getDefault();
     this.advancedLogic = new AdvancedLogic(this.currencyManager);
     this.transaction = new TransactionManager(dataAccess, decryptionProvider);
     this.requestLogic = new RequestLogic(this.transaction, signatureProvider, this.advancedLogic);
     this.contentData = new ContentDataExtension(this.advancedLogic);
-    this.bitcoinDetectionProvider = bitcoinDetectionProvider;
+    this.paymentNetworkFactory = new PaymentNetworkFactory(
+      this.advancedLogic,
+      this.currencyManager,
+      paymentOptions,
+    );
   }
 
   /**
@@ -173,7 +177,6 @@ export default class RequestNetwork {
     options?: {
       disablePaymentDetection?: boolean;
       disableEvents?: boolean;
-      explorerApiKeys?: Record<string, string>;
     },
   ): Promise<Request> {
     const requestAndMeta: RequestLogicTypes.IReturnGetRequestFromId =
@@ -188,14 +191,7 @@ export default class RequestNetwork {
     const requestState: RequestLogicTypes.IRequest = requestAndMeta.result.request
       ? requestAndMeta.result.request
       : (requestAndMeta.result.pending as RequestLogicTypes.IRequest);
-    const paymentNetwork: PaymentTypes.IPaymentNetwork | null =
-      PaymentNetworkFactory.getPaymentNetworkFromRequest({
-        advancedLogic: this.advancedLogic,
-        bitcoinDetectionProvider: this.bitcoinDetectionProvider,
-        request: requestState,
-        explorerApiKeys: options?.explorerApiKeys,
-        currencyManager: this.currencyManager,
-      });
+    const paymentNetwork = this.paymentNetworkFactory.getPaymentNetworkFromRequest(requestState);
 
     // create the request object
     const request = new Request(requestId, this.requestLogic, this.currencyManager, {
@@ -281,13 +277,8 @@ export default class RequestNetwork {
           ? requestFromLogic.request
           : (requestFromLogic.pending as RequestLogicTypes.IRequest);
 
-        const paymentNetwork: PaymentTypes.IPaymentNetwork | null =
-          PaymentNetworkFactory.getPaymentNetworkFromRequest({
-            advancedLogic: this.advancedLogic,
-            bitcoinDetectionProvider: this.bitcoinDetectionProvider,
-            request: requestState,
-            currencyManager: this.currencyManager,
-          });
+        const paymentNetwork =
+          this.paymentNetworkFactory.getPaymentNetworkFromRequest(requestState);
 
         // create the request object
         const request = new Request(
@@ -340,13 +331,8 @@ export default class RequestNetwork {
           ? requestFromLogic.request
           : (requestFromLogic.pending as RequestLogicTypes.IRequest);
 
-        const paymentNetwork: PaymentTypes.IPaymentNetwork | null =
-          PaymentNetworkFactory.getPaymentNetworkFromRequest({
-            advancedLogic: this.advancedLogic,
-            bitcoinDetectionProvider: this.bitcoinDetectionProvider,
-            request: requestState,
-            currencyManager: this.currencyManager,
-          });
+        const paymentNetwork =
+          this.paymentNetworkFactory.getPaymentNetworkFromRequest(requestState);
 
         // create the request object
         const request = new Request(
@@ -401,7 +387,6 @@ export default class RequestNetwork {
       ...parameters.requestInfo,
       currency,
     };
-    const paymentNetworkCreationParameters = parameters.paymentNetwork;
     const contentData = parameters.contentData;
     const topics = parameters.topics?.slice() || [];
 
@@ -416,24 +401,19 @@ export default class RequestNetwork {
     const copiedRequestParameters = Utils.deepCopy(requestParameters);
     copiedRequestParameters.extensionsData = [];
 
-    let paymentNetwork: PaymentTypes.IPaymentNetwork | null = null;
-    if (paymentNetworkCreationParameters) {
-      paymentNetwork = PaymentNetworkFactory.createPaymentNetwork({
-        advancedLogic: this.advancedLogic,
-        bitcoinDetectionProvider: this.bitcoinDetectionProvider,
-        currency: requestParameters.currency,
-        paymentNetworkCreationParameters,
-        currencyManager: this.currencyManager,
-      });
+    const paymentNetwork = parameters.paymentNetwork
+      ? this.paymentNetworkFactory.createPaymentNetwork(
+          parameters.paymentNetwork.id,
+          requestParameters.currency.type,
+          requestParameters.currency.network,
+        )
+      : null;
 
-      if (paymentNetwork) {
-        // create the extensions data for the payment network
-        copiedRequestParameters.extensionsData.push(
-          await paymentNetwork.createExtensionsDataForCreation(
-            paymentNetworkCreationParameters.parameters,
-          ),
-        );
-      }
+    if (paymentNetwork) {
+      // create the extensions data for the payment network
+      copiedRequestParameters.extensionsData.push(
+        await paymentNetwork.createExtensionsDataForCreation(parameters.paymentNetwork?.parameters),
+      );
     }
 
     if (contentData) {

--- a/packages/request-client.js/src/http-request-network.ts
+++ b/packages/request-client.js/src/http-request-network.ts
@@ -16,8 +16,6 @@ import MockStorage from './mock-storage';
  * Exposes RequestNetwork module configured to use http-data-access.
  */
 export default class HttpRequestNetwork extends RequestNetwork {
-  public _mockStorage: MockStorage | undefined;
-
   /**
    * Creates an instance of HttpRequestNetwork.
    *

--- a/packages/request-client.js/src/http-request-network.ts
+++ b/packages/request-client.js/src/http-request-network.ts
@@ -16,7 +16,6 @@ import MockStorage from './mock-storage';
  * Exposes RequestNetwork module configured to use http-data-access.
  */
 export default class HttpRequestNetwork extends RequestNetwork {
-  /** Public for test purpose */
   public _mockStorage: MockStorage | undefined;
 
   /**
@@ -56,12 +55,8 @@ export default class HttpRequestNetwork extends RequestNetwork {
       useMockStorage: false,
     },
   ) {
-    let _mockStorage: MockStorage | undefined;
-    if (useMockStorage) {
-      _mockStorage = new MockStorage();
-    }
-    const dataAccess: DataAccessTypes.IDataAccess = _mockStorage
-      ? new MockDataAccess(_mockStorage)
+    const dataAccess: DataAccessTypes.IDataAccess = useMockStorage
+      ? new MockDataAccess(new MockStorage())
       : new HttpDataAccess({ httpConfig, nodeConnectionConfig });
 
     if (!currencyManager) {
@@ -69,8 +64,5 @@ export default class HttpRequestNetwork extends RequestNetwork {
     }
 
     super({ dataAccess, signatureProvider, decryptionProvider, currencyManager });
-
-    // store it for test purpose
-    this._mockStorage = _mockStorage;
   }
 }

--- a/packages/request-client.js/src/http-request-network.ts
+++ b/packages/request-client.js/src/http-request-network.ts
@@ -36,6 +36,7 @@ export default class HttpRequestNetwork extends RequestNetwork {
       useMockStorage,
       currencies,
       currencyManager,
+      paymentOptions,
     }: {
       decryptionProvider?: DecryptionProviderTypes.IDecryptionProvider;
       httpConfig?: Partial<ClientTypes.IHttpDataAccessConfig>;
@@ -61,6 +62,6 @@ export default class HttpRequestNetwork extends RequestNetwork {
       currencyManager = new CurrencyManager(currencies || CurrencyManager.getDefaultList());
     }
 
-    super({ dataAccess, signatureProvider, decryptionProvider, currencyManager });
+    super({ dataAccess, signatureProvider, decryptionProvider, currencyManager, paymentOptions });
   }
 }

--- a/packages/request-client.js/src/index.ts
+++ b/packages/request-client.js/src/index.ts
@@ -3,6 +3,7 @@ import { PaymentReferenceCalculator } from '@requestnetwork/payment-detection';
 import Request from './api/request';
 import Utils from './api/utils';
 import { default as RequestNetwork } from './http-request-network';
+import { default as RequestNetworkBase } from './api/request-network';
 import * as Types from './types';
 
-export { PaymentReferenceCalculator, Request, RequestNetwork, Types, Utils };
+export { PaymentReferenceCalculator, Request, RequestNetwork, RequestNetworkBase, Types, Utils };


### PR DESCRIPTION
# Description
The PaymentNetworkFactory was used as a set of static methods. I refactored it to be able to pass common dependencies in the constructor, like in the rest of the codebase.

# Context
This is in preparation for additional properties available for Payment Detection customization, like Subgraph URLs.
The idea is to be able to pass the configuration to the request client directly