### PR TITLE
chore: support 'near-testnet' aside 'aurora-testnet'

### DIFF
--- a/packages/advanced-logic/src/extensions/payment-network/any-to-near.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-near.ts
@@ -4,7 +4,7 @@ import { UnsupportedNetworkError } from './address-based';
 import AnyToNativeTokenPaymentNetwork from './any-to-native';
 
 const CURRENT_VERSION = '0.1.0';
-const supportedNetworks = ['aurora', 'aurora-testnet'];
+const supportedNetworks = ['aurora', 'aurora-testnet', 'near-testnet'];
 
 export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetwork {
   public constructor(
@@ -26,6 +26,7 @@ export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetw
       case 'aurora':
         return this.isValidMainnetAddress(address);
       case 'aurora-testnet':
+      case 'near-testnet':
         return this.isValidTestnetAddress(address);
       case undefined:
         return this.isValidMainnetAddress(address) || this.isValidTestnetAddress(address);

--- a/packages/advanced-logic/src/extensions/payment-network/near-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/near-native.ts
@@ -3,7 +3,7 @@ import { UnsupportedNetworkError } from './address-based';
 import NativeTokenPaymentNetwork from './native-token';
 
 const CURRENT_VERSION = '0.2.0';
-const supportedNetworks = ['aurora', 'aurora-testnet'];
+const supportedNetworks = ['aurora', 'aurora-testnet', 'near-testnet'];
 
 /**
  * Implementation of the payment network to pay in Near based on input data.
@@ -27,6 +27,7 @@ export default class NearNativePaymentNetwork extends NativeTokenPaymentNetwork 
       case 'aurora':
         return this.isValidMainnetAddress(address);
       case 'aurora-testnet':
+      case 'near-testnet':
         return this.isValidTestnetAddress(address);
       case undefined:
         return this.isValidMainnetAddress(address) || this.isValidTestnetAddress(address);

--- a/packages/advanced-logic/test/extensions/payment-network/any-to-near.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/any-to-near.test.ts
@@ -186,7 +186,7 @@ describe('extensions/payment-network/any-to-native-token', () => {
                 network: 'another-chain',
               });
             }).toThrowError(
-              `Payment network 'another-chain' is not supported by this extension (only aurora, aurora-testnet)`,
+              `Payment network 'another-chain' is not supported by this extension (only aurora, aurora-testnet, near-testnet)`,
             );
           });
           it('throws when payment network is missing', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
@@ -136,7 +136,7 @@ describe('extensions/payment-network/native-token', () => {
           paymentNetworkName: 'another-chain',
         });
       }).toThrowError(
-        `Payment network 'another-chain' is not supported by this extension (only aurora, aurora-testnet)`,
+        `Payment network 'another-chain' is not supported by this extension (only aurora, aurora-testnet, near-testnet)`,
       );
     });
     it('createCreationAction() throws without payment network', () => {

--- a/packages/currency/src/conversion-aggregators.ts
+++ b/packages/currency/src/conversion-aggregators.ts
@@ -36,6 +36,7 @@ const chainlinkCurrencyPairs: AggregatorsMap = {
 const fluxCurrencyPairs: AggregatorsMap = {
   aurora: nearAggregator,
   'aurora-testnet': nearTestnetAggregator,
+  'near-testnet': nearTestnetAggregator,
 };
 
 // FIX ME: This fix enables to get these networks registered in conversionSupportedNetworks.

--- a/packages/currency/src/currency-utils.ts
+++ b/packages/currency/src/currency-utils.ts
@@ -13,7 +13,11 @@ import { RequestLogicTypes } from '@requestnetwork/types';
  */
 export const isValidNearAddress = (address: string, network?: string): boolean => {
   if (!network) {
-    return isValidNearAddress(address, 'aurora') || isValidNearAddress(address, 'aurora-testnet');
+    return (
+      isValidNearAddress(address, 'aurora') ||
+      isValidNearAddress(address, 'aurora-testnet') ||
+      isValidNearAddress(address, 'near-testnet')
+    );
   }
   // see link bellow for NEAR address specification
   // https://nomicon.io/DataStructures/Account.html

--- a/packages/currency/src/currency-utils.ts
+++ b/packages/currency/src/currency-utils.ts
@@ -39,6 +39,7 @@ export const isValidNearAddress = (address: string, network?: string): boolean =
     case 'aurora':
       return !!address.match(/\.near$/);
     case 'aurora-testnet':
+    case 'near-testnet':
       return !!address.match(/\.testnet$/);
     default:
       throw new Error(`Cannot validate NEAR address for network ${network}`);

--- a/packages/payment-detection/src/eth/multichainExplorerApiProvider.ts
+++ b/packages/payment-detection/src/eth/multichainExplorerApiProvider.ts
@@ -46,6 +46,7 @@ export class MultichainExplorerApiProvider extends ethers.providers.EtherscanPro
       case 'aurora':
         return 'https://explorer.mainnet.near.org';
       case 'aurora-testnet':
+      case 'near-testnet':
         return 'https://explorer.testnet.near.org';
       case 'arbitrum-rinkeby':
         return 'https://testnet.arbiscan.io/';

--- a/packages/payment-detection/src/near/near-conversion-detector.ts
+++ b/packages/payment-detection/src/near/near-conversion-detector.ts
@@ -51,6 +51,9 @@ export class NearConversionNativeTokenPaymentDetector extends AnyToAnyDetector<
       'aurora-testnet': {
         '0.1.0': 'native.conversion.reqnetwork.testnet',
       },
+      'near-testnet': {
+        '0.1.0': 'native.conversion.reqnetwork.testnet',
+      },
     };
     if (versionMap[chainName]?.[version]) {
       return versionMap[chainName][version];

--- a/packages/payment-detection/src/near/near-detector.ts
+++ b/packages/payment-detection/src/near/near-detector.ts
@@ -41,6 +41,10 @@ export class NearNativeTokenPaymentDetector extends ReferenceBasedDetector<
         '0.1.0': 'dev-1626339335241-5544297',
         '0.2.0': 'dev-1631521265288-35171138540673',
       },
+      'near-testnet': {
+        '0.1.0': 'dev-1626339335241-5544297',
+        '0.2.0': 'dev-1631521265288-35171138540673',
+      },
     };
     if (versionMap[chainName]?.[version]) {
       return versionMap[chainName][version];

--- a/packages/payment-detection/src/near/retrievers/near-info-retriever.ts
+++ b/packages/payment-detection/src/near/retrievers/near-info-retriever.ts
@@ -25,7 +25,7 @@ export class NearInfoRetriever {
     protected eventName: PaymentTypes.EVENTS_NAMES,
     network: string,
   ) {
-    if (network !== 'aurora' && network !== 'aurora-testnet') {
+    if (network !== 'aurora' && network !== 'aurora-testnet' && network !== 'near-testnet') {
       throw new Error('Near input data info-retriever only works with Near mainnet and testnet');
     }
 

--- a/packages/payment-detection/src/payment-network-factory.ts
+++ b/packages/payment-detection/src/payment-network-factory.ts
@@ -50,6 +50,9 @@ const supportedPaymentNetwork: ISupportedPaymentNetworkByCurrency = {
     'aurora-testnet': {
       [PN_ID.NATIVE_TOKEN]: NearNativeTokenPaymentDetector,
     },
+    'near-testnet': {
+      [PN_ID.NATIVE_TOKEN]: NearNativeTokenPaymentDetector,
+    },
     '*': {
       [PN_ID.ETH_INPUT_DATA]: EthInputDataPaymentDetector,
       [PN_ID.ETH_FEE_PROXY_CONTRACT]: EthFeeProxyPaymentDetector,

--- a/packages/payment-detection/test/near/near-native-conversion.test.ts
+++ b/packages/payment-detection/test/near/near-native-conversion.test.ts
@@ -199,7 +199,7 @@ describe('Near payments detection', () => {
         error: {
           code: 2,
           message:
-            'Payment network unknown-network not supported by pn-any-to-native-token payment detection. Supported networks: aurora, near-testnet',
+            'Payment network unknown-network not supported by pn-any-to-native-token payment detection. Supported networks: aurora, aurora-testnet, near-testnet',
         },
         events: [],
       });

--- a/packages/payment-detection/test/near/near-native-conversion.test.ts
+++ b/packages/payment-detection/test/near/near-native-conversion.test.ts
@@ -18,7 +18,7 @@ import { mocked } from 'ts-jest/utils';
 jest.mock('graphql-request');
 const graphql = mocked(GraphQLClient.prototype);
 const mockNearPaymentNetwork = {
-  supportedNetworks: ['aurora', 'aurora-testnet'],
+  supportedNetworks: ['aurora', 'aurora-testnet', 'near-testnet'],
 };
 const currencyManager = CurrencyManager.getDefault();
 
@@ -199,7 +199,7 @@ describe('Near payments detection', () => {
         error: {
           code: 2,
           message:
-            'Payment network unknown-network not supported by pn-any-to-native-token payment detection. Supported networks: aurora, aurora-testnet',
+            'Payment network unknown-network not supported by pn-any-to-native-token payment detection. Supported networks: aurora, near-testnet',
         },
         events: [],
       });

--- a/packages/payment-detection/test/near/near-native.test.ts
+++ b/packages/payment-detection/test/near/near-native.test.ts
@@ -11,7 +11,7 @@ import { NearNativeTokenPaymentDetector, NearInfoRetriever } from '../../src/nea
 import { deepCopy } from 'ethers/lib/utils';
 
 const mockNearPaymentNetwork = {
-  supportedNetworks: ['aurora', 'aurora-testnet'],
+  supportedNetworks: ['aurora', 'aurora-testnet', 'near-testnet'],
 };
 const currencyManager = CurrencyManager.getDefault();
 
@@ -134,7 +134,7 @@ describe('Near payments detection', () => {
         error: {
           code: 2,
           message:
-            'Payment network unknown-network not supported by pn-native-token payment detection. Supported networks: aurora, aurora-testnet',
+            'Payment network unknown-network not supported by pn-native-token payment detection. Supported networks: aurora, aurora-testnet, near-testnet',
         },
         events: [],
       });

--- a/packages/payment-processor/src/payment/utils-near.ts
+++ b/packages/payment-processor/src/payment/utils-near.ts
@@ -26,7 +26,10 @@ export const isValidNearAddress = async (nearNetwork: Near, address: string): Pr
 };
 
 export const isNearNetwork = (network?: string): boolean => {
-  return !!network && (network === 'aurora-testnet' || network === 'aurora');
+  return (
+    !!network &&
+    (network === 'near-testnet' || network === 'aurora-testnet' || network === 'aurora')
+  );
 };
 
 export const isNearAccountSolvent = (


### PR DESCRIPTION
## Description of the changes
This is a first temporary step towards replacing all the mistaken mentions of `aurora`.

This step is non-breaking and does not change the way we create or store requests.
It only focuses on testnet.

Target design after the whole change:
- Bump the request-logic version, and the concerned extension versions. These versions will only support `near` and `near-testnet`
- Keep supporting `aurora` and `aurora-testnet` for earlier versions of the extensions and request-logic
- The support for `aurora` and `aurora-testnet` should impact a small portion of the code, where we read the storage layer.