### PR TITLE
chore: refacto supported conversion

### DIFF
--- a/packages/advanced-logic/package.json
+++ b/packages/advanced-logic/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@requestnetwork/currency": "0.9.0",
+    "@requestnetwork/smart-contracts": "0.29.0",
     "@requestnetwork/types": "0.36.0",
     "@requestnetwork/utils": "0.36.0",
     "@types/node": "14.14.16",

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
@@ -1,10 +1,7 @@
-import {
-  conversionSupportedNetworks,
-  ICurrencyManager,
-  UnsupportedCurrencyError,
-} from '@requestnetwork/currency';
+import { ICurrencyManager, UnsupportedCurrencyError } from '@requestnetwork/currency';
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import Erc20FeeProxyPaymentNetwork from './erc20/fee-proxy-contract';
+import { erc20ConversionProxy } from '@requestnetwork/smart-contracts';
 
 const CURRENT_VERSION = '0.1.0';
 
@@ -135,7 +132,7 @@ export default class AnyToErc20ProxyPaymentNetwork extends Erc20FeeProxyPaymentN
       return;
     }
 
-    if (!conversionSupportedNetworks.includes(network)) {
+    if (!erc20ConversionProxy.isDeployedOnNetwork(network)) {
       throw new Error(`The network (${network}) is not supported for this payment network.`);
     }
 

--- a/packages/currency/src/conversion-aggregators.ts
+++ b/packages/currency/src/conversion-aggregators.ts
@@ -40,17 +40,6 @@ const fluxCurrencyPairs: AggregatorsMap = {
   'near-testnet': nearTestnetAggregator,
 };
 
-// FIX ME: This fix enables to get these networks registered in conversionSupportedNetworks.
-// Could be improved by removing the supported network check from the protocol
-const noConversionNetworks: AggregatorsMap = {
-  'arbitrum-rinkeby': {},
-  'arbitrum-one': {},
-  xdai: {},
-  avalanche: {},
-  bsc: {},
-  optimism: {},
-};
-
 /**
  * Conversion paths per network used by default if no other path given to the Currency Manager.
  * Must be updated every time an aggregator is added to one network.
@@ -58,10 +47,7 @@ const noConversionNetworks: AggregatorsMap = {
 export const defaultConversionPairs: AggregatorsMap = {
   ...chainlinkCurrencyPairs,
   ...fluxCurrencyPairs,
-  ...noConversionNetworks,
 };
-
-export const conversionSupportedNetworks = Object.keys(defaultConversionPairs);
 
 /**
  * Gets the on-chain conversion path between two currencies.

--- a/packages/currency/src/index.ts
+++ b/packages/currency/src/index.ts
@@ -1,10 +1,6 @@
 export { getSupportedERC20Tokens } from './erc20';
 export { getSupportedERC777Tokens } from './erc777';
-export {
-  conversionSupportedNetworks,
-  CurrencyPairs,
-  AggregatorsMap,
-} from './conversion-aggregators';
+export { CurrencyPairs, AggregatorsMap } from './conversion-aggregators';
 export { getHash as getCurrencyHash } from './getHash';
 export { CurrencyManager } from './currencyManager';
 export * from './types';

--- a/packages/smart-contracts/src/lib/ContractArtifact.ts
+++ b/packages/smart-contracts/src/lib/ContractArtifact.ts
@@ -42,6 +42,7 @@ export class ContractArtifact<TContract extends Contract> {
     this.getDeploymentInformation = this.getDeploymentInformation.bind(this);
     this.getAllAddresses = this.getAllAddresses.bind(this);
     this.getOptionalDeploymentInformation = this.getOptionalDeploymentInformation.bind(this);
+    this.isDeployedOnNetwork = this.isDeployedOnNetwork.bind(this);
   }
 
   /**
@@ -134,5 +135,18 @@ export class ContractArtifact<TContract extends Contract> {
     version = this.lastVersion,
   ): DeploymentInformation | null {
     return this.info[version]?.deployment[networkName] || null;
+  }
+
+  /**
+   * Check if the artifact has been deployed on a specific network
+   * @param networkName the network to check the deployment for
+   * @param version optional version to check the deployment for. If not set check for all versions
+   * @returns the check result
+   */
+  isDeployedOnNetwork(networkName: string, version?: string): boolean {
+    const entries = Object.entries(this.info);
+    return entries.some(
+      ([vrs, { deployment }]) => !!deployment[networkName] && (!version || version === vrs),
+    );
   }
 }

--- a/packages/toolbox/src/commands/chainlink/addAggregators.ts
+++ b/packages/toolbox/src/commands/chainlink/addAggregators.ts
@@ -2,7 +2,7 @@ import * as yargs from 'yargs';
 import inquirer from 'inquirer';
 import { runUpdate } from './contractUtils';
 import { Aggregator, getAvailableAggregators, getCurrencyManager } from './aggregatorsUtils';
-import { conversionSupportedNetworks } from '@requestnetwork/currency';
+import { erc20ConversionProxy, ethConversionArtifact } from '@requestnetwork/smart-contracts';
 
 type Options = {
   dryRun: boolean;
@@ -73,11 +73,11 @@ export const handler = async (args: Options): Promise<void> => {
 
   const currencyManager = await getCurrencyManager(args.list);
 
-  if (!conversionSupportedNetworks.includes(network)) {
-    console.warn(
-      `WARNING: ${network} is missing in conversionSupportedNetworks from the Currency package.`,
-      `Add '${network}: {}' to chainlinkCurrencyPairs, in currency/src/conversion-aggregators.ts.`,
-    );
+  if (
+    !erc20ConversionProxy.isDeployedOnNetwork(network) &&
+    !ethConversionArtifact.isDeployedOnNetwork(network)
+  ) {
+    console.warn(`WARNING: ${network} does not support any-to-eth nor any-to-erc.`);
   }
 
   const availableAggregators = await getAvailableAggregators(


### PR DESCRIPTION
## Description of the changes

This add a utility function in the `ContractArtifact` class to determine if a contract is deployed on a specific network.

It allows to remove the `supportedConversionNetworks` variable from the advanced-logic, which reduces the number of file to update when deploying our contracts to new chains. 