### PR TITLE
feat: add near-testnet naming conversion

### DIFF
--- a/packages/advanced-logic/src/extensions/payment-network/any-to-near.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-near.ts
@@ -4,7 +4,7 @@ import { UnsupportedNetworkError } from './address-based';
 import AnyToNativeTokenPaymentNetwork from './any-to-native';
 
 const CURRENT_VERSION = '0.1.0';
-const supportedNetworks = ['aurora', 'aurora-testnet', 'near-testnet'];
+const supportedNetworks = ['aurora', 'aurora-testnet'];
 
 export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetwork {
   public constructor(
@@ -26,7 +26,6 @@ export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetw
       case 'aurora':
         return this.isValidMainnetAddress(address);
       case 'aurora-testnet':
-      case 'near-testnet':
         return this.isValidTestnetAddress(address);
       case undefined:
         return this.isValidMainnetAddress(address) || this.isValidTestnetAddress(address);
@@ -58,7 +57,7 @@ export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetw
     if (!extensionAction.parameters.network || extensionAction.parameters.network.length === 0) {
       throw Error('network is required');
     }
-    // FIXME: Needed during naming migration from aurora to near
+    // // FIXME: Remove when the mistaken network name 'aurora' is gone
     extensionAction.parameters.network = extensionAction.parameters.network.replace(
       'near',
       'aurora',
@@ -142,7 +141,7 @@ export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetw
     actionSigner: IdentityTypes.IIdentity,
     timestamp: number,
   ): ExtensionTypes.IState {
-    // FIXME: Needed during naming migration from aurora to near
+    // // FIXME: Remove when the mistaken network name 'aurora' is gone
     extensionState.values.network = extensionState.values.network.replace('near', 'aurora');
 
     const paymentAddress = extensionAction.parameters.paymentAddress;
@@ -165,7 +164,7 @@ export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetw
     actionSigner: IdentityTypes.IIdentity,
     timestamp: number,
   ): ExtensionTypes.IState {
-    // FIXME: Needed during naming migration from aurora to near
+    // // FIXME: Remove when the mistaken network name 'aurora' is gone
     requestState.extensions[ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_NATIVE_TOKEN].values.network =
       requestState.extensions[
         ExtensionTypes.ID.PAYMENT_NETWORK_ANY_TO_NATIVE_TOKEN
@@ -208,7 +207,7 @@ export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetw
         `The network must be provided by the creation action or by the extension state`,
       );
     }
-    // FIXME: Needed during naming migration from aurora to near
+    // // FIXME: Remove when the mistaken network name 'aurora' is gone
     network = network.replace('near', 'aurora');
 
     if (!supportedNetworks.includes(network)) {

--- a/packages/advanced-logic/src/extensions/payment-network/near-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/near-native.ts
@@ -3,7 +3,7 @@ import { UnsupportedNetworkError } from './address-based';
 import NativeTokenPaymentNetwork from './native-token';
 
 const CURRENT_VERSION = '0.2.0';
-const supportedNetworks = ['aurora', 'aurora-testnet'];
+const supportedNetworks = ['aurora', 'aurora-testnet', 'near-testnet'];
 
 /**
  * Implementation of the payment network to pay in Near based on input data.
@@ -27,6 +27,7 @@ export default class NearNativePaymentNetwork extends NativeTokenPaymentNetwork 
       case 'aurora':
         return this.isValidMainnetAddress(address);
       case 'aurora-testnet':
+      case 'near-testnet':
         return this.isValidTestnetAddress(address);
       case undefined:
         return this.isValidMainnetAddress(address) || this.isValidTestnetAddress(address);

--- a/packages/advanced-logic/src/extensions/payment-network/near-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/near-native.ts
@@ -3,7 +3,7 @@ import { UnsupportedNetworkError } from './address-based';
 import NativeTokenPaymentNetwork from './native-token';
 
 const CURRENT_VERSION = '0.2.0';
-const supportedNetworks = ['aurora', 'aurora-testnet', 'near-testnet'];
+const supportedNetworks = ['aurora', 'aurora-testnet'];
 
 /**
  * Implementation of the payment network to pay in Near based on input data.
@@ -27,7 +27,6 @@ export default class NearNativePaymentNetwork extends NativeTokenPaymentNetwork 
       case 'aurora':
         return this.isValidMainnetAddress(address);
       case 'aurora-testnet':
-      case 'near-testnet':
         return this.isValidTestnetAddress(address);
       case undefined:
         return this.isValidMainnetAddress(address) || this.isValidTestnetAddress(address);
@@ -42,5 +41,18 @@ export default class NearNativePaymentNetwork extends NativeTokenPaymentNetwork 
 
   private isValidTestnetAddress(address: string): boolean {
     return this.isValidAddressForSymbolAndNetwork(address, 'NEAR-testnet', 'aurora-testnet');
+  }
+
+  // // FIXME: Remove when the mistaken network name 'aurora' is gone
+  public createCreationAction(
+    creationParameters: ExtensionTypes.PnReferenceBased.ICreationParameters,
+  ): ExtensionTypes.IAction<ExtensionTypes.PnReferenceBased.ICreationParameters> {
+    if (creationParameters.paymentNetworkName) {
+      creationParameters.paymentNetworkName = creationParameters.paymentNetworkName.replace(
+        'near',
+        'aurora',
+      );
+    }
+    return super.createCreationAction(creationParameters);
   }
 }

--- a/packages/advanced-logic/test/extensions/payment-network/any-to-near.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/any-to-near.test.ts
@@ -186,7 +186,7 @@ describe('extensions/payment-network/any-to-native-token', () => {
                 network: 'another-chain',
               });
             }).toThrowError(
-              `Payment network 'another-chain' is not supported by this extension (only aurora, aurora-testnet)`,
+              `Payment network 'another-chain' is not supported by this extension (only aurora, aurora-testnet, near-testnet)`,
             );
           });
           it('throws when payment network is missing', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/any-to-near.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/any-to-near.test.ts
@@ -186,7 +186,7 @@ describe('extensions/payment-network/any-to-native-token', () => {
                 network: 'another-chain',
               });
             }).toThrowError(
-              `Payment network 'another-chain' is not supported by this extension (only aurora, aurora-testnet, near-testnet)`,
+              `Payment network 'another-chain' is not supported by this extension (only aurora, aurora-testnet)`,
             );
           });
           it('throws when payment network is missing', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
@@ -136,7 +136,7 @@ describe('extensions/payment-network/native-token', () => {
           paymentNetworkName: 'another-chain',
         });
       }).toThrowError(
-        `Payment network 'another-chain' is not supported by this extension (only aurora, aurora-testnet)`,
+        `Payment network 'another-chain' is not supported by this extension (only aurora, aurora-testnet, near-testnet)`,
       );
     });
     it('createCreationAction() throws without payment network', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
@@ -28,7 +28,7 @@ describe('extensions/payment-network/native-token', () => {
   };
   const nativeTokenTestCases = [
     {
-      name: 'Near',
+      name: 'aurora',
       paymentNetwork: new NearNativePaymentNetwork() as NativeTokenPaymentNetwork,
       networkName: 'aurora',
       suffix: 'near',
@@ -37,9 +37,27 @@ describe('extensions/payment-network/native-token', () => {
       wrongCurrency: nearTestnetCurrency,
     },
     {
-      name: 'Near testnet',
+      name: 'aurora-testnet',
       paymentNetwork: new NearNativePaymentNetwork() as NativeTokenPaymentNetwork,
       networkName: 'aurora-testnet',
+      suffix: 'testnet',
+      wrongSuffix: 'near',
+      currency: nearTestnetCurrency,
+      wrongCurrency: nearCurrency,
+    },
+    {
+      name: 'near',
+      paymentNetwork: new NearNativePaymentNetwork() as NativeTokenPaymentNetwork,
+      networkName: 'near',
+      suffix: 'near',
+      wrongSuffix: 'testnet',
+      currency: nearCurrency,
+      wrongCurrency: nearTestnetCurrency,
+    },
+    {
+      name: 'near-testnet',
+      paymentNetwork: new NearNativePaymentNetwork() as NativeTokenPaymentNetwork,
+      networkName: 'near-testnet',
       suffix: 'testnet',
       wrongSuffix: 'near',
       currency: nearTestnetCurrency,
@@ -136,7 +154,7 @@ describe('extensions/payment-network/native-token', () => {
           paymentNetworkName: 'another-chain',
         });
       }).toThrowError(
-        `Payment network 'another-chain' is not supported by this extension (only aurora, aurora-testnet, near-testnet)`,
+        `Payment network 'another-chain' is not supported by this extension (only aurora, aurora-testnet)`,
       );
     });
     it('createCreationAction() throws without payment network', () => {


### PR DESCRIPTION
## Description of the changes
Accept near-testnet network name by mapping it to aurora-test in all actions