### PR TITLE
refactor(currency): simplify network

### DIFF
--- a/packages/currency/src/currency-utils.ts
+++ b/packages/currency/src/currency-utils.ts
@@ -1,9 +1,9 @@
 import {
   CurrencyInput,
-  ERC20CurrencyInput,
-  ERC777CurrencyInput,
-  ISO4217CurrencyInput,
-  NativeCurrencyInput,
+  ERC20Currency,
+  ERC777Currency,
+  ISO4217Currency,
+  NativeCurrency,
 } from './types';
 import { RequestLogicTypes } from '@requestnetwork/types';
 
@@ -51,21 +51,21 @@ export const isValidNearAddress = (address: string, network?: string): boolean =
  * Enable filtering per currency type
  */
 
-export const isNativeCurrency = (currency: CurrencyInput): currency is NativeCurrencyInput => {
+export const isNativeCurrency = (currency: CurrencyInput): currency is NativeCurrency => {
   return (
     currency.type === RequestLogicTypes.CURRENCY.BTC ||
     currency.type === RequestLogicTypes.CURRENCY.ETH
   );
 };
 
-export const isISO4217Currency = (currency: CurrencyInput): currency is ISO4217CurrencyInput => {
+export const isISO4217Currency = (currency: CurrencyInput): currency is ISO4217Currency => {
   return currency.type === RequestLogicTypes.CURRENCY.ISO4217;
 };
 
-export const isERC20Currency = (currency: CurrencyInput): currency is ERC20CurrencyInput => {
+export const isERC20Currency = (currency: CurrencyInput): currency is ERC20Currency => {
   return currency.type === RequestLogicTypes.CURRENCY.ERC20;
 };
 
-export const isERC777Currency = (currency: CurrencyInput): currency is ERC777CurrencyInput => {
+export const isERC777Currency = (currency: CurrencyInput): currency is ERC777Currency => {
   return currency.type === RequestLogicTypes.CURRENCY.ERC777;
 };

--- a/packages/currency/src/currencyManager.ts
+++ b/packages/currency/src/currencyManager.ts
@@ -125,7 +125,7 @@ export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta>
     return this.knownCurrencies.find(
       (x) =>
         x.symbol.toUpperCase() === symbol &&
-        ((x.type === ISO4217 && !network) || ('network' in x && x.network === network) || !network),
+        ((x.type === ISO4217 && !network) || (x.network && x.network === network) || !network),
     );
   }
 
@@ -133,7 +133,7 @@ export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta>
     return this.knownCurrencies.find(
       (x) =>
         x.hash.toLowerCase() === hash.toLowerCase() &&
-        ((x.type === ISO4217 && !network) || ('network' in x && x.network === network) || !network),
+        ((x.type === ISO4217 && !network) || (x.network && x.network === network) || !network),
     );
   }
   /**
@@ -210,7 +210,7 @@ export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta>
    * Utility function to compute the unique identifier
    */
   static currencyId(currency: CurrencyInput): string {
-    return 'network' in currency ? `${currency.symbol}-${currency.network}` : currency.symbol;
+    return currency.network ? `${currency.symbol}-${currency.network}` : currency.symbol;
   }
 
   /**

--- a/packages/currency/src/currencyManager.ts
+++ b/packages/currency/src/currencyManager.ts
@@ -286,9 +286,6 @@ export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta>
       type: ISO4217,
     }));
 
-    const eth: CurrencyInput[] = nativeCurrencies.ETH.map((x) => ({ ...x, type: ETH }));
-    const btc: CurrencyInput[] = nativeCurrencies.BTC.map((x) => ({ ...x, type: BTC }));
-
     const erc20Tokens = getSupportedERC20Tokens();
     const erc20Currencies: CurrencyInput[] = erc20Tokens.map((x) => ({ ...x, type: ERC20 }));
 
@@ -298,8 +295,7 @@ export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta>
     return isoCurrencies
       .concat(erc20Currencies)
       .concat(erc777Currencies)
-      .concat(eth)
-      .concat(btc)
+      .concat(nativeCurrencies)
       .map(CurrencyManager.fromInput);
   }
 

--- a/packages/currency/src/erc20/index.ts
+++ b/packages/currency/src/erc20/index.ts
@@ -1,3 +1,4 @@
+import { RequestLogicTypes } from '@requestnetwork/types';
 import { ERC20Currency } from '../types';
 import { supportedNetworks } from './networks';
 
@@ -12,6 +13,7 @@ export function getSupportedERC20Tokens(): ERC20Currency[] {
       return [
         ...acc,
         ...Object.entries(supportedCurrencies).map(([address, token]) => ({
+          type: RequestLogicTypes.CURRENCY.ERC20 as RequestLogicTypes.CURRENCY.ERC20,
           address,
           network: networkName,
           decimals: token.decimals,

--- a/packages/currency/src/erc777/index.ts
+++ b/packages/currency/src/erc777/index.ts
@@ -1,3 +1,4 @@
+import { RequestLogicTypes } from '@requestnetwork/types';
 import { ERC777Currency } from '../types';
 import { supportedNetworks } from './networks';
 
@@ -12,6 +13,7 @@ export function getSupportedERC777Tokens(): ERC777Currency[] {
       return [
         ...acc,
         ...Object.entries(supportedCurrencies).map(([address, token]) => ({
+          type: RequestLogicTypes.CURRENCY.ERC777 as RequestLogicTypes.CURRENCY.ERC777,
           address,
           network: networkName,
           decimals: token.decimals,

--- a/packages/currency/src/native.ts
+++ b/packages/currency/src/native.ts
@@ -1,135 +1,139 @@
 import { RequestLogicTypes } from '@requestnetwork/types';
 import { NativeCurrency, NativeCurrencyType } from './types';
 
-export const nativeCurrencies: Record<NativeCurrencyType, (NativeCurrency & { name: string })[]> = {
-  [RequestLogicTypes.CURRENCY.ETH]: [
+export const nativeCurrencies: NativeCurrency[] = [
+  {
+    symbol: 'ETH',
+    decimals: 18,
+    name: 'Ether',
+    network: 'mainnet',
+  },
+  {
+    symbol: 'ETH-rinkeby',
+    decimals: 18,
+    name: 'Rinkeby Ether',
+    network: 'rinkeby',
+  },
+  {
+    symbol: 'ETH-goerli',
+    decimals: 18,
+    name: 'Goerli Ether',
+    network: 'goerli',
+  },
+  {
+    symbol: 'MATIC',
+    decimals: 18,
+    name: 'Matic',
+    network: 'matic',
+  },
+  {
+    symbol: 'xDAI',
+    decimals: 18,
+    name: 'xDAI',
+    network: 'xdai',
+  },
+  {
+    symbol: 'POA',
+    decimals: 18,
+    name: 'POA Sokol Ether',
+    network: 'sokol',
+  },
+  {
+    symbol: 'FUSE',
+    decimals: 18,
+    name: 'FUSE',
+    network: 'fuse',
+  },
+  {
+    symbol: 'CELO',
+    decimals: 18,
+    name: 'CELO',
+    network: 'celo',
+  },
+  {
+    symbol: 'FTM',
+    decimals: 18,
+    name: 'Fantom',
+    network: 'fantom',
+  },
+  {
+    symbol: 'BNB',
+    decimals: 18,
+    name: 'BNB',
+    network: 'bsc',
+  },
+  {
+    symbol: 'NEAR',
+    decimals: 24,
+    name: 'Near',
+    network: 'aurora',
+  },
+  {
+    symbol: 'NEAR-testnet',
+    decimals: 24,
+    name: 'Near Testnet',
+    network: 'aurora-testnet',
+  },
+  {
+    symbol: 'NEAR-testnet',
+    decimals: 24,
+    name: 'Test Near',
+    network: 'near-testnet',
+  },
+  {
+    symbol: 'ARETH',
+    decimals: 18,
+    name: 'Arbitrum Testnet',
+    network: 'arbitrum-rinkeby',
+  },
+  {
+    symbol: 'AETH',
+    decimals: 18,
+    name: 'Arbitrum Ether',
+    network: 'arbitrum-one',
+  },
+  {
+    symbol: 'AVAX',
+    decimals: 18,
+    name: 'AVAX',
+    network: 'avalanche',
+  },
+  {
+    symbol: 'ETH-optimism',
+    decimals: 18,
+    name: 'Optimism Ether',
+    network: 'optimism',
+  },
+  {
+    symbol: 'GLMR',
+    decimals: 18,
+    name: 'Glimmer',
+    network: 'moonbeam',
+  },
+  {
+    symbol: 'TOMB',
+    decimals: 18,
+    name: 'Tomb',
+    network: 'tombchain',
+  },
+]
+  .map((x) => ({
+    type: RequestLogicTypes.CURRENCY.ETH as NativeCurrencyType,
+    ...x,
+  }))
+  .concat(
     {
-      symbol: 'ETH',
-      decimals: 18,
-      name: 'Ether',
-      network: 'mainnet',
-    },
-    {
-      symbol: 'ETH-rinkeby',
-      decimals: 18,
-      name: 'Rinkeby Ether',
-      network: 'rinkeby',
-    },
-    {
-      symbol: 'ETH-goerli',
-      decimals: 18,
-      name: 'Goerli Ether',
-      network: 'goerli',
-    },
-    {
-      symbol: 'MATIC',
-      decimals: 18,
-      name: 'Matic',
-      network: 'matic',
-    },
-    {
-      symbol: 'xDAI',
-      decimals: 18,
-      name: 'xDAI',
-      network: 'xdai',
-    },
-    {
-      symbol: 'POA',
-      decimals: 18,
-      name: 'POA Sokol Ether',
-      network: 'sokol',
-    },
-    {
-      symbol: 'FUSE',
-      decimals: 18,
-      name: 'FUSE',
-      network: 'fuse',
-    },
-    {
-      symbol: 'CELO',
-      decimals: 18,
-      name: 'CELO',
-      network: 'celo',
-    },
-    {
-      symbol: 'FTM',
-      decimals: 18,
-      name: 'Fantom',
-      network: 'fantom',
-    },
-    {
-      symbol: 'BNB',
-      decimals: 18,
-      name: 'BNB',
-      network: 'bsc',
-    },
-    {
-      symbol: 'NEAR',
-      decimals: 24,
-      name: 'Near',
-      network: 'aurora',
-    },
-    {
-      symbol: 'NEAR-testnet',
-      decimals: 24,
-      name: 'Near Testnet',
-      network: 'aurora-testnet',
-    },
-    {
-      symbol: 'NEAR-testnet',
-      decimals: 24,
-      name: 'Test Near',
-      network: 'near-testnet',
-    },
-    {
-      symbol: 'ARETH',
-      decimals: 18,
-      name: 'Arbitrum Testnet',
-      network: 'arbitrum-rinkeby',
-    },
-    {
-      symbol: 'AETH',
-      decimals: 18,
-      name: 'Arbitrum Ether',
-      network: 'arbitrum-one',
-    },
-    {
-      symbol: 'AVAX',
-      decimals: 18,
-      name: 'AVAX',
-      network: 'avalanche',
-    },
-    {
-      symbol: 'ETH-optimism',
-      decimals: 18,
-      name: 'Optimism Ether',
-      network: 'optimism',
-    },
-    {
-      symbol: 'GLMR',
-      decimals: 18,
-      name: 'Glimmer',
-      network: 'moonbeam',
-    },
-    {
-      symbol: 'TOMB',
-      decimals: 18,
-      name: 'Tomb',
-      network: 'tombchain',
-    },
-  ],
-  [RequestLogicTypes.CURRENCY.BTC]: [
-    {
+      type: RequestLogicTypes.CURRENCY.BTC,
       symbol: 'BTC',
       decimals: 8,
       name: 'Bitcoin',
       network: 'mainnet',
     },
     {
+      type: RequestLogicTypes.CURRENCY.BTC,
       symbol: 'BTC-testnet',
       decimals: 8,
       name: 'Test Bitcoin',
       network: 'testnet',
     },
-  ],
-};
+  );

--- a/packages/currency/src/types.ts
+++ b/packages/currency/src/types.ts
@@ -1,29 +1,33 @@
 import { RequestLogicTypes } from '@requestnetwork/types';
 
+/** Native Currency types */
+export type NativeCurrencyType = RequestLogicTypes.CURRENCY.BTC | RequestLogicTypes.CURRENCY.ETH;
+
 /**
  * A native blockchain token (ETH, MATIC, ETH-rinkeby...)
  */
 export type NativeCurrency = {
+  type: NativeCurrencyType;
   symbol: string;
   decimals: number;
   network: string;
 };
 
-/** Native Currency types */
-export type NativeCurrencyType = RequestLogicTypes.CURRENCY.BTC | RequestLogicTypes.CURRENCY.ETH;
-
 /**
  * A Fiat currency (EUR, USD...)
  */
 export type ISO4217Currency = {
+  type: RequestLogicTypes.CURRENCY.ISO4217;
   symbol: string;
   decimals: number;
+  network?: never;
 };
 
 /**
  * An ERC20 token (DAI, USDT...)
  */
 export type ERC20Currency = {
+  type: RequestLogicTypes.CURRENCY.ERC20;
   symbol: string;
   decimals: number;
   network: string;
@@ -34,6 +38,7 @@ export type ERC20Currency = {
  * An ERC777 SuperToken (DAIx, USDCx...)
  */
 export type ERC777Currency = {
+  type: RequestLogicTypes.CURRENCY.ERC777;
   symbol: string;
   decimals: number;
   network: string;
@@ -41,41 +46,9 @@ export type ERC777Currency = {
 };
 
 /**
- * The minimum properties of a native Currency
- */
-export type NativeCurrencyInput = {
-  type: RequestLogicTypes.CURRENCY.ETH | RequestLogicTypes.CURRENCY.BTC;
-} & NativeCurrency;
-
-/**
- * The minimum properties of an ISO4217 Currency
- */
-export type ISO4217CurrencyInput = {
-  type: RequestLogicTypes.CURRENCY.ISO4217;
-} & ISO4217Currency;
-
-/**
- * The minimum properties of an ERC20 Currency
- */
-export type ERC20CurrencyInput = {
-  type: RequestLogicTypes.CURRENCY.ERC20;
-} & ERC20Currency;
-
-/**
- * The minimum properties of an ERC777 Currency
- */
-export type ERC777CurrencyInput = {
-  type: RequestLogicTypes.CURRENCY.ERC777;
-} & ERC777Currency;
-
-/**
  * The minimum properties of a Currency
  */
-export type CurrencyInput =
-  | NativeCurrencyInput
-  | ISO4217CurrencyInput
-  | ERC20CurrencyInput
-  | ERC777CurrencyInput;
+export type CurrencyInput = NativeCurrency | ISO4217Currency | ERC20Currency | ERC777Currency;
 
 /**
  * The description of Currency, its core properties and some computed properties.

--- a/packages/currency/test/currencyManager.test.ts
+++ b/packages/currency/test/currencyManager.test.ts
@@ -450,7 +450,7 @@ describe('CurrencyManager', () => {
         const def = CurrencyManager.fromInput(currency);
         expect(def).toBeDefined();
         expect(def).toEqual(defaultManager.from(def.id));
-        if ('network' in def) {
+        if (def.network) {
           expect(def).toEqual(defaultManager.from(def.symbol, def.network));
           expect(def).toEqual(defaultManager.fromSymbol(def.symbol, def.network));
         }

--- a/packages/currency/test/types.test.ts
+++ b/packages/currency/test/types.test.ts
@@ -1,0 +1,47 @@
+import { RequestLogicTypes } from '@requestnetwork/types';
+import { CurrencyManager } from '../src';
+
+// NB: this file only tests types; the expects are here to mute warnings
+
+describe('Currency types', () => {
+  const currency = CurrencyManager.getDefault().fromId('DAI-mainnet');
+  if (!currency) throw new Error();
+  it('Network', () => {
+    // @ts-expect-error network can be undefined
+    const a: string = currency.network;
+    // @ts-expect-error network can be defined
+    const b: undefined = currency.network;
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+
+    if (currency.type === RequestLogicTypes.CURRENCY.ERC20) {
+      // no error
+      const a: string = currency.network;
+      // @ts-expect-error cannot be undefined
+      const b: undefined = currency.network;
+      expect(a).toBeDefined();
+      expect(b).toBeDefined();
+    }
+    if (currency.type === RequestLogicTypes.CURRENCY.ERC20) {
+      // no error
+      const a: string = currency.network;
+      // @ts-expect-error cannot be undefined
+      const b: undefined = currency.network;
+      expect(a).toBeDefined();
+      expect(b).toBeDefined();
+    }
+    // @ts-expect-error type cannot be ISO4217
+    if (currency?.network && currency.type === RequestLogicTypes.CURRENCY.ISO4217) {
+      fail('wrong!');
+    }
+  });
+
+  it('Address', () => {
+    // @ts-expect-error
+    currency.address;
+
+    if (currency.type === RequestLogicTypes.CURRENCY.ERC20) {
+      currency.address;
+    }
+  });
+});

--- a/packages/integration-test/test/node-client.test.ts
+++ b/packages/integration-test/test/node-client.test.ts
@@ -541,7 +541,7 @@ describe('ERC20 localhost request creation and detection test', () => {
   it.only('can create ERC20 requests with any to erc20 proxy', async () => {
     const tokenContractAddress = '0x38cF23C52Bb4B13F051Aec09580a2dE845a7FA35';
 
-    const currencies = [
+    const currencies: CurrencyInput[] = [
       ...CurrencyManager.getDefaultList(),
       {
         address: tokenContractAddress,

--- a/packages/payment-detection/src/erc20/currency.ts
+++ b/packages/payment-detection/src/erc20/currency.ts
@@ -1,9 +1,4 @@
-import {
-  CurrencyDefinition,
-  CurrencyManager,
-  getCurrencyHash,
-  StorageCurrency,
-} from '@requestnetwork/currency';
+import { CurrencyDefinition, CurrencyManager, StorageCurrency } from '@requestnetwork/currency';
 import { RequestLogicTypes } from '@requestnetwork/types';
 import { ERC20__factory } from '@requestnetwork/smart-contracts/types';
 import { isAddress } from 'ethers/lib/utils';
@@ -27,19 +22,14 @@ export const loadCurrencyFromContract = async (
     if (!symbol) {
       return null;
     }
-    const definition = {
+    return CurrencyManager.fromInput({
       address: currency.value,
       decimals,
       symbol,
       network: currency.network,
       type: RequestLogicTypes.CURRENCY.ERC20,
-    };
-    return {
-      ...definition,
-      id: CurrencyManager.currencyId(definition),
-      hash: getCurrencyHash(CurrencyManager.toStorageCurrency(definition)),
-      meta: null as never,
-    };
+      meta: null,
+    });
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
Revival of https://github.com/RequestNetwork/requestNetwork/pull/832

The objective is to simplify usage and drop the need for `"network" in currency`

```ts
if(curr.type === 'ISO4217'){
  // type: undefined
  curr.network
} else{
  // type: string
  curr.network
}
```