### PR TITLE
refactor(advanced-logic): add evm-based PN

### DIFF
--- a/packages/advanced-logic/src/extensions/abstract-extension.ts
+++ b/packages/advanced-logic/src/extensions/abstract-extension.ts
@@ -9,8 +9,8 @@ export abstract class AbstractExtension<TCreationParameters> {
 
   public constructor(
     public extensionType: ExtensionTypes.TYPE,
-    public extensionId: ExtensionTypes.ID,
-    public currentVersion: string,
+    public readonly extensionId: ExtensionTypes.ID,
+    public readonly currentVersion: string,
   ) {
     this.actions = {};
   }

--- a/packages/advanced-logic/src/extensions/abstract-extension.ts
+++ b/packages/advanced-logic/src/extensions/abstract-extension.ts
@@ -7,8 +7,8 @@ import Utils from '@requestnetwork/utils';
 export abstract class AbstractExtension<TCreationParameters> {
   protected actions: ExtensionTypes.SupportedActions;
 
-  public constructor(
-    public extensionType: ExtensionTypes.TYPE,
+  protected constructor(
+    public readonly extensionType: ExtensionTypes.TYPE,
     public readonly extensionId: ExtensionTypes.ID,
     public readonly currentVersion: string,
   ) {

--- a/packages/advanced-logic/src/extensions/content-data.ts
+++ b/packages/advanced-logic/src/extensions/content-data.ts
@@ -10,8 +10,8 @@ export default class ContentDataExtension<
   TCreationParameters extends ExtensionTypes.ContentData.ICreationParameters = ExtensionTypes.ContentData.ICreationParameters,
 > extends AbstractExtension<TCreationParameters> {
   public constructor(
-    public extensionId: ExtensionTypes.ID = ExtensionTypes.ID.CONTENT_DATA,
-    public currentVersion: string = CURRENT_VERSION,
+    public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID.CONTENT_DATA,
+    public readonly currentVersion: string = CURRENT_VERSION,
   ) {
     super(ExtensionTypes.TYPE.CONTENT_DATA, extensionId, currentVersion);
   }

--- a/packages/advanced-logic/src/extensions/payment-network/address-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/address-based.ts
@@ -10,7 +10,7 @@ import DeclarativePaymentNetwork from './declarative';
 export default abstract class AddressBasedPaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnAddressBased.ICreationParameters = ExtensionTypes.PnAddressBased.ICreationParameters,
 > extends DeclarativePaymentNetwork<TCreationParameters> {
-  public constructor(
+  protected constructor(
     public readonly extensionId: ExtensionTypes.ID,
     public readonly currentVersion: string,
     public readonly supportedNetworks: string[],
@@ -29,7 +29,7 @@ export default abstract class AddressBasedPaymentNetwork<
   /**
    * Creates the extensionsData for address based payment networks
    *
-   * @param extensions extensions parameters to create
+   * @param creationParameters extensions parameters to create
    *
    * @returns IExtensionCreationAction the extensionsData to be stored in the request
    */
@@ -58,7 +58,7 @@ export default abstract class AddressBasedPaymentNetwork<
   /**
    * Creates the extensionsData to add a payment address
    *
-   * @param extensions extensions parameters to create
+   * @param addPaymentAddressParameters extensions parameters to create
    *
    * @returns IAction the extensionsData to be stored in the request
    */
@@ -82,7 +82,7 @@ export default abstract class AddressBasedPaymentNetwork<
   /**
    * Creates the extensionsData to add a refund address
    *
-   * @param extensions extensions parameters to create
+   * @param addRefundAddressParameters extensions parameters to create
    *
    * @returns IAction the extensionsData to be stored in the request
    */

--- a/packages/advanced-logic/src/extensions/payment-network/address-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/address-based.ts
@@ -11,10 +11,10 @@ export default abstract class AddressBasedPaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnAddressBased.ICreationParameters = ExtensionTypes.PnAddressBased.ICreationParameters,
 > extends DeclarativePaymentNetwork<TCreationParameters> {
   public constructor(
-    public extensionId: ExtensionTypes.ID,
-    public currentVersion: string,
-    public supportedNetworks: string[],
-    public supportedCurrencyType: RequestLogicTypes.CURRENCY,
+    public readonly extensionId: ExtensionTypes.ID,
+    public readonly currentVersion: string,
+    public readonly supportedNetworks: string[],
+    public readonly supportedCurrencyType: RequestLogicTypes.CURRENCY,
   ) {
     super(extensionId, currentVersion);
     this.actions = {

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
@@ -10,7 +10,7 @@ const CURRENT_VERSION = '0.1.0';
 
 export default class AnyToErc20ProxyPaymentNetwork extends Erc20FeeProxyPaymentNetwork {
   public constructor(
-    private currencyManager: ICurrencyManager,
+    private readonly currencyManager: ICurrencyManager,
     public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID
       .PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
     public readonly currentVersion: string = CURRENT_VERSION,

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
@@ -11,8 +11,9 @@ const CURRENT_VERSION = '0.1.0';
 export default class AnyToErc20ProxyPaymentNetwork extends Erc20FeeProxyPaymentNetwork {
   public constructor(
     private currencyManager: ICurrencyManager,
-    extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
-    currentVersion: string = CURRENT_VERSION,
+    public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID
+      .PAYMENT_NETWORK_ANY_TO_ERC20_PROXY,
+    public readonly currentVersion: string = CURRENT_VERSION,
   ) {
     super(
       extensionId,

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-eth-proxy.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-eth-proxy.ts
@@ -11,8 +11,9 @@ const CURRENT_VERSION = '0.2.0';
 export default class AnyToEthProxyPaymentNetwork extends EthereumFeeProxyPaymentNetwork {
   public constructor(
     private currencyManager: ICurrencyManager,
-    extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_ETH_PROXY,
-    currentVersion: string = CURRENT_VERSION,
+    public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID
+      .PAYMENT_NETWORK_ANY_TO_ETH_PROXY,
+    public readonly currentVersion: string = CURRENT_VERSION,
   ) {
     super(extensionId, currentVersion, conversionSupportedNetworks);
   }

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-native.ts
@@ -4,9 +4,9 @@ import { InvalidPaymentAddressError } from './address-based';
 
 export default abstract class AnyToNativeTokenPaymentNetwork extends FeeReferenceBasedPaymentNetwork {
   public constructor(
-    extensionId: ExtensionTypes.ID,
-    currentVersion: string,
-    supportedNetworks: string[],
+    public readonly extensionId: ExtensionTypes.ID,
+    public readonly currentVersion: string,
+    public readonly supportedNetworks: string[],
   ) {
     super(extensionId, currentVersion, supportedNetworks, RequestLogicTypes.CURRENCY.ETH);
   }

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-native.ts
@@ -3,7 +3,7 @@ import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { InvalidPaymentAddressError } from './address-based';
 
 export default abstract class AnyToNativeTokenPaymentNetwork extends FeeReferenceBasedPaymentNetwork {
-  public constructor(
+  protected constructor(
     public readonly extensionId: ExtensionTypes.ID,
     public readonly currentVersion: string,
     public readonly supportedNetworks: string[],

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-near.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-near.ts
@@ -9,8 +9,9 @@ const supportedNetworks = ['aurora', 'aurora-testnet'];
 export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetwork {
   public constructor(
     private currencyManager: ICurrencyManager,
-    extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_NATIVE_TOKEN,
-    currentVersion: string = CURRENT_VERSION,
+    public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID
+      .PAYMENT_NETWORK_ANY_TO_NATIVE_TOKEN,
+    public readonly currentVersion: string = CURRENT_VERSION,
   ) {
     super(extensionId, currentVersion, supportedNetworks);
   }

--- a/packages/advanced-logic/src/extensions/payment-network/bitcoin/mainnet-address-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/bitcoin/mainnet-address-based.ts
@@ -12,9 +12,10 @@ const BITCOIN_NETWORK = 'mainnet';
  */
 export default class BitcoinAddressBasedPaymentNetwork extends AddressBasedPaymentNetwork {
   public constructor(
-    public extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_BITCOIN_ADDRESS_BASED,
-    public currentVersion: string = CURRENT_VERSION,
-    public supportedNetworks: string[] = [BITCOIN_NETWORK],
+    public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID
+      .PAYMENT_NETWORK_BITCOIN_ADDRESS_BASED,
+    public readonly currentVersion: string = CURRENT_VERSION,
+    public readonly supportedNetworks: string[] = [BITCOIN_NETWORK],
   ) {
     super(extensionId, currentVersion, supportedNetworks, RequestLogicTypes.CURRENCY.BTC);
   }

--- a/packages/advanced-logic/src/extensions/payment-network/declarative.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/declarative.ts
@@ -11,8 +11,9 @@ export default class DeclarativePaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnAnyDeclarative.ICreationParameters = ExtensionTypes.PnAnyDeclarative.ICreationParameters,
 > extends AbstractExtension<TCreationParameters> {
   public constructor(
-    public extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_ANY_DECLARATIVE,
-    public currentVersion: string = CURRENT_VERSION,
+    public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID
+      .PAYMENT_NETWORK_ANY_DECLARATIVE,
+    public readonly currentVersion: string = CURRENT_VERSION,
   ) {
     super(ExtensionTypes.TYPE.PAYMENT_NETWORK, extensionId, currentVersion);
     this.actions = {

--- a/packages/advanced-logic/src/extensions/payment-network/erc20/address-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/address-based.ts
@@ -1,9 +1,8 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import AddressBasedPaymentNetwork from '../address-based';
+import EvmBasedPaymentNetwork from '../evm-based';
 
 const CURRENT_VERSION = '0.1.0';
-
-const supportedNetworks = ['mainnet', 'rinkeby', 'private', 'goerli'];
 
 /**
  * Implementation of the payment network to pay in ERC20 tokens based on an Ethereum address
@@ -11,12 +10,15 @@ const supportedNetworks = ['mainnet', 'rinkeby', 'private', 'goerli'];
  * Every ERC20 ethereum transaction, using the request currency ERC20, that reaches these addresses will be interpreted as payment or refund.
  * Important: the addresses must be exclusive to the request
  */
-export default class Erc20AddressBasedPaymentNetwork extends AddressBasedPaymentNetwork {
+export default class Erc20AddressBasedPaymentNetwork
+  extends AddressBasedPaymentNetwork
+  implements EvmBasedPaymentNetwork
+{
   public constructor() {
     super(
       ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_ADDRESS_BASED,
       CURRENT_VERSION,
-      supportedNetworks,
+      EvmBasedPaymentNetwork.EVM_NETWORKS,
       RequestLogicTypes.CURRENCY.ERC20,
     );
   }

--- a/packages/advanced-logic/src/extensions/payment-network/erc20/fee-proxy-contract.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/fee-proxy-contract.ts
@@ -1,5 +1,6 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { FeeReferenceBasedPaymentNetwork } from '../fee-reference-based';
+import EvmBasedPaymentNetwork from '../evm-based';
 
 const CURRENT_VERSION = '0.2.0';
 
@@ -7,29 +8,16 @@ const CURRENT_VERSION = '0.2.0';
  * Implementation of the payment network to pay in ERC20, including third-party fees payment, based on a reference provided to a proxy contract.
  */
 export default class Erc20FeeProxyPaymentNetwork<
-  TCreationParameters extends ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
-> extends FeeReferenceBasedPaymentNetwork<TCreationParameters> {
+    TCreationParameters extends ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
+  >
+  extends FeeReferenceBasedPaymentNetwork<TCreationParameters>
+  implements EvmBasedPaymentNetwork
+{
   public constructor(
-    extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT,
-    currentVersion: string = CURRENT_VERSION,
-    public supportedNetworks: string[] = [
-      'mainnet',
-      'rinkeby',
-      'goerli',
-      'private',
-      'matic',
-      'mumbai',
-      'celo',
-      'alfajores',
-      'fuse',
-      'bsctest',
-      'bsc',
-      'xdai',
-      'fantom',
-      'arbitrum-rinkeby',
-      'arbitrum-one',
-      'avalanche',
-    ],
+    public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID
+      .PAYMENT_NETWORK_ERC20_FEE_PROXY_CONTRACT,
+    public readonly currentVersion: string = CURRENT_VERSION,
+    public readonly supportedNetworks: string[] = EvmBasedPaymentNetwork.EVM_NETWORKS,
     public supportedCurrencyType: RequestLogicTypes.CURRENCY = RequestLogicTypes.CURRENCY.ERC20,
   ) {
     super(extensionId, currentVersion, supportedNetworks, supportedCurrencyType);

--- a/packages/advanced-logic/src/extensions/payment-network/erc20/proxy-contract.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/proxy-contract.ts
@@ -1,5 +1,6 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import ReferenceBasedPaymentNetwork from '../reference-based';
+import EvmBasedPaymentNetwork from '../evm-based';
 
 const CURRENT_VERSION = '0.1.0';
 
@@ -7,13 +8,16 @@ const CURRENT_VERSION = '0.1.0';
  * Implementation of the payment network to pay in ERC20 based on a reference provided to a proxy contract.
  */
 export default class Erc20ProxyPaymentNetwork<
-  TCreationParameters extends ExtensionTypes.PnReferenceBased.ICreationParameters = ExtensionTypes.PnReferenceBased.ICreationParameters,
-> extends ReferenceBasedPaymentNetwork<TCreationParameters> {
+    TCreationParameters extends ExtensionTypes.PnReferenceBased.ICreationParameters = ExtensionTypes.PnReferenceBased.ICreationParameters,
+  >
+  extends ReferenceBasedPaymentNetwork<TCreationParameters>
+  implements EvmBasedPaymentNetwork
+{
   public constructor(
     public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID
       .PAYMENT_NETWORK_ERC20_PROXY_CONTRACT,
     public readonly currentVersion: string = CURRENT_VERSION,
-    public readonly supportedNetworks: string[] = ['mainnet', 'rinkeby', 'goerli', 'private'],
+    public readonly supportedNetworks: string[] = EvmBasedPaymentNetwork.EVM_NETWORKS,
     public supportedCurrencyType: RequestLogicTypes.CURRENCY = RequestLogicTypes.CURRENCY.ERC20,
   ) {
     super(extensionId, currentVersion, supportedNetworks, supportedCurrencyType);

--- a/packages/advanced-logic/src/extensions/payment-network/erc20/proxy-contract.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/proxy-contract.ts
@@ -10,9 +10,10 @@ export default class Erc20ProxyPaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnReferenceBased.ICreationParameters = ExtensionTypes.PnReferenceBased.ICreationParameters,
 > extends ReferenceBasedPaymentNetwork<TCreationParameters> {
   public constructor(
-    public extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_ERC20_PROXY_CONTRACT,
-    public currentVersion: string = CURRENT_VERSION,
-    public supportedNetworks: string[] = ['mainnet', 'rinkeby', 'goerli', 'private'],
+    public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID
+      .PAYMENT_NETWORK_ERC20_PROXY_CONTRACT,
+    public readonly currentVersion: string = CURRENT_VERSION,
+    public readonly supportedNetworks: string[] = ['mainnet', 'rinkeby', 'goerli', 'private'],
     public supportedCurrencyType: RequestLogicTypes.CURRENCY = RequestLogicTypes.CURRENCY.ERC20,
   ) {
     super(extensionId, currentVersion, supportedNetworks, supportedCurrencyType);

--- a/packages/advanced-logic/src/extensions/payment-network/erc777/stream.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc777/stream.ts
@@ -1,25 +1,23 @@
 import { ExtensionTypes, RequestLogicTypes, TypesUtils } from '@requestnetwork/types';
 import ReferenceBasedPaymentNetwork from '../reference-based';
 import Utils from '@requestnetwork/utils';
+import EvmBasedPaymentNetwork from '../evm-based';
 const CURRENT_VERSION = '0.1.0';
 
 /**
  * Implementation of the payment network to pay in ERC777, including third-party fees payment, based on a reference provided to a proxy contract.
  */
 export default class Erc777StreamPaymentNetwork<
-  TCreationParameters extends ExtensionTypes.PnStreamReferenceBased.ICreationParameters = ExtensionTypes.PnStreamReferenceBased.ICreationParameters,
-> extends ReferenceBasedPaymentNetwork<TCreationParameters> {
+    TCreationParameters extends ExtensionTypes.PnStreamReferenceBased.ICreationParameters = ExtensionTypes.PnStreamReferenceBased.ICreationParameters,
+  >
+  extends ReferenceBasedPaymentNetwork<TCreationParameters>
+  implements EvmBasedPaymentNetwork
+{
   public constructor(
-    extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,
-    currentVersion: string = CURRENT_VERSION,
-    public supportedNetworks: string[] = [
-      'matic',
-      'xdai',
-      'mumbai',
-      'rinkeby',
-      'goerli',
-      'arbitrum-rinkeby',
-    ],
+    public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID
+      .PAYMENT_NETWORK_ERC777_STREAM,
+    public readonly currentVersion: string = CURRENT_VERSION,
+    public readonly supportedNetworks: string[] = EvmBasedPaymentNetwork.EVM_NETWORKS,
     public supportedCurrencyType: RequestLogicTypes.CURRENCY = RequestLogicTypes.CURRENCY.ERC777,
   ) {
     super(extensionId, currentVersion, supportedNetworks, supportedCurrencyType);

--- a/packages/advanced-logic/src/extensions/payment-network/ethereum/fee-proxy-contract.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/ethereum/fee-proxy-contract.ts
@@ -1,5 +1,6 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { FeeReferenceBasedPaymentNetwork } from '../fee-reference-based';
+import EvmBasedPaymentNetwork from '../evm-based';
 
 const CURRENT_VERSION = '0.2.0';
 
@@ -7,12 +8,16 @@ const CURRENT_VERSION = '0.2.0';
  * Implementation of the payment network to pay in Ethereum, including third-party fees payment, based on a reference provided to a proxy contract.
  */
 export default class EthereumFeeProxyPaymentNetwork<
-  TCreationParameters extends ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
-> extends FeeReferenceBasedPaymentNetwork<TCreationParameters> {
+    TCreationParameters extends ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
+  >
+  extends FeeReferenceBasedPaymentNetwork<TCreationParameters>
+  implements EvmBasedPaymentNetwork
+{
   public constructor(
-    extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_ETH_FEE_PROXY_CONTRACT,
-    currentVersion: string = CURRENT_VERSION,
-    public supportedNetworks: string[] = ['mainnet', 'rinkeby', 'goerli', 'private'],
+    public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID
+      .PAYMENT_NETWORK_ETH_FEE_PROXY_CONTRACT,
+    public readonly currentVersion: string = CURRENT_VERSION,
+    public readonly supportedNetworks: string[] = EvmBasedPaymentNetwork.EVM_NETWORKS,
   ) {
     super(extensionId, currentVersion, supportedNetworks, RequestLogicTypes.CURRENCY.ETH);
   }

--- a/packages/advanced-logic/src/extensions/payment-network/ethereum/input-data.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/ethereum/input-data.ts
@@ -1,33 +1,27 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import ReferenceBasedPaymentNetwork from '../reference-based';
+import EvmBasedPaymentNetwork from '../evm-based';
 
 const CURRENT_VERSION = '0.3.0';
-const supportedNetworks = [
-  'mainnet',
-  'rinkeby',
-  'goerli',
-  'xdai',
-  'sokol',
-  'fuse',
-  'matic',
-  'celo',
-  'fantom',
-  'bsctest',
-  'bsc',
-  'arbitrum-rinkeby',
-  'arbitrum-one',
-  'avalanche',
-];
 
 /**
  * Implementation of the payment network to pay in native token
  * FIXME: rename into EVMNativePaymentNetwork
  */
-export default class EthInputPaymentNetwork extends ReferenceBasedPaymentNetwork {
+export default class EthInputPaymentNetwork
+  extends ReferenceBasedPaymentNetwork
+  implements EvmBasedPaymentNetwork
+{
   public constructor(
-    extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_ETH_INPUT_DATA,
-    currentVersion: string = CURRENT_VERSION,
+    public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID
+      .PAYMENT_NETWORK_ETH_INPUT_DATA,
+    public readonly currentVersion: string = CURRENT_VERSION,
   ) {
-    super(extensionId, currentVersion, supportedNetworks, RequestLogicTypes.CURRENCY.ETH);
+    super(
+      extensionId,
+      currentVersion,
+      EvmBasedPaymentNetwork.EVM_NETWORKS,
+      RequestLogicTypes.CURRENCY.ETH,
+    );
   }
 }

--- a/packages/advanced-logic/src/extensions/payment-network/evm-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/evm-based.ts
@@ -1,0 +1,21 @@
+export default abstract class EvmBasedPaymentNetwork {
+  static EVM_NETWORKS = [
+    'alfajores',
+    'arbitrum-one',
+    'arbitrum-rinkeby',
+    'avalanche',
+    'bsc',
+    'bsctest',
+    'celo',
+    'fantom',
+    'fuse',
+    'goerli',
+    'mainnet',
+    'matic',
+    'mumbai',
+    'private',
+    'rinkeby',
+    'sokol',
+    'xdai',
+  ];
+}

--- a/packages/advanced-logic/src/extensions/payment-network/fee-reference-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/fee-reference-based.ts
@@ -10,10 +10,10 @@ export abstract class FeeReferenceBasedPaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
 > extends ReferenceBasedPaymentNetwork<TCreationParameters> {
   public constructor(
-    public extensionId: ExtensionTypes.ID,
-    public currentVersion: string,
-    public supportedNetworks: string[],
-    public supportedCurrencyType: RequestLogicTypes.CURRENCY,
+    public readonly extensionId: ExtensionTypes.ID,
+    public readonly currentVersion: string,
+    public readonly supportedNetworks: string[],
+    public readonly supportedCurrencyType: RequestLogicTypes.CURRENCY,
   ) {
     super(extensionId, currentVersion, supportedNetworks, supportedCurrencyType);
     this.actions = {

--- a/packages/advanced-logic/src/extensions/payment-network/fee-reference-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/fee-reference-based.ts
@@ -9,7 +9,7 @@ import Utils from '@requestnetwork/utils';
 export abstract class FeeReferenceBasedPaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
 > extends ReferenceBasedPaymentNetwork<TCreationParameters> {
-  public constructor(
+  protected constructor(
     public readonly extensionId: ExtensionTypes.ID,
     public readonly currentVersion: string,
     public readonly supportedNetworks: string[],

--- a/packages/advanced-logic/src/extensions/payment-network/native-token.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/native-token.ts
@@ -8,9 +8,9 @@ import ReferenceBasedPaymentNetwork from './reference-based';
  */
 export default abstract class NativeTokenPaymentNetwork extends ReferenceBasedPaymentNetwork {
   public constructor(
-    extensionId: ExtensionTypes.ID,
-    currentVersion: string,
-    supportedNetworks: string[],
+    public readonly extensionId: ExtensionTypes.ID,
+    public readonly currentVersion: string,
+    public readonly supportedNetworks: string[],
   ) {
     super(extensionId, currentVersion, supportedNetworks, RequestLogicTypes.CURRENCY.ETH);
   }

--- a/packages/advanced-logic/src/extensions/payment-network/near-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/near-native.ts
@@ -10,8 +10,8 @@ const supportedNetworks = ['aurora', 'aurora-testnet'];
  */
 export default class NearNativePaymentNetwork extends NativeTokenPaymentNetwork {
   public constructor(
-    extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_NATIVE_TOKEN,
-    currentVersion: string = CURRENT_VERSION,
+    public readonly extensionId: ExtensionTypes.ID = ExtensionTypes.ID.PAYMENT_NETWORK_NATIVE_TOKEN,
+    public readonly currentVersion: string = CURRENT_VERSION,
   ) {
     super(extensionId, currentVersion, supportedNetworks);
   }

--- a/packages/advanced-logic/src/extensions/payment-network/reference-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/reference-based.ts
@@ -12,9 +12,9 @@ export default abstract class ReferenceBasedPaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnReferenceBased.ICreationParameters = ExtensionTypes.PnReferenceBased.ICreationParameters,
 > extends AddressBasedPaymentNetwork<TCreationParameters> {
   public constructor(
-    public extensionId: ExtensionTypes.ID,
-    public currentVersion: string,
-    public supportedNetworks: string[],
+    public readonly extensionId: ExtensionTypes.ID,
+    public readonly currentVersion: string,
+    public readonly supportedNetworks: string[],
     public supportedCurrencyType: RequestLogicTypes.CURRENCY,
   ) {
     super(extensionId, currentVersion, supportedNetworks, supportedCurrencyType);

--- a/packages/advanced-logic/src/extensions/payment-network/reference-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/reference-based.ts
@@ -11,7 +11,7 @@ const eightHexRegex = /[0-9a-f]{16,}/;
 export default abstract class ReferenceBasedPaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnReferenceBased.ICreationParameters = ExtensionTypes.PnReferenceBased.ICreationParameters,
 > extends AddressBasedPaymentNetwork<TCreationParameters> {
-  public constructor(
+  protected constructor(
     public readonly extensionId: ExtensionTypes.ID,
     public readonly currentVersion: string,
     public readonly supportedNetworks: string[],


### PR DESCRIPTION
This PR adds a composable `evm-based` payment network. It decouples the advanced-logic layer from the current state of deployed smart contracts. See discussion: https://github.com/RequestNetwork/requestNetwork/pull/943#discussion_r990978153

This PR, if merged, would supersede the following: https://github.com/RequestNetwork/requestNetwork/pull/943