### PR TITLE
fix: Equalize currency types by adding missing never keys

### DIFF
--- a/packages/currency/src/types.ts
+++ b/packages/currency/src/types.ts
@@ -7,6 +7,7 @@ export type NativeCurrency = {
   symbol: string;
   decimals: number;
   network: string;
+  address: never;
 };
 
 /** Native Currency types */
@@ -18,6 +19,8 @@ export type NativeCurrencyType = RequestLogicTypes.CURRENCY.BTC | RequestLogicTy
 export type ISO4217Currency = {
   symbol: string;
   decimals: number;
+  network: never;
+  address: never;
 };
 
 /**


### PR DESCRIPTION
## Description of the changes

This PR equalizes the `CurrencyInput` type so we don't get TS errors when trying to access `network` or `address`