### PR TITLE
fix: minimal changes for near testnet renaming

### DIFF
--- a/packages/currency/src/conversion-aggregators.ts
+++ b/packages/currency/src/conversion-aggregators.ts
@@ -35,7 +35,7 @@ const chainlinkCurrencyPairs: AggregatorsMap = {
 // Pairs supported by Flux Protocol
 const fluxCurrencyPairs: AggregatorsMap = {
   aurora: nearAggregator,
-  'aurora-testnet': nearTestnetAggregator,
+  'near-testnet': nearTestnetAggregator,
 };
 
 // FIX ME: This fix enables to get these networks registered in conversionSupportedNetworks.

--- a/packages/currency/src/currency-utils.ts
+++ b/packages/currency/src/currency-utils.ts
@@ -13,7 +13,7 @@ import { RequestLogicTypes } from '@requestnetwork/types';
  */
 export const isValidNearAddress = (address: string, network?: string): boolean => {
   if (!network) {
-    return isValidNearAddress(address, 'aurora') || isValidNearAddress(address, 'aurora-testnet');
+    return isValidNearAddress(address, 'aurora') || isValidNearAddress(address, 'near-testnet');
   }
   // see link bellow for NEAR address specification
   // https://nomicon.io/DataStructures/Account.html
@@ -34,7 +34,7 @@ export const isValidNearAddress = (address: string, network?: string): boolean =
   switch (network) {
     case 'aurora':
       return !!address.match(/\.near$/);
-    case 'aurora-testnet':
+    case 'near-testnet':
       return !!address.match(/\.testnet$/);
     default:
       throw new Error(`Cannot validate NEAR address for network ${network}`);

--- a/packages/currency/src/native.ts
+++ b/packages/currency/src/native.ts
@@ -79,7 +79,7 @@ export const nativeCurrencies: Record<NativeCurrencyType, (NativeCurrency & { na
       symbol: 'NEAR-testnet',
       decimals: 24,
       name: 'Near Testnet',
-      network: 'aurora-testnet',
+      network: 'near-testnet',
     },
     {
       symbol: 'ARETH',

--- a/packages/currency/test/currencyManager.test.ts
+++ b/packages/currency/test/currencyManager.test.ts
@@ -455,7 +455,7 @@ describe('CurrencyManager', () => {
 
     const nearAddresses: Record<string, string> = {
       aurora: 'requestnetwork.near',
-      'aurora-testnet': 'requestnetwork.testnet',
+      'near-testnet': 'requestnetwork.testnet',
     };
 
     const eip55Addresses: string[] = [
@@ -486,7 +486,7 @@ describe('CurrencyManager', () => {
         'NEAR-testnet': {
           type: RequestLogicTypes.CURRENCY.ETH,
           symbol: 'NEAR-testnet',
-          network: 'aurora-testnet',
+          network: 'near-testnet',
         },
       },
     };


### PR DESCRIPTION
## Description of the changes
to correct the near testnet naming and make https://github.com/RequestNetwork/currency-api/pull/225 tests work