### PR TITLE
fix: NEAR native timestamp precision

### DIFF
--- a/packages/payment-detection/test/near/near-native.test.ts
+++ b/packages/payment-detection/test/near/near-native.test.ts
@@ -64,7 +64,7 @@ describe('Near payments detection', () => {
     expect(events).toHaveLength(1);
 
     expect(events[0].amount).toBe('1000000000000000000000000');
-    expect(events[0].timestamp).toBe(1631788427230);
+    expect(events[0].timestamp).toBe(1631788427);
     expect(events[0].parameters?.receiptId).toBe('FYVnCvJFoNtK7LE2uAdTFfReFMGiCUHMczLsvEni1Cpf');
     expect(events[0].parameters?.txHash).toBeUndefined();
     expect(events[0].parameters?.block).toBe(47891257);


### PR DESCRIPTION
## Description of the changes
* Adapt to the subgraph timestamp fix