### PR TITLE
feat(request-client): add option to skip refresh

### DIFF
--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -75,7 +75,10 @@ export default class RequestNetwork {
    * @param requestParameters Parameters to create a request
    * @returns The created request
    */
-  public async createRequest(parameters: Types.ICreateRequestParameters): Promise<Request> {
+  public async createRequest(
+    parameters: Types.ICreateRequestParameters,
+    options?: Types.ICreateRequestOptions,
+  ): Promise<Request> {
     const { requestParameters, topics, paymentNetwork } = await this.prepareRequestParameters(
       parameters,
     );
@@ -100,8 +103,10 @@ export default class RequestNetwork {
       },
     );
 
-    // refresh the local request data
-    await request.refresh();
+    if (!options?.skipRefresh) {
+      // refresh the local request data
+      await request.refresh();
+    }
 
     return request;
   }
@@ -116,6 +121,7 @@ export default class RequestNetwork {
   public async _createEncryptedRequest(
     parameters: Types.ICreateRequestParameters,
     encryptionParams: EncryptionTypes.IEncryptionParameters[],
+    options?: Types.ICreateRequestOptions,
   ): Promise<Request> {
     const { requestParameters, topics, paymentNetwork } = await this.prepareRequestParameters(
       parameters,
@@ -142,8 +148,10 @@ export default class RequestNetwork {
       },
     );
 
-    // refresh the local request data
-    await request.refresh();
+    if (!options?.skipRefresh) {
+      // refresh the local request data
+      await request.refresh();
+    }
 
     return request;
   }

--- a/packages/types/src/client-types.ts
+++ b/packages/types/src/client-types.ts
@@ -38,6 +38,14 @@ export interface ICreateRequestParameters {
   disableEvents?: boolean;
 }
 
+export interface ICreateRequestOptions {
+  /**
+   * Disable the request refresh after creation
+   * Warning: the `balance` will be null.
+   */
+  skipRefresh?: boolean;
+}
+
 /** Parameters to create a request. ICreateParameters with a more flexible currency */
 export interface IRequestInfo {
   currency: string | RequestLogic.ICurrency;


### PR DESCRIPTION
The refresh is useful when you want to use the request directly, but in a scenario where you will work with it asynchronously, it can cause instability