### PR TITLE
chore: NEAR transaction callback arguments

### DIFF
--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -21,6 +21,7 @@ import { encodeRequestErc20Approval } from './encoder-approval';
 import { encodeRequestPayment } from './encoder-payment';
 import { IPreparedTransaction } from './prepared-transaction';
 import { IRequestPaymentOptions } from './settings';
+export { INearTransactionCallback } from './utils-near';
 
 export const noConversionNetworks = [
   ExtensionTypes.ID.PAYMENT_NETWORK_ERC777_STREAM,

--- a/packages/payment-processor/src/payment/near-conversion.ts
+++ b/packages/payment-processor/src/payment/near-conversion.ts
@@ -9,7 +9,11 @@ import {
   getAmountToPay,
   getPaymentExtensionVersion,
 } from './utils';
-import { isNearNetwork, processNearPaymentWithConversion } from './utils-near';
+import {
+  INearTransactionCallback,
+  isNearNetwork,
+  processNearPaymentWithConversion,
+} from './utils-near';
 import { IConversionPaymentSettings } from '.';
 import { CurrencyManager, UnsupportedCurrencyError } from '@requestnetwork/currency';
 
@@ -24,6 +28,7 @@ export async function payNearConversionRequest(
   walletConnection: WalletConnection,
   paymentSettings: IConversionPaymentSettings,
   amount?: BigNumberish,
+  callback?: INearTransactionCallback,
 ): Promise<void> {
   validateRequest(request, PaymentTypes.PAYMENT_NETWORK_ID.ANY_TO_NATIVE);
 
@@ -59,6 +64,7 @@ export async function payNearConversionRequest(
     paymentSettings.maxToSpend,
     maxRateTimespan || '0',
     version,
+    callback,
   );
 }
 

--- a/packages/payment-processor/src/payment/near-input-data.ts
+++ b/packages/payment-processor/src/payment/near-input-data.ts
@@ -9,7 +9,7 @@ import {
   getAmountToPay,
   getPaymentExtensionVersion,
 } from './utils';
-import { isNearNetwork, processNearPayment } from './utils-near';
+import { INearTransactionCallback, isNearNetwork, processNearPayment } from './utils-near';
 
 /**
  * processes the transaction to pay a Near request.
@@ -21,6 +21,7 @@ export async function payNearInputDataRequest(
   request: ClientTypes.IRequestData,
   walletConnection: WalletConnection,
   amount?: BigNumberish,
+  callback?: INearTransactionCallback,
 ): Promise<void> {
   if (!request.currencyInfo.network || !isNearNetwork(request.currencyInfo.network)) {
     throw new Error('request.currencyInfo should be a Near network');
@@ -42,5 +43,6 @@ export async function payNearInputDataRequest(
     paymentAddress,
     paymentReference,
     version,
+    callback,
   );
 }

--- a/packages/payment-processor/src/payment/utils-near.ts
+++ b/packages/payment-processor/src/payment/utils-near.ts
@@ -6,6 +6,16 @@ import {
   NearConversionNativeTokenPaymentDetector,
 } from '@requestnetwork/payment-detection';
 
+/**
+ * Callback arguments for the Near web wallet.
+ * @member callbackUrl called upon transaction approval
+ * @member callbackMeta (according to Near docs: `meta` will be attached to the `callbackUrl` as a url search param)
+ */
+export interface INearTransactionCallback {
+  callbackUrl?: string;
+  meta?: string;
+}
+
 export const isValidNearAddress = async (nearNetwork: Near, address: string): Promise<boolean> => {
   try {
     await nearNetwork.connection.provider.query(`account/${address}`, '');
@@ -44,6 +54,7 @@ export const processNearPayment = async (
   to: string,
   paymentReference: string,
   version = '0.2.0',
+  callback: INearTransactionCallback | undefined = undefined,
 ): Promise<void> => {
   if (version !== '0.2.0') {
     if (version === '0.1.0') {
@@ -66,14 +77,15 @@ export const processNearPayment = async (
         viewMethods: [],
       },
     ) as any;
-    await contract.transfer_with_reference(
-      {
+    await contract.transfer_with_reference({
+      args: {
         to,
         payment_reference: paymentReference,
       },
-      GAS_LIMIT_NATIVE,
-      amount.toString(),
-    );
+      gas: GAS_LIMIT_NATIVE,
+      amount: amount.toString(),
+      ...callback,
+    });
     return;
   } catch (e) {
     throw new Error(`Could not pay Near request. Got ${e.message}`);
@@ -99,6 +111,7 @@ export const processNearPaymentWithConversion = async (
   maxToSpend: BigNumberish,
   maxRateTimespan = '0',
   version = '0.1.0',
+  callback: INearTransactionCallback | undefined = undefined,
 ): Promise<void> => {
   if (version !== '0.1.0') {
     throw new Error('Native Token with conversion payments on Near only support v0.1.0 extensions');
@@ -120,8 +133,8 @@ export const processNearPaymentWithConversion = async (
         viewMethods: [],
       },
     ) as any;
-    await contract.transfer_with_reference(
-      {
+    await contract.transfer_with_reference({
+      args: {
         payment_reference: paymentReference,
         to,
         amount,
@@ -130,9 +143,10 @@ export const processNearPaymentWithConversion = async (
         fee_amount: feeAmount,
         max_rate_timespan: maxRateTimespan,
       },
-      GAS_LIMIT_CONVERSION_TO_NATIVE,
-      maxToSpend.toString(),
-    );
+      gas: GAS_LIMIT_CONVERSION_TO_NATIVE,
+      amount: maxToSpend.toString(),
+      ...callback,
+    });
     return;
   } catch (e) {
     throw new Error(`Could not pay Near request. Got ${e.message}`);


### PR DESCRIPTION
## Description of the changes

This lets dapps configure a callback URL for NEAR payment method calls.