### PR TITLE
feat(toolbox): add aggregators by name

### DIFF
--- a/packages/toolbox/src/commands/chainlink/addAggregator.ts
+++ b/packages/toolbox/src/commands/chainlink/addAggregator.ts
@@ -1,5 +1,7 @@
 import * as yargs from 'yargs';
 import { runUpdate } from './contractUtils';
+import { getAllAggregators, getCurrencyManager } from './aggregatorsUtils';
+import assert from 'assert';
 
 type Options = {
   dryRun: boolean;
@@ -8,7 +10,8 @@ type Options = {
   mnemonic?: string;
   input: string;
   output: string;
-  aggregator: string;
+  aggregator?: string;
+  list?: string;
 };
 
 export const command = 'addAggregator <network>';
@@ -26,14 +29,17 @@ export const builder = (): yargs.Argv<Options> =>
     input: {
       type: 'string',
       demandOption: true,
+      describe: 'The token hash, or symbol, to use as input',
     },
     output: {
       type: 'string',
       demandOption: true,
+      describe: 'The token hash, or symbol, to use as output',
     },
     aggregator: {
       type: 'string',
-      demandOption: true,
+      describe:
+        'The address of the aggregation contract, or its name on ChainLink docs. eg. "USDC / USD". If omitted, will default to "input / output"',
     },
     mnemonic: {
       type: 'string',
@@ -42,9 +48,38 @@ export const builder = (): yargs.Argv<Options> =>
       type: 'string',
       describe: 'Takes precedence over mnemonic',
     },
+    list: {
+      type: 'string',
+      describe:
+        'Required when passing symbols in input or output. The list NAME must be available at https://api.request.network/currency/list/NAME',
+    },
   });
 
 export const handler = async (args: Options): Promise<void> => {
-  const { input, output, aggregator } = args;
+  let { input, output, aggregator } = args;
+  const { network, list } = args;
+
+  const currencyManager = await getCurrencyManager(list);
+  const inputCcy = currencyManager.from(input, network) || currencyManager.from(input);
+  const outputCcy = currencyManager.from(output, network) || currencyManager.from(output);
+
+  if (!input.startsWith('0x')) {
+    assert(inputCcy, `input ${input} not found`);
+    input = inputCcy.hash;
+  }
+  if (!output.startsWith('0x')) {
+    assert(outputCcy, `output ${output} not found`);
+    output = outputCcy.hash;
+  }
+  if (!aggregator) {
+    aggregator = `${inputCcy?.symbol} / ${outputCcy?.symbol}`;
+  }
+  if (!aggregator.startsWith('0x')) {
+    const aggregators = await getAllAggregators(network);
+    const newAggregator = aggregators.find((x) => x.pair === aggregator);
+    assert(newAggregator, `aggregator ${aggregator} not found`);
+    aggregator = newAggregator.proxy;
+  }
+  assert(aggregator);
   await runUpdate('updateAggregator', [input, output, aggregator], args);
 };

--- a/packages/toolbox/src/commands/chainlink/aggregatorsUtils.ts
+++ b/packages/toolbox/src/commands/chainlink/aggregatorsUtils.ts
@@ -37,12 +37,7 @@ const feedMap: Record<string, [chainKey: string, networkName: string]> = {
   avalanche: ['avalanche', 'Avalanche Mainnet'],
 };
 
-export const getAvailableAggregators = async (
-  network: string,
-  cm: CurrencyManager,
-  pairs?: string[],
-  listAll?: boolean,
-): Promise<Aggregator[]> => {
+export const getAllAggregators = async (network: string): Promise<Proxy[]> => {
   const [feedName, networkName] = feedMap[network] || [];
   if (!feedName || !networkName) {
     throw new Error(
@@ -57,11 +52,22 @@ export const getAvailableAggregators = async (
   if (!proxies) {
     throw new Error(`not proxies for feed ${feedName} > ${networkName}`);
   }
+  return proxies;
+};
+
+export const getAvailableAggregators = async (
+  network: string,
+  cm: CurrencyManager,
+  pairs?: string[],
+  listAll?: boolean,
+): Promise<Aggregator[]> => {
+  const proxies = await getAllAggregators(network);
+
   const missingAggregators: Aggregator[] = [];
   for (const proxy of proxies) {
     const [from, to] = proxy.pair.split(' / ');
-    const fromCurrency = cm.from(from, network);
-    const toCurrency = cm.from(to, network);
+    const fromCurrency = cm.from(from, network) || cm.from(from);
+    const toCurrency = cm.from(to, network) || cm.from(to);
     if (pairs && !pairs.includes(`${from}-${to}`.toLowerCase())) {
       continue;
     }


### PR DESCRIPTION
Add an (optional) option to pass names instead of addresses

Doc: https://www.notion.so/request/Configure-conversion-aggregators-035c8bdb4d714590b97f96edb71bc28b#e6da9c3660a24053abfcf7f307f0b67f

Usage: 
```bash
export PRIVATE_KEY=...
yarn request-toolbox addAggregator goerli --input USDC --output USD --list invoicing --dryRun
# OR, use addresses 
yarn request-toolbox addAggregator goerli --input 0x... --output 0x775eb53d00dd0acd3ec1696472105d579b9b386b --aggregator 0x... --list invoicing --dryRun
```