### PR TITLE
chore: adding tNEAR for near-testnet

### DIFF
--- a/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
@@ -21,10 +21,15 @@ describe('extensions/payment-network/native-token', () => {
     value: 'NEAR',
     network: 'aurora',
   };
-  const nearTestnetCurrency = {
+  const auroraTestnetCurrency = {
     type: RequestLogicTypes.CURRENCY.ETH,
     value: 'NEAR-testnet',
     network: 'aurora-testnet',
+  };
+  const nearTestnetCurrency = {
+    type: RequestLogicTypes.CURRENCY.ETH,
+    value: 'tNEAR',
+    network: 'near-testnet',
   };
   const nativeTokenTestCases = [
     {
@@ -34,12 +39,21 @@ describe('extensions/payment-network/native-token', () => {
       suffix: 'near',
       wrongSuffix: 'testnet',
       currency: nearCurrency,
-      wrongCurrency: nearTestnetCurrency,
+      wrongCurrency: auroraTestnetCurrency,
+    },
+    {
+      name: 'Aurora testnet',
+      paymentNetwork: new NearNativePaymentNetwork() as NativeTokenPaymentNetwork,
+      networkName: 'aurora-testnet',
+      suffix: 'testnet',
+      wrongSuffix: 'near',
+      currency: auroraTestnetCurrency,
+      wrongCurrency: nearCurrency,
     },
     {
       name: 'Near testnet',
       paymentNetwork: new NearNativePaymentNetwork() as NativeTokenPaymentNetwork,
-      networkName: 'aurora-testnet',
+      networkName: 'near-testnet',
       suffix: 'testnet',
       wrongSuffix: 'near',
       currency: nearTestnetCurrency,

--- a/packages/currency/src/currencyManager.ts
+++ b/packages/currency/src/currencyManager.ts
@@ -237,6 +237,7 @@ export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta>
         switch (currency.symbol) {
           case 'NEAR':
           case 'NEAR-testnet':
+          case 'tNEAR':
             return isValidNearAddress(address, currency.network);
           default:
             // we don't pass a third argument to the validate method here

--- a/packages/currency/src/native.ts
+++ b/packages/currency/src/native.ts
@@ -61,12 +61,6 @@ export const nativeCurrencies: Record<NativeCurrencyType, (NativeCurrency & { na
       symbol: 'BNB',
       decimals: 18,
       name: 'BNB',
-      network: 'bsctest',
-    },
-    {
-      symbol: 'BNB',
-      decimals: 18,
-      name: 'BNB',
       network: 'bsc',
     },
     {
@@ -80,6 +74,12 @@ export const nativeCurrencies: Record<NativeCurrencyType, (NativeCurrency & { na
       decimals: 24,
       name: 'Near Testnet',
       network: 'aurora-testnet',
+    },
+    {
+      symbol: 'tNEAR',
+      decimals: 24,
+      name: 'Test Near',
+      network: 'near-testnet',
     },
     {
       symbol: 'ARETH',

--- a/packages/currency/test/currencyManager.test.ts
+++ b/packages/currency/test/currencyManager.test.ts
@@ -456,6 +456,7 @@ describe('CurrencyManager', () => {
     const nearAddresses: Record<string, string> = {
       aurora: 'requestnetwork.near',
       'aurora-testnet': 'requestnetwork.testnet',
+      'near-testnet': 'requestnetwork.testnet',
     };
 
     const eip55Addresses: string[] = [
@@ -489,6 +490,13 @@ describe('CurrencyManager', () => {
           network: 'aurora-testnet',
         },
       },
+      near: {
+        tNEAR: {
+          type: RequestLogicTypes.CURRENCY.ETH,
+          symbol: 'tNEAR',
+          network: 'near-testnet',
+        },
+      },
     };
 
     const testValidateAddressForCurrency = (
@@ -520,6 +528,7 @@ describe('CurrencyManager', () => {
                   switch (currency.symbol) {
                     case 'NEAR':
                     case 'NEAR-testnet':
+                    case 'tNEAR':
                       testValidateAddressForCurrency(nearAddresses[currency.network], currency);
                       break;
                     default:


### PR DESCRIPTION
## Description of the changes
need new native token declared on new chain to be able to test the integration in currency-api and then from end to end