### PR TITLE
chore: default Avalanche currencies and aggregation util

### DIFF
--- a/packages/currency/src/erc20/networks/avalanche.ts
+++ b/packages/currency/src/erc20/networks/avalanche.ts
@@ -1,0 +1,35 @@
+import { TokenMap } from './types';
+
+// List of the supported bsc network tokens
+export const supportedAvalancheERC20: TokenMap = {
+  '0x9fB1d52596c44603198fB0aee434fac3a679f702': {
+    name: 'Jarvis Synthetic Euro',
+    symbol: 'jEUR',
+    decimals: 18,
+  },
+  '0xc7198437980c041c805A1EDcbA50c1Ce5db95118': {
+    name: 'Tether USD',
+    symbol: 'USDTe',
+    decimals: 6,
+  },
+  '0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664': {
+    name: 'USD Coin',
+    symbol: 'USDCe',
+    decimals: 6,
+  },
+  '0xd586E7F844cEa2F87f50152665BCbc2C279D8d70': {
+    name: 'Dai Stablecoin',
+    symbol: 'DAIe',
+    decimals: 18,
+  },
+  '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E': {
+    name: 'USD Coin',
+    symbol: 'USDC',
+    decimals: 6,
+  },
+  '0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7': {
+    name: 'TetherToken',
+    symbol: 'USDT',
+    decimals: 6,
+  },
+};

--- a/packages/currency/src/erc20/networks/index.ts
+++ b/packages/currency/src/erc20/networks/index.ts
@@ -8,6 +8,7 @@ import { supportedBSCTestERC20 } from './bsctest';
 import { supportedBSCERC20 } from './bsc';
 import { supportedXDAIERC20 } from './xdai';
 import { supportedGoerliERC20 } from './goerli';
+import { supportedAvalancheERC20 } from './avalanche';
 
 export const supportedNetworks: Record<string, TokenMap> = {
   celo: supportedCeloERC20,
@@ -20,6 +21,7 @@ export const supportedNetworks: Record<string, TokenMap> = {
   bsctest: supportedBSCTestERC20,
   bsc: supportedBSCERC20,
   xdai: supportedXDAIERC20,
+  avalanche: supportedAvalancheERC20,
 };
 
 export type { TokenMap };

--- a/packages/toolbox/src/commands/chainlink/aggregatorsUtils.ts
+++ b/packages/toolbox/src/commands/chainlink/aggregatorsUtils.ts
@@ -34,6 +34,7 @@ const feedMap: Record<string, [chainKey: string, networkName: string]> = {
   matic: ['polygon', 'Polygon Mainnet'],
   xdai: ['gnosis-chain', 'Gnosis Chain Mainnet'],
   bsc: ['bnb-chain', 'BNB Chain Mainnet'],
+  avalanche: ['avalanche', 'Avalanche Mainnet'],
 };
 
 export const getAvailableAggregators = async (


### PR DESCRIPTION
## Description of the changes

Adds a few Avalanche ERC20 as Currency Manager defaults.

Support the Avalanche network for the aggregators toolbox.