### PR TITLE
fix: ci fails on prs from external forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ yarn run lint
 
 ### Test
 
+Disable API tests OR define all required etherscan API keys.
+
+```bash
+export DISABLE_API_TESTS=1
+# OR
+export EXPLORER_API_KEY_MAINNET=
+export EXPLORER_API_KEY_RINKEBY=
+export EXPLORER_API_KEY_FUSE=
+export EXPLORER_API_KEY_MATIC=
+export EXPLORER_API_KEY_FANTOM=
+```
+
 Test all the packages in the monorepo.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ yarn run lint
 
 ### Test
 
-Disable API tests OR define all required etherscan API keys.
+Disable API tests OR define all required explorer API keys.
 
 ```bash
 export DISABLE_API_TESTS=1

--- a/packages/payment-detection/README.md
+++ b/packages/payment-detection/README.md
@@ -67,7 +67,7 @@ yarn codegen
 
 # Test
 
-The `Multichain` `InfoRetriever` tests require etherscan API keys.
+The ETH `InfoRetriever` tests require etherscan API keys.
 
 Before running the payment-detection tests, disable API tests OR define all
 required etherscan API keys.

--- a/packages/payment-detection/README.md
+++ b/packages/payment-detection/README.md
@@ -64,3 +64,22 @@ The code generation is included in the pre-build script and can be run manually:
 ```
 yarn codegen
 ```
+
+# Test
+
+The `Multichain` `InfoRetriever` tests require etherscan API keys.
+
+Before running the payment-detection tests, disable API tests OR define all
+required etherscan API keys.
+
+```bash
+export DISABLE_API_TESTS=1
+# OR
+export EXPLORER_API_KEY_MAINNET=
+export EXPLORER_API_KEY_RINKEBY=
+export EXPLORER_API_KEY_FUSE=
+export EXPLORER_API_KEY_MATIC=
+export EXPLORER_API_KEY_FANTOM=
+
+yarn run test
+```

--- a/packages/payment-detection/README.md
+++ b/packages/payment-detection/README.md
@@ -67,10 +67,9 @@ yarn codegen
 
 # Test
 
-The ETH `InfoRetriever` tests require etherscan API keys.
-
-Before running the payment-detection tests, disable API tests OR define all
-required etherscan API keys.
+The ETH `InfoRetriever` tests require explorer API keys. Before running the
+payment-detection tests, define `DISABLE_API_TESTS` or define all required
+explorer API keys.
 
 ```bash
 export DISABLE_API_TESTS=1

--- a/packages/payment-detection/test/eth/info-retriever.test.ts
+++ b/packages/payment-detection/test/eth/info-retriever.test.ts
@@ -59,7 +59,12 @@ describe('api/eth/info-retriever', () => {
       'matic',
       'fantom',
     ].forEach((network) => {
-      it(`Can get the balance on ${network}`, async () => {
+      it(`Can get the balance on ${network}`, async function (this: Mocha.Context) {
+        // Skip test if EXPLORER_API_KEY is not set
+        if (!process.env[`EXPLORER_API_KEY_${network.toUpperCase()}`]) {
+          console.warn(`No explorer API key for ${network}!`);
+          this.skip();
+        }
         const retriever = new EthInputDataInfoRetriever(
           '0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB',
           PaymentTypes.EVENTS_NAMES.PAYMENT,
@@ -71,7 +76,13 @@ describe('api/eth/info-retriever', () => {
       });
     });
 
-    it('can detect a MATIC payment to self', async () => {
+    it('can detect a MATIC payment to self', async function (this: Mocha.Context) {
+      // Skip test if EXPLORER_API_KEY is not set
+      if (!process.env[`EXPLORER_API_KEY_MATIC`]) {
+        console.warn(`No explorer API key for MATIC!`);
+        this.skip();
+      }
+
       // NB: The from and to are the same
       const paymentAddress = '0x4E64C2d06d19D13061e62E291b2C4e9fe5679b93';
       const paymentReference = PaymentReferenceCalculator.calculate(

--- a/packages/payment-detection/test/eth/info-retriever.test.ts
+++ b/packages/payment-detection/test/eth/info-retriever.test.ts
@@ -45,7 +45,14 @@ describe('api/eth/info-retriever', () => {
     await expect(infoRetreiver.getTransferEvents()).rejects.toThrowError();
   });
 
-  describe('Multichain', () => {
+  describe('Multichain', function (this: Mocha.Context) {
+    // Skip tests if build is from external fork or API tests are disabled
+    // External forks cannot access secrets API keys
+    if (process.env.CIRCLE_PR_NUMBER || process.env.DISABLE_API_TESTS) {
+      console.warn('Skipping API tests');
+      this.skip();
+    }
+
     // TODO temporary disable xDAI, CELO, Sokol, and Goerli
     // FIXME: API-based checks should run nightly and be mocked for CI
     [

--- a/packages/payment-detection/test/eth/info-retriever.test.ts
+++ b/packages/payment-detection/test/eth/info-retriever.test.ts
@@ -45,14 +45,11 @@ describe('api/eth/info-retriever', () => {
     await expect(infoRetreiver.getTransferEvents()).rejects.toThrowError();
   });
 
-  describe('Multichain', function (this: Mocha.Context) {
-    // Skip tests if build is from external fork or API tests are disabled
-    // External forks cannot access secrets API keys
-    if (process.env.CIRCLE_PR_NUMBER || process.env.DISABLE_API_TESTS) {
-      console.warn('Skipping API tests');
-      this.skip();
-    }
-
+  // Skip tests if build is from external fork or API tests are disabled
+  // External forks cannot access secrets API keys
+  const describeIf =
+    process.env.CIRCLE_PR_NUMBER || process.env.DISABLE_API_TESTS ? describe : describe.skip;
+  describeIf('Multichain', () => {
     // TODO temporary disable xDAI, CELO, Sokol, and Goerli
     // FIXME: API-based checks should run nightly and be mocked for CI
     [

--- a/packages/payment-detection/test/eth/info-retriever.test.ts
+++ b/packages/payment-detection/test/eth/info-retriever.test.ts
@@ -79,30 +79,26 @@ describe('api/eth/info-retriever', () => {
       });
     });
 
-    it(
-      'can detect a MATIC payment to self',
-      async () => {
-        // NB: The from and to are the same
-        const paymentAddress = '0x4E64C2d06d19D13061e62E291b2C4e9fe5679b93';
-        const paymentReference = PaymentReferenceCalculator.calculate(
-          '01b809015dcda94dccfc626609b0a1d8f8e656ec787cf7f59d59d242dc9f1db0ca',
-          'a1a2a3a4a5a6a7a8',
-          paymentAddress,
-        );
+    it('can detect a MATIC payment to self', async () => {
+      // NB: The from and to are the same
+      const paymentAddress = '0x4E64C2d06d19D13061e62E291b2C4e9fe5679b93';
+      const paymentReference = PaymentReferenceCalculator.calculate(
+        '01b809015dcda94dccfc626609b0a1d8f8e656ec787cf7f59d59d242dc9f1db0ca',
+        'a1a2a3a4a5a6a7a8',
+        paymentAddress,
+      );
 
-        const infoRetriever = new EthInputDataInfoRetriever(
-          paymentAddress,
-          PaymentTypes.EVENTS_NAMES.PAYMENT,
-          'matic',
-          paymentReference,
-          process.env[`EXPLORER_API_KEY_MATIC`],
-        );
-        const events = await infoRetriever.getTransferEvents();
-        expect(events).toHaveLength(1);
+      const infoRetriever = new EthInputDataInfoRetriever(
+        paymentAddress,
+        PaymentTypes.EVENTS_NAMES.PAYMENT,
+        'matic',
+        paymentReference,
+        process.env[`EXPLORER_API_KEY_MATIC`],
+      );
+      const events = await infoRetriever.getTransferEvents();
+      expect(events).toHaveLength(1);
 
-        expect(events[0].amount).toBe('1000000000000000');
-      },
-      undefined,
-    );
+      expect(events[0].amount).toBe('1000000000000000');
+    });
   });
 });

--- a/packages/payment-detection/test/eth/info-retriever.test.ts
+++ b/packages/payment-detection/test/eth/info-retriever.test.ts
@@ -59,12 +59,7 @@ describe('api/eth/info-retriever', () => {
       'matic',
       'fantom',
     ].forEach((network) => {
-      it(`Can get the balance on ${network}`, async function (this: Mocha.Context) {
-        // Skip test if EXPLORER_API_KEY is not set
-        if (!process.env[`EXPLORER_API_KEY_${network.toUpperCase()}`]) {
-          console.warn(`No explorer API key for ${network}!`);
-          this.skip();
-        }
+      it(`Can get the balance on ${network}`, async () => {
         const retriever = new EthInputDataInfoRetriever(
           '0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB',
           PaymentTypes.EVENTS_NAMES.PAYMENT,
@@ -76,13 +71,7 @@ describe('api/eth/info-retriever', () => {
       });
     });
 
-    it('can detect a MATIC payment to self', async function (this: Mocha.Context) {
-      // Skip test if EXPLORER_API_KEY is not set
-      if (!process.env[`EXPLORER_API_KEY_MATIC`]) {
-        console.warn(`No explorer API key for MATIC!`);
-        this.skip();
-      }
-
+    it('can detect a MATIC payment to self', async () => {
       // NB: The from and to are the same
       const paymentAddress = '0x4E64C2d06d19D13061e62E291b2C4e9fe5679b93';
       const paymentReference = PaymentReferenceCalculator.calculate(


### PR DESCRIPTION
Fixes #1029

## Description of the changes

- Add `DISABLE_API_TESTS` env var. When set, disable tests that require API keys.
- Detect `CIRCLE_PR_NUMBER` env var and disable API tests if found. `CIRCLE_PR_NUMBER` indicates that PR originates from an external fork and thus cannot access secret API keys

## Motivation

- Failing CI tests are a major pain point for external contributors right now.
- This is a "bandaid fix". The underlying problem is that API-based checks should run nightly and unit tests should use mocks. See #1031.

## Why use `CIRCLE_PR_NUMBER`?

* `CIRCLE_PR_NUMBER` is recommended by the Circle Blog: https://circleci.com/blog/managing-secrets-when-you-have-pull-requests-from-outside-contributors/

* `CIRCLE_PR_NUMBER` is **only** defined on PRs from external forks and shouldn't have any effect on PRs from internal branches.

* `CIRCLE_PR_NUMBER` is just one of 3 Circle CI environment variables that exist only on PRs from external forks.  The other two are `CIRCLE_PR_REPONAME` and `CIRCLE_PR_USERNAME`.
![image](https://user-images.githubusercontent.com/2530913/210248980-168f9735-218d-4c83-b2be-fb8e4c80552b.png)
Source: https://circleci.com/docs/variables/#built-in-environment-variables