### PR TITLE
feat: tombchain

### DIFF
--- a/packages/currency/src/native.ts
+++ b/packages/currency/src/native.ts
@@ -111,6 +111,12 @@ export const nativeCurrencies: Record<NativeCurrencyType, (NativeCurrency & { na
       name: 'Glimmer',
       network: 'moonbeam',
     },
+    {
+      symbol: 'TOMB',
+      decimals: 18,
+      name: 'Tomb',
+      network: 'tombchain',
+    },
   ],
   [RequestLogicTypes.CURRENCY.BTC]: [
     {

--- a/packages/smart-contracts/hardhat.config.ts
+++ b/packages/smart-contracts/hardhat.config.ts
@@ -135,6 +135,11 @@ export default {
       chainId: 1284,
       accounts,
     },
+    tombchain: {
+      url: url('tombchain'),
+      chainId: 6969,
+      accounts,
+    },
   },
   etherscan: {
     apiKey: {

--- a/packages/smart-contracts/scripts-create2/contract-setup/adminTasks.ts
+++ b/packages/smart-contracts/scripts-create2/contract-setup/adminTasks.ts
@@ -248,7 +248,13 @@ export const getSignerAndGasFees = async (
     provider = utils.getDefaultProvider(network);
   }
   const signer = new hre.ethers.Wallet(hre.config.xdeploy.signer).connect(provider);
-  const txOverrides = await utils.estimateGasFees({ provider });
+
+  let txOverrides;
+  try {
+    txOverrides = await utils.estimateGasFees({ provider });
+  } catch (err) {
+    txOverrides = {};
+  }
 
   return {
     signer,

--- a/packages/smart-contracts/scripts-create2/xdeployer.ts
+++ b/packages/smart-contracts/scripts-create2/xdeployer.ts
@@ -71,12 +71,15 @@ export const xdeploy = async (
     let receipt = undefined;
     let deployed = false;
     let error = undefined;
+    let txOverrides: Overrides;
 
-    const txOverrides: Overrides = await utils.estimateGasFees({ provider });
     try {
+      txOverrides = await utils.estimateGasFees({ provider });
       const gasLimit = hre.config.xdeploy.gasLimit;
       txOverrides.gasLimit = gasLimit;
     } catch (e) {
+      // NOTE: On some networks utils.estimateGasFees do not work
+      txOverrides = {};
       console.log('Cannot estimate gasLimit');
     }
 

--- a/packages/smart-contracts/src/lib/artifacts/ERC20FeeProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/ERC20FeeProxy/index.ts
@@ -131,6 +131,10 @@ export const erc20FeeProxyArtifact = new ContractArtifact<ERC20FeeProxy>(
           address: '0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE',
           creationBlockNumber: 2415492,
         },
+        tombchain: {
+          address: '0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE',
+          creationBlockNumber: 2951048,
+        },
       },
     },
     // Additional deployments of same versions, not worth upgrading the version number but worth using within next versions

--- a/packages/smart-contracts/src/lib/artifacts/EthereumFeeProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/EthereumFeeProxy/index.ts
@@ -118,6 +118,10 @@ export const ethereumFeeProxyArtifact = new ContractArtifact<EthereumFeeProxy>(
           address: '0xe11BF2fDA23bF0A98365e1A4c04A87C9339e8687',
           creationBlockNumber: 2415490,
         },
+        tombchain: {
+          address: '0xe11BF2fDA23bF0A98365e1A4c04A87C9339e8687',
+          creationBlockNumber: 2951047,
+        },
       },
     },
   },

--- a/packages/smart-contracts/src/lib/artifacts/RequestDeployer/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/RequestDeployer/index.ts
@@ -69,6 +69,10 @@ export const requestDeployer = new ContractArtifact<RequestDeployer>(
           address: '0xE99Ab70a5FAE59551544FA326fA048f7B95A24B2',
           creationBlockNumber: 2415122,
         },
+        tombchain: {
+          address: '0xE99Ab70a5FAE59551544FA326fA048f7B95A24B2',
+          creationBlockNumber: 2950756,
+        },
       },
     },
   },

--- a/packages/utils/src/providers.ts
+++ b/packages/utils/src/providers.ts
@@ -43,6 +43,7 @@ const networkRpcs: Record<string, string> = {
   avalanche: 'https://api.avax.network/ext/bc/C/rpc',
   optimism: 'https://mainnet.optimism.io',
   moonbeam: 'https://moonbeam.public.blastapi.io',
+  tombchain: 'https://rpc.tombchain.com/',
 };
 
 /**


### PR DESCRIPTION
## Description of the changes

Tombchain is a permissioned L2 evm.
Deployments: only `ERC20FeeProxy` and `EthFeeProxy.`

Additional fix:
When making the deployment, I was blocked as the Tombchain Node RPC did not support the eth_FeeHistory method used by the eip1559.
All evm nodes may not support it yet. It does not block the deployment anymore