### PR TITLE
feat(ethereum-storage): add minimum gas price option

### DIFF
--- a/packages/ethereum-storage/src/ethereum-storage-ethers.ts
+++ b/packages/ethereum-storage/src/ethereum-storage-ethers.ts
@@ -1,12 +1,16 @@
 import { EventEmitter } from 'events';
-import { ContractReceipt, providers, Signer } from 'ethers';
+import { BigNumber, ContractReceipt, providers, Signer } from 'ethers';
 import TypedEmitter from 'typed-emitter';
 import Utils from '@requestnetwork/utils';
 import { LogTypes, StorageTypes } from '@requestnetwork/types';
 import { requestHashSubmitterArtifact } from '@requestnetwork/smart-contracts';
 import { EthereumTransactionSubmitter } from './ethereum-tx-submitter';
 
-export type SubmitterProps = {
+export type GasDefinerProps = {
+  gasPriceMin?: BigNumber;
+};
+
+export type SubmitterProps = GasDefinerProps & {
   network: string;
   signer: Signer;
   logger?: LogTypes.ILogger;
@@ -28,11 +32,11 @@ export class EthereumStorageEthers implements StorageTypes.IStorageWrite {
   private readonly network: string;
   private readonly txSubmitter: EthereumTransactionSubmitter;
 
-  constructor({ network, signer, ipfsStorage, logger }: StorageProps) {
+  constructor({ network, signer, ipfsStorage, logger, gasPriceMin }: StorageProps) {
     this.logger = logger || new Utils.SimpleLogger();
     this.ipfsStorage = ipfsStorage;
     this.network = network;
-    this.txSubmitter = new EthereumTransactionSubmitter({ network, signer, logger });
+    this.txSubmitter = new EthereumTransactionSubmitter({ network, signer, logger, gasPriceMin });
   }
 
   async initialize(): Promise<void> {

--- a/packages/ethereum-storage/src/ethereum-storage-ethers.ts
+++ b/packages/ethereum-storage/src/ethereum-storage-ethers.ts
@@ -57,6 +57,15 @@ export class EthereumStorageEthers implements StorageTypes.IStorageWrite {
       meta: {
         ipfs: { size: ipfsSize },
         local: { location: ipfsHash },
+        ethereum: {
+          blockConfirmation: tx.confirmations,
+          blockNumber: Number(tx.blockNumber),
+          // wrong value, but this metadata will not be used, as it's in Pending state
+          blockTimestamp: -1,
+          networkName: this.network,
+          smartContractAddress: this.txSubmitter.hashSubmitterAddress,
+          transactionHash: tx.hash,
+        },
         state: StorageTypes.ContentState.PENDING,
         storageType: StorageTypes.StorageSystemType.LOCAL,
         timestamp: Utils.getCurrentTimestampInSecond(),

--- a/packages/ethereum-storage/src/ethereum-storage.ts
+++ b/packages/ethereum-storage/src/ethereum-storage.ts
@@ -10,6 +10,7 @@ import IgnoredDataIds from './ignored-dataIds';
 import SmartContractManager from './smart-contract-manager';
 
 import * as Keyv from 'keyv';
+import { BigNumber } from 'ethers';
 
 // time to wait before considering the web3 provider is not reachable
 const WEB3_PROVIDER_TIMEOUT = 10000;
@@ -77,12 +78,14 @@ export class EthereumStorage implements StorageTypes.IStorage {
       maxConcurrency,
       maxRetries,
       retryDelay,
+      gasPriceMin,
     }: {
       getLastBlockNumberDelay?: number;
       logger?: LogTypes.ILogger;
       maxConcurrency?: number;
       maxRetries?: number;
       retryDelay?: number;
+      gasPriceMin?: BigNumber;
     } = {},
     metadataStore?: Keyv.Store<any>,
   ) {
@@ -95,6 +98,7 @@ export class EthereumStorage implements StorageTypes.IStorage {
       maxConcurrency: this.maxConcurrency,
       maxRetries,
       retryDelay,
+      gasPriceMin,
     });
     this.ethereumMetadataCache = new EthereumMetadataCache(metadataStore);
     this.ignoredDataIds = new IgnoredDataIds(metadataStore);

--- a/packages/ethereum-storage/src/ethereum-tx-submitter.ts
+++ b/packages/ethereum-storage/src/ethereum-tx-submitter.ts
@@ -1,10 +1,10 @@
-import { BigNumber, ContractTransaction, providers, utils } from 'ethers';
+import { ContractTransaction, providers, utils } from 'ethers';
 import Utils from '@requestnetwork/utils';
 import { LogTypes } from '@requestnetwork/types';
 import { requestHashSubmitterArtifact } from '@requestnetwork/smart-contracts';
 import { RequestOpenHashSubmitter } from '@requestnetwork/smart-contracts/types';
-import { suggestFees } from 'eip1559-fee-suggestions-ethers';
 import { SubmitterProps } from './ethereum-storage-ethers';
+import { GasFeeDefiner } from './gas-fee-definer';
 
 /**
  * Handles the submission of a hash on the request HashSubmitter contract
@@ -14,14 +14,17 @@ export class EthereumTransactionSubmitter {
   private enableEip1559 = true;
   private readonly hashSubmitter: RequestOpenHashSubmitter;
   private readonly provider: providers.JsonRpcProvider;
+  private readonly gasFeeDefiner: GasFeeDefiner;
 
-  constructor({ network, signer, logger }: SubmitterProps) {
+  constructor({ network, signer, logger, gasPriceMin }: SubmitterProps) {
     this.logger = logger || new Utils.SimpleLogger();
-    this.provider = signer.provider as providers.JsonRpcProvider;
+    const provider = signer.provider as providers.JsonRpcProvider;
+    this.provider = provider;
     this.hashSubmitter = requestHashSubmitterArtifact.connect(
       network,
       signer,
     ) as RequestOpenHashSubmitter; // type mismatch with ethers.
+    this.gasFeeDefiner = new GasFeeDefiner({ provider, gasPriceMin });
   }
 
   async initialize(): Promise<void> {
@@ -44,7 +47,7 @@ export class EthereumTransactionSubmitter {
   /** Encodes the submission of an IPFS hash, with fees according to `ipfsSize` */
   async prepareSubmit(ipfsHash: string, ipfsSize: number): Promise<providers.TransactionRequest> {
     const fee = await this.hashSubmitter.getFeesAmount(ipfsSize);
-    const gasFees = await this.getGasFees();
+    const gasFees = this.enableEip1559 ? await this.gasFeeDefiner.getGasFees() : {};
 
     const tx = this.hashSubmitter.interface.encodeFunctionData('submitHash', [
       ipfsHash,
@@ -52,24 +55,5 @@ export class EthereumTransactionSubmitter {
     ]);
 
     return { to: this.hashSubmitter.address, data: tx, value: fee, ...gasFees };
-  }
-
-  private async getGasFees(): Promise<{
-    maxFeePerGas?: BigNumber;
-    maxPriorityFeePerGas?: BigNumber;
-  }> {
-    if (!this.enableEip1559) {
-      return {};
-    }
-    const suggestedFee = await suggestFees(
-      this.hashSubmitter.provider as providers.JsonRpcProvider,
-    );
-    const maxPriorityFeePerGas = BigNumber.from(suggestedFee.maxPriorityFeeSuggestions.urgent);
-    const maxFeePerGas = maxPriorityFeePerGas.add(suggestedFee.baseFeeSuggestion);
-
-    return {
-      maxPriorityFeePerGas: maxPriorityFeePerGas.gt(0) ? maxPriorityFeePerGas : undefined,
-      maxFeePerGas: maxFeePerGas.gt(0) ? maxFeePerGas : undefined,
-    };
   }
 }

--- a/packages/ethereum-storage/src/ethereum-tx-submitter.ts
+++ b/packages/ethereum-storage/src/ethereum-tx-submitter.ts
@@ -27,6 +27,10 @@ export class EthereumTransactionSubmitter {
     this.gasFeeDefiner = new GasFeeDefiner({ provider, gasPriceMin });
   }
 
+  get hashSubmitterAddress(): string {
+    return this.hashSubmitter.address;
+  }
+
   async initialize(): Promise<void> {
     try {
       await this.provider.send('eth_feeHistory', [1, 'latest', []]);

--- a/packages/ethereum-storage/src/gas-fee-definer.ts
+++ b/packages/ethereum-storage/src/gas-fee-definer.ts
@@ -1,0 +1,41 @@
+import { BigNumber, providers } from 'ethers';
+import { suggestFees } from 'eip1559-fee-suggestions-ethers';
+import { GasDefinerProps } from './ethereum-storage-ethers';
+
+export class GasFeeDefiner {
+  private readonly provider: providers.JsonRpcProvider;
+  private readonly gasPriceMin: BigNumber | undefined;
+
+  constructor({
+    provider,
+    gasPriceMin,
+  }: GasDefinerProps & { provider: providers.JsonRpcProvider }) {
+    this.provider = provider;
+    this.gasPriceMin = gasPriceMin;
+  }
+
+  public async getGasFees(): Promise<{
+    maxFeePerGas?: BigNumber;
+    maxPriorityFeePerGas?: BigNumber;
+  }> {
+    const suggestedFee = await suggestFees(this.provider);
+
+    let maxPriorityFeePerGas: BigNumber | undefined;
+    let maxFeePerGas: BigNumber | undefined;
+
+    maxPriorityFeePerGas = BigNumber.from(suggestedFee.maxPriorityFeeSuggestions.urgent);
+    maxFeePerGas = maxPriorityFeePerGas.add(suggestedFee.baseFeeSuggestion);
+
+    maxPriorityFeePerGas = maxPriorityFeePerGas.gt(0) ? maxPriorityFeePerGas : undefined;
+    maxFeePerGas = maxFeePerGas.gt(0) ? maxFeePerGas : undefined;
+
+    if (this.gasPriceMin && maxFeePerGas && maxFeePerGas.lt(this.gasPriceMin)) {
+      maxFeePerGas = BigNumber.from(this.gasPriceMin);
+    }
+
+    return {
+      maxPriorityFeePerGas,
+      maxFeePerGas,
+    };
+  }
+}

--- a/packages/ethereum-storage/src/gas-fee-definer.ts
+++ b/packages/ethereum-storage/src/gas-fee-definer.ts
@@ -26,7 +26,7 @@ export class GasFeeDefiner {
 
     baseFee = BigNumber.from(suggestedFee.baseFeeSuggestion);
     if (this.gasPriceMin && baseFee.lt(this.gasPriceMin)) {
-      baseFee = BigNumber.from(this.gasPriceMin);
+      baseFee = this.gasPriceMin;
     }
 
     maxPriorityFeePerGas = BigNumber.from(suggestedFee.maxPriorityFeeSuggestions.urgent);

--- a/packages/ethereum-storage/src/gas-fee-definer.ts
+++ b/packages/ethereum-storage/src/gas-fee-definer.ts
@@ -30,7 +30,7 @@ export class GasFeeDefiner {
     }
 
     maxPriorityFeePerGas = BigNumber.from(suggestedFee.maxPriorityFeeSuggestions.urgent);
-    maxFeePerGas = maxPriorityFeePerGas.add(baseFee);
+    maxFeePerGas = baseFee.add(maxPriorityFeePerGas);
 
     maxPriorityFeePerGas = maxPriorityFeePerGas.gt(0) ? maxPriorityFeePerGas : undefined;
     maxFeePerGas = maxFeePerGas.gt(0) ? maxFeePerGas : undefined;

--- a/packages/ethereum-storage/src/gas-fee-definer.ts
+++ b/packages/ethereum-storage/src/gas-fee-definer.ts
@@ -20,18 +20,20 @@ export class GasFeeDefiner {
   }> {
     const suggestedFee = await suggestFees(this.provider);
 
+    let baseFee: BigNumber | undefined;
     let maxPriorityFeePerGas: BigNumber | undefined;
     let maxFeePerGas: BigNumber | undefined;
 
+    baseFee = BigNumber.from(suggestedFee.baseFeeSuggestion);
+    if (this.gasPriceMin && baseFee.lt(this.gasPriceMin)) {
+      baseFee = BigNumber.from(this.gasPriceMin);
+    }
+
     maxPriorityFeePerGas = BigNumber.from(suggestedFee.maxPriorityFeeSuggestions.urgent);
-    maxFeePerGas = maxPriorityFeePerGas.add(suggestedFee.baseFeeSuggestion);
+    maxFeePerGas = maxPriorityFeePerGas.add(baseFee);
 
     maxPriorityFeePerGas = maxPriorityFeePerGas.gt(0) ? maxPriorityFeePerGas : undefined;
     maxFeePerGas = maxFeePerGas.gt(0) ? maxFeePerGas : undefined;
-
-    if (this.gasPriceMin && maxFeePerGas && maxFeePerGas.lt(this.gasPriceMin)) {
-      maxFeePerGas = BigNumber.from(this.gasPriceMin);
-    }
 
     return {
       maxPriorityFeePerGas,

--- a/packages/ethereum-storage/src/gas-price-definer.ts
+++ b/packages/ethereum-storage/src/gas-price-definer.ts
@@ -9,6 +9,7 @@ import Utils from '@requestnetwork/utils';
 
 import { BigNumber } from 'ethers';
 import XDaiFixedProvider from './gas-price-providers/xdai-fixed-provider';
+import { GasDefinerProps } from './ethereum-storage-ethers';
 
 /**
  * Determines the gas price to use depending on the used network
@@ -36,12 +37,19 @@ export class GasPriceDefiner {
    */
   private logger: LogTypes.ILogger;
 
+  private readonly gasPriceMin: BigNumber | undefined;
+
   /**
    * Constructor
    * @param logger Logger instance
+   * @param gasPriceMin Minimum gas price to return
    */
-  public constructor(logger?: LogTypes.ILogger) {
+  public constructor({
+    logger,
+    gasPriceMin,
+  }: GasDefinerProps & { logger?: LogTypes.ILogger } = {}) {
     this.logger = logger || new Utils.SimpleLogger();
+    this.gasPriceMin = gasPriceMin;
   }
 
   /**
@@ -60,10 +68,13 @@ export class GasPriceDefiner {
       const gasPriceArray = await this.pollProviders(type, network);
       if (gasPriceArray.length > 0) {
         // Get the highest gas price from the providers
-        return gasPriceArray.reduce(
+        const gasPrice = gasPriceArray.reduce(
           (currentMax, gasPrice) => (currentMax.gt(gasPrice) ? currentMax : gasPrice),
           BigNumber.from(0),
         );
+        return this.gasPriceMin && gasPrice.lt(this.gasPriceMin)
+          ? BigNumber.from(this.gasPriceMin)
+          : gasPrice;
       } else {
         this.logger.warn('Cannot determine gas price: There is no available gas price provider', [
           'ethereum',

--- a/packages/ethereum-storage/src/gas-price-definer.ts
+++ b/packages/ethereum-storage/src/gas-price-definer.ts
@@ -72,9 +72,7 @@ export class GasPriceDefiner {
           (currentMax, gasPrice) => (currentMax.gt(gasPrice) ? currentMax : gasPrice),
           BigNumber.from(0),
         );
-        return this.gasPriceMin && gasPrice.lt(this.gasPriceMin)
-          ? BigNumber.from(this.gasPriceMin)
-          : gasPrice;
+        return this.gasPriceMin && gasPrice.lt(this.gasPriceMin) ? this.gasPriceMin : gasPrice;
       } else {
         this.logger.warn('Cannot determine gas price: There is no available gas price provider', [
           'ethereum',

--- a/packages/request-node/src/config.ts
+++ b/packages/request-node/src/config.ts
@@ -1,11 +1,13 @@
 import { LogTypes, StorageTypes } from '@requestnetwork/types';
 import * as yargs from 'yargs';
 import { modeType } from './logger';
+// Load environment variables from .env file (without overriding variables already set)
+import { config } from 'dotenv';
+import { formatUnits } from 'ethers/lib/utils';
+import { BigNumber } from 'ethers';
 
 const argv = yargs.parseSync();
 
-// Load environment variables from .env file (without overriding variables already set)
-import { config } from 'dotenv';
 config();
 
 /**
@@ -17,6 +19,7 @@ const defaultValues: any = {
     ethereum: {
       networkId: 0,
       web3ProviderUrl: 'http://localhost:8545',
+      gasPriceMin: formatUnits('1', 'gwei'),
     },
     ipfs: {
       host: 'localhost',
@@ -107,6 +110,14 @@ export function getGraphNodeUrl(): string | undefined {
     process.env.GRAPH_NODE_URL ||
     defaultValues.ethereumStorage.ethereum.graphNodeUrl
   );
+}
+
+export function getGasPriceMin(): BigNumber | undefined {
+  const gasPriceMin =
+    argv.gasPriceMin ||
+    process.env.GAS_PRICE_MIN ||
+    defaultValues.ethereumStorage.ethereum.graphNodeUrl;
+  return gasPriceMin && BigNumber.from(gasPriceMin);
 }
 
 /**

--- a/packages/request-node/src/config.ts
+++ b/packages/request-node/src/config.ts
@@ -1,13 +1,13 @@
 import { LogTypes, StorageTypes } from '@requestnetwork/types';
 import * as yargs from 'yargs';
 import { modeType } from './logger';
-// Load environment variables from .env file (without overriding variables already set)
 import { config } from 'dotenv';
 import { formatUnits } from 'ethers/lib/utils';
 import { BigNumber } from 'ethers';
 
 const argv = yargs.parseSync();
 
+// Load environment variables from .env file (without overriding variables already set)
 config();
 
 /**

--- a/packages/request-node/src/storageUtils.ts
+++ b/packages/request-node/src/storageUtils.ts
@@ -69,6 +69,7 @@ export function getEthereumStorage(
       logger,
       maxConcurrency: config.getStorageConcurrency(),
       retryDelay: config.getEthereumRetryDelay(),
+      gasPriceMin: config.getGasPriceMin(),
     },
     store,
   );


### PR DESCRIPTION
## Description of the changes

This PR adds a new configuration to the request node:
- `argv.gasPriceMin`
- `process.env.GAS_PRICE_MIN`

This defaults to 1gwei, as we noticed by trial and error that most RPC nodes do not accept tx with a lower gas price (however we cannot find official spec to support this claim).

Typical errors from RPCs are:
> Error: FeeTooLow, EffectivePriorityFeePerGas too low 586749412 < 1000000000, BaseFee: 7