### PR TITLE
chore(tsconfig): specify included files during dev

### DIFF
--- a/packages/advanced-logic/tsconfig.build.json
+++ b/packages/advanced-logic/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../currency/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },

--- a/packages/advanced-logic/tsconfig.json
+++ b/packages/advanced-logic/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig",
   "compilerOptions": {
     "types": ["node", "jest"]
-  }
+  },
+  "include": ["src/", "test/"]
 }

--- a/packages/currency/tsconfig.build.json
+++ b/packages/currency/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*", "./src/aggregators/*.json"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "scripts/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" }

--- a/packages/currency/tsconfig.json
+++ b/packages/currency/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig",
   "compilerOptions": {
     "esModuleInterop": true
-  }
+  },
+  "include": ["src/", "src/aggregators/*.json", "scripts/", "test/"]
 }

--- a/packages/data-access/tsconfig.build.json
+++ b/packages/data-access/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*", "./src/aggregators/*.json"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" },

--- a/packages/data-access/tsconfig.json
+++ b/packages/data-access/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }

--- a/packages/data-format/tsconfig.build.json
+++ b/packages/data-format/tsconfig.build.json
@@ -4,6 +4,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*", "./src/format/address.json", "./src/format/**/*.json"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"]
 }

--- a/packages/data-format/tsconfig.json
+++ b/packages/data-format/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig",
   "compilerOptions": {
     "resolveJsonModule": true
-  }
+  },
+  "include": ["src/", "src/format/**/*.json", "test/"]
 }

--- a/packages/epk-decryption/tsconfig.build.json
+++ b/packages/epk-decryption/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" },

--- a/packages/epk-decryption/tsconfig.json
+++ b/packages/epk-decryption/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }

--- a/packages/epk-signature/tsconfig.build.json
+++ b/packages/epk-signature/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" }

--- a/packages/epk-signature/tsconfig.json
+++ b/packages/epk-signature/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }

--- a/packages/ethereum-storage/tsconfig.build.json
+++ b/packages/ethereum-storage/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" },

--- a/packages/ethereum-storage/tsconfig.json
+++ b/packages/ethereum-storage/tsconfig.json
@@ -1,6 +1,4 @@
 {
   "extends": "../../tsconfig",
-  "compilerOptions": {
-    "resolveJsonModule": true
-  }
+  "include": ["src/", "test/"]
 }

--- a/packages/integration-test/tsconfig.json
+++ b/packages/integration-test/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["test/"]
 }

--- a/packages/multi-format/tsconfig.build.json
+++ b/packages/multi-format/tsconfig.build.json
@@ -4,7 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [{ "path": "../types/tsconfig.build.json" }]
 }

--- a/packages/multi-format/tsconfig.json
+++ b/packages/multi-format/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }

--- a/packages/payment-detection/tsconfig.build.json
+++ b/packages/payment-detection/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../currency/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },

--- a/packages/payment-detection/tsconfig.json
+++ b/packages/payment-detection/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }

--- a/packages/payment-processor/tsconfig.build.json
+++ b/packages/payment-processor/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" },

--- a/packages/payment-processor/tsconfig.json
+++ b/packages/payment-processor/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }

--- a/packages/prototype-estimator/tsconfig.build.json
+++ b/packages/prototype-estimator/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../data-access/tsconfig.build.json" },
     { "path": "../epk-signature/tsconfig.build.json" },

--- a/packages/prototype-estimator/tsconfig.json
+++ b/packages/prototype-estimator/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }

--- a/packages/request-client.js/tsconfig.build.json
+++ b/packages/request-client.js/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../advanced-logic/tsconfig.build.json" },
     { "path": "../currency/tsconfig.build.json" },

--- a/packages/request-client.js/tsconfig.json
+++ b/packages/request-client.js/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }

--- a/packages/request-logic/tsconfig.build.json
+++ b/packages/request-logic/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../advanced-logic/tsconfig.build.json" },
     { "path": "../multi-format/tsconfig.build.json" },

--- a/packages/request-logic/tsconfig.json
+++ b/packages/request-logic/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }

--- a/packages/request-node/tsconfig.build.json
+++ b/packages/request-node/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../data-access/tsconfig.build.json" },
     { "path": "../ethereum-storage/tsconfig.build.json" },

--- a/packages/request-node/tsconfig.json
+++ b/packages/request-node/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig",
   "compilerOptions": {
     "esModuleInterop": true
-  }
+  },
+  "include": ["src/", "test/"]
 }

--- a/packages/smart-contracts/tsconfig.build.json
+++ b/packages/smart-contracts/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": ["src/**/*", "src/**/*.json", "scripts", "hardhat.config.ts", "scripts-create2"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../currency/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" }

--- a/packages/smart-contracts/tsconfig.json
+++ b/packages/smart-contracts/tsconfig.json
@@ -2,5 +2,13 @@
   "extends": "../../tsconfig",
   "compilerOptions": {
     "resolveJsonModule": true
-  }
+  },
+  "include": [
+    "src/",
+    "src/lib/artifacts/**/*.json",
+    "test/",
+    "scripts/",
+    "scripts-create2/",
+    "hardhat.config.ts"
+  ]
 }

--- a/packages/thegraph-data-access/tsconfig.build.json
+++ b/packages/thegraph-data-access/tsconfig.build.json
@@ -4,7 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [{ "path": "../types/tsconfig.build.json" }]
 }

--- a/packages/thegraph-data-access/tsconfig.json
+++ b/packages/thegraph-data-access/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }

--- a/packages/toolbox/tsconfig.build.json
+++ b/packages/toolbox/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../epk-signature/tsconfig.build.json" },
     { "path": "../request-client.js/tsconfig.build.json" },

--- a/packages/toolbox/tsconfig.json
+++ b/packages/toolbox/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "lib": ["ES2019"]
-  }
+  },
+  "include": ["src/", "test/"]
 }

--- a/packages/transaction-manager/tsconfig.build.json
+++ b/packages/transaction-manager/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" },

--- a/packages/transaction-manager/tsconfig.json
+++ b/packages/transaction-manager/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }

--- a/packages/types/tsconfig.build.json
+++ b/packages/types/tsconfig.build.json
@@ -4,6 +4,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"]
 }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig",
   "compilerOptions": {
     "importHelpers": false
-  }
+  },
+  "include": ["src/", "test/"]
 }

--- a/packages/usage-examples/tsconfig.build.json
+++ b/packages/usage-examples/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../data-access/tsconfig.build.json" },
     { "path": "../epk-decryption/tsconfig.build.json" },

--- a/packages/usage-examples/tsconfig.json
+++ b/packages/usage-examples/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -4,7 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [{ "path": "../types/tsconfig.build.json" }]
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }

--- a/packages/web3-signature/tsconfig.build.json
+++ b/packages/web3-signature/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["test/", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" }

--- a/packages/web3-signature/tsconfig.json
+++ b/packages/web3-signature/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig",
+  "include": ["src/", "test/"]
 }


### PR DESCRIPTION
## Description of the changes

This PR fixes IDE errors happening when a package needs JSON files. JSON files are not included by default by Typescript. This PR modifies our `tsconfig.json` project files and specifies all dependencies, instead of using the default value of `include` (which is `**` and excludes JSON files).