### PR TITLE
feat: batch create encrypted requests

### DIFF
--- a/packages/request-client.js/test/api/request.test.ts
+++ b/packages/request-client.js/test/api/request.test.ts
@@ -17,6 +17,9 @@ const mockRequestLogic: RequestLogicTypes.IRequestLogic = {
   async createEncryptedRequest(): Promise<any> {
     return;
   },
+  async batchCreateEncryptedRequests(): Promise<any> {
+    return;
+  },
   async computeRequestId(): Promise<any> {
     return;
   },
@@ -490,6 +493,9 @@ describe('api/request', () => {
           return;
         },
         async createEncryptedRequest(): Promise<any> {
+          return;
+        },
+        async batchCreateEncryptedRequests(): Promise<any> {
           return;
         },
         async computeRequestId(): Promise<any> {

--- a/packages/request-client.js/test/data-test.ts
+++ b/packages/request-client.js/test/data-test.ts
@@ -12,6 +12,7 @@ import { normalizeKeccak256Hash, sign } from '@requestnetwork/utils';
 import AxiosMockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 import { Types } from '../src';
+import { ISignatureBatchParameters } from 'types/src/signature-provider-types';
 
 export const arbitraryTimestamp = 1549953337;
 
@@ -41,6 +42,17 @@ export const delegate = {
   identity: {
     type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
     value: '0x5AEDA56215b167893e80B4fE645BA6d5Bab767DE',
+  },
+};
+
+export const otherPayee = {
+  identity: {
+    type: IdentityTypes.TYPE.ETHEREUM_ADDRESS,
+    value: '0xE6558f7D7C507B3b9598792ad7C9D6BeeD896149',
+  },
+  signatureParams: {
+    method: SignatureTypes.METHOD.ECDSA,
+    privateKey: '0x60456c06c01e8f844b5259b3709b46c7cf918d7b5e15f0cd66d73857d6f5b88e',
   },
 };
 
@@ -256,18 +268,34 @@ export const signatureParametersDelegate: SignatureTypes.ISignatureParameters = 
   privateKey: '0x8d5366123cb560bb606379f90a0bfd4769eecc0557f1b362dcae9012b548b1e5',
 };
 
+export const signatureParametersThirdParty: SignatureTypes.ISignatureParameters = {
+  method: SignatureTypes.METHOD.ECDSA,
+  privateKey: '0x60456c06c01e8f844b5259b3709b46c7cf918d7b5e15f0cd66d73857d6f5b88e',
+};
+
 export const fakeSignatureProvider: SignatureProviderTypes.ISignatureProvider = {
   sign: (data: any, signer: IdentityTypes.IIdentity): any => {
     if (signer.value === payee.identity.value) {
       return sign(data, signatureParametersPayee);
     } else if (signer.value === payer.identity.value) {
       return sign(data, signatureParametersPayer);
+    } else if (signer.value === otherPayee.identity.value) {
+      return sign(data, signatureParametersThirdParty);
     } else {
       return sign(data, signatureParametersDelegate);
     }
   },
   supportedIdentityTypes: [IdentityTypes.TYPE.ETHEREUM_ADDRESS],
   supportedMethods: [SignatureTypes.METHOD.ECDSA],
+};
+
+export const fakeBatchSignatureProvider: SignatureProviderTypes.ISignatureProvider = {
+  ...fakeSignatureProvider,
+  batchSign: (parameters: ISignatureBatchParameters[]): any => {
+    return parameters.map((parameter) =>
+      fakeBatchSignatureProvider.sign(parameter.data, parameter.signer),
+    );
+  },
 };
 
 export const mockAxiosRequestNode = (): AxiosMockAdapter => {

--- a/packages/request-client.js/test/data-test.ts
+++ b/packages/request-client.js/test/data-test.ts
@@ -268,7 +268,7 @@ export const signatureParametersDelegate: SignatureTypes.ISignatureParameters = 
   privateKey: '0x8d5366123cb560bb606379f90a0bfd4769eecc0557f1b362dcae9012b548b1e5',
 };
 
-export const signatureParametersThirdParty: SignatureTypes.ISignatureParameters = {
+export const signatureParametersOtherPayee: SignatureTypes.ISignatureParameters = {
   method: SignatureTypes.METHOD.ECDSA,
   privateKey: '0x60456c06c01e8f844b5259b3709b46c7cf918d7b5e15f0cd66d73857d6f5b88e',
 };
@@ -280,7 +280,7 @@ export const fakeSignatureProvider: SignatureProviderTypes.ISignatureProvider = 
     } else if (signer.value === payer.identity.value) {
       return sign(data, signatureParametersPayer);
     } else if (signer.value === otherPayee.identity.value) {
-      return sign(data, signatureParametersThirdParty);
+      return sign(data, signatureParametersOtherPayee);
     } else {
       return sign(data, signatureParametersDelegate);
     }

--- a/packages/request-client.js/test/index.test.ts
+++ b/packages/request-client.js/test/index.test.ts
@@ -1283,14 +1283,16 @@ describe('request-client.js', () => {
         },
       ]);
 
-      // Check access for Payee One:
+      // Check requests and access for Payee One:
       const requestNetworkPayeeOne = new RequestNetworkBase({
         decryptionProvider: fakeDecryptionProvider,
         signatureProvider: TestData.fakeBatchSignatureProvider,
         dataAccess: mockDataAccess,
       });
       const payeeOneRequest = await requestNetworkPayeeOne.fromRequestId(requests[0].requestId);
-      expect(payeeOneRequest as Request).toMatchObject<Request>(requests[0] as Request);
+      const payeeOneRequests = await requestNetworkPayeeOne.fromIdentity(TestData.payee.identity);
+      expect(payeeOneRequest.getData()).not.toBe(null);
+      expect(payeeOneRequests.length).toBe(1);
       await expect(requestNetworkPayeeOne.fromRequestId(requests[1].requestId)).rejects.toThrow();
 
       // Check access for Payee Two
@@ -1300,7 +1302,11 @@ describe('request-client.js', () => {
         dataAccess: mockDataAccess,
       });
       const payeeTwoRequest = await requestNetworkPayeeTwo.fromRequestId(requests[1].requestId);
-      expect(payeeTwoRequest).toMatchObject<Request>(requests[1]);
+      const payeeTwoRequests = await requestNetworkPayeeTwo.fromIdentity(
+        TestData.otherPayee.identity,
+      );
+      expect(payeeTwoRequest.getData()).not.toBe(null);
+      expect(payeeTwoRequests.length).toBe(1);
       await expect(requestNetworkPayeeTwo.fromRequestId(requests[0].requestId)).rejects.toThrow();
     });
 

--- a/packages/request-client.js/test/index.test.ts
+++ b/packages/request-client.js/test/index.test.ts
@@ -1209,7 +1209,7 @@ describe('request-client.js', () => {
     });
   });
 
-  describe.only('Request Logic with encryption created in batch', () => {
+  describe('Request Logic with encryption created in batch', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });
@@ -1252,7 +1252,7 @@ describe('request-client.js', () => {
       ).toEqual(['ecies-aes256-gcm', 'ecies-aes256-gcm']);
     });
 
-    it.only('cannot access request created in batch with a different identity', async () => {
+    it('cannot access request created in batch with a different identity', async () => {
       const mockStorage = new MockStorage();
       const mockDataAccess = new MockDataAccess(mockStorage);
 
@@ -1302,6 +1302,33 @@ describe('request-client.js', () => {
       const payeeTwoRequest = await requestNetworkPayeeTwo.fromRequestId(requests[1].requestId);
       expect(payeeTwoRequest).toMatchObject<Request>(requests[1]);
       await expect(requestNetworkPayeeTwo.fromRequestId(requests[0].requestId)).rejects.toThrow();
+    });
+
+    it('cannot create the exact same request twice', async () => {
+      const requestNetwork = new RequestNetwork({
+        decryptionProvider: fakeDecryptionProvider,
+        signatureProvider: TestData.fakeBatchSignatureProvider,
+        useMockStorage: true,
+      });
+
+      await expect(
+        requestNetwork._batchCreateEncryptedRequests([
+          {
+            parameters: {
+              requestInfo: TestData.parametersWithoutExtensionsData,
+              signer: TestData.payee.identity,
+            },
+            encryptionParams: [idRaw1.encryptionParams],
+          },
+          {
+            parameters: {
+              requestInfo: TestData.parametersWithoutExtensionsData,
+              signer: TestData.payee.identity,
+            },
+            encryptionParams: [idRaw1.encryptionParams],
+          },
+        ]),
+      ).rejects.toThrowError('Only unique requests can be batched together');
     });
 
     it('cannot batch create encrypted requests without encryption parameters', async () => {

--- a/packages/request-client.js/test/index.test.ts
+++ b/packages/request-client.js/test/index.test.ts
@@ -126,7 +126,6 @@ const fakeDecryptionProviderExtended: DecryptionProviderTypes.IDecryptionProvide
     data: EncryptionTypes.IEncryptedData,
     identity: IdentityTypes.IIdentity,
   ): Promise<string> => {
-    console.log(identity);
     switch (identity.value.toLowerCase()) {
       case idRaw1.identity.value:
         return decrypt(data, idRaw1.decryptionParams);

--- a/packages/request-logic/src/action.ts
+++ b/packages/request-logic/src/action.ts
@@ -4,12 +4,14 @@ import * as Semver from 'semver';
 import Role from './role';
 import Version from './version';
 import { normalizeKeccak256Hash, recoverSigner } from '@requestnetwork/utils';
+import { ISignatureBatchParameters } from 'types/dist/signature-provider-types';
 
 /**
  * Function to manage Request logic action (object that will be interpreted to create or modify a request)
  */
 export default {
   createAction,
+  createActions,
   getRequestId,
   getRoleInAction,
   getRoleInUnsignedAction,
@@ -35,6 +37,27 @@ function createAction(
   signatureProvider: SignatureProviderTypes.ISignatureProvider,
 ): Promise<RequestLogicTypes.IAction> {
   return signatureProvider.sign(unsignedAction, signerIdentity);
+}
+
+/**
+ * Creates several actions from unsigned actions data and a signatures parameters
+ *
+ * @notice it will sign the hash (keccak256) of the actions data
+ *
+ * @param IUnsignedAction unsignedActions The unsigned action to sign
+ * @param IIdentity signerIdentity Identity of the signer
+ * @param ISignatureProvider signatureProvider Signature provider in charge of the signature
+ *
+ * @returns IAction the action with the signature
+ */
+function createActions(
+  actionAndSigners: ISignatureBatchParameters[],
+  signatureProvider: SignatureProviderTypes.ISignatureProvider,
+): Promise<RequestLogicTypes.IAction[]> {
+  if (!signatureProvider.batchSign) {
+    throw new Error('Signature provider does not support batch signature');
+  }
+  return signatureProvider.batchSign(actionAndSigners);
 }
 
 /**

--- a/packages/request-logic/src/action.ts
+++ b/packages/request-logic/src/action.ts
@@ -40,12 +40,11 @@ function createAction(
 }
 
 /**
- * Creates several actions from unsigned actions data and a signatures parameters
+ * Creates several actions from unsigned actions data and signatures parameters
  *
- * @notice it will sign the hash (keccak256) of the actions data
+ * @notice it will sign the hash (keccak256) of each actions data
  *
- * @param IUnsignedAction unsignedActions The unsigned action to sign
- * @param IIdentity signerIdentity Identity of the signer
+ * @param ISignatureBatchParameters actions data and associated signers
  * @param ISignatureProvider signatureProvider Signature provider in charge of the signature
  *
  * @returns IAction the action with the signature

--- a/packages/request-logic/src/actions/create.ts
+++ b/packages/request-logic/src/actions/create.ts
@@ -180,10 +180,6 @@ function createRequest(
     request.creator = action.data.parameters.payer;
     return request;
   }
-  console.log(request);
-  console.log(action);
-  console.log(signer);
-  console.log(signerRole);
 
   throw new Error('Signer must be the payee or the payer');
 }

--- a/packages/request-logic/src/actions/create.ts
+++ b/packages/request-logic/src/actions/create.ts
@@ -44,8 +44,8 @@ function format(
  *
  * If requestParameters.timestamp not given, "Date.now() / 1000" will be used as default
  *
- * @param requestsParameters ICreateParameters[] parameters to create the requests
- * @param IIdentity signerIdentities Identities of the signer
+ * @param requestsParameters parameters to create the requests
+ * @param signerIdentities Identities of the different signers
  * @param ISignatureProvider signatureProvider Signature provider in charge of the signature
  *
  * @returns IAction  the action with the signature

--- a/packages/request-logic/src/request-logic.ts
+++ b/packages/request-logic/src/request-logic.ts
@@ -144,12 +144,9 @@ export default class RequestLogic implements RequestLogicTypes.IRequestLogic {
   /**
    * Creates encrypted requests in batch and persists them on the transaction manager layer
    *
-   * @param requestParameters parameters to create a request
-   * @param signerIdentity Identity of the signer
-   * @param encryptionParams list of encryption parameters to encrypt the channel key with
-   * @param topics list of string to topic the request
+   * @param batchCreationInput Array of objects to create the requests for
    *
-   * @returns the request id and the meta data
+   * @returns the request ids and the meta data
    */
   public async batchCreateEncryptedRequests(
     batchCreationInput: {

--- a/packages/request-logic/src/request-logic.ts
+++ b/packages/request-logic/src/request-logic.ts
@@ -169,6 +169,16 @@ export default class RequestLogic implements RequestLogicTypes.IRequestLogic {
       batchCreationInput,
     );
 
+    // Assert requests unicity
+    if (
+      actionsRequestsIdsAndTopics.some(
+        ({ requestId }, index, self) =>
+          self.findIndex((val) => requestId === val.requestId) !== index,
+      )
+    ) {
+      throw new Error('Only unique requests can be batched together');
+    }
+
     const resultPersistTxs = await Promise.all(
       actionsRequestsIdsAndTopics.map(async ({ action, requestId, hashedTopics }, index) => {
         // Validate all actions, the apply will throw in case of error

--- a/packages/request-logic/src/requestLogicCore.ts
+++ b/packages/request-logic/src/requestLogicCore.ts
@@ -20,6 +20,7 @@ export default {
   formatAddExtensionsData: AddExtensionsData.format,
   formatCancel: CancelAction.format,
   formatCreate: CreateAction.format,
+  formatCreateBatch: CreateAction.formatBatch,
   formatIncreaseExpectedAmount: IncreaseExpectedAmountAction.format,
   formatReduceExpectedAmount: ReduceExpectedAmountAction.format,
   formatAddStakeholders: AddStakeholdersAction.format,

--- a/packages/request-logic/src/types.ts
+++ b/packages/request-logic/src/types.ts
@@ -1,0 +1,13 @@
+import { IdentityTypes, RequestLogicTypes } from 'types/dist';
+
+export interface ICreateCreationActionRequestIdAndTopicsParameters {
+  requestParameters: RequestLogicTypes.ICreateParameters;
+  signerIdentity: IdentityTypes.IIdentity;
+  topics: any[];
+}
+
+export interface ICreateCreationActionRequestIdAndTopicsResult {
+  action: RequestLogicTypes.IAction;
+  hashedTopics: string[];
+  requestId: RequestLogicTypes.RequestId;
+}

--- a/packages/types/src/request-logic-types.ts
+++ b/packages/types/src/request-logic-types.ts
@@ -20,6 +20,14 @@ export interface IRequestLogic {
     encryptionParams: Encryption.IEncryptionParameters[],
     topics: any[],
   ) => Promise<IReturnCreateRequest>;
+  batchCreateEncryptedRequests: (
+    batchCreationInput: {
+      requestParameters: ICreateParameters;
+      signerIdentity: Identity.IIdentity;
+      encryptionParams: Encryption.IEncryptionParameters[];
+      topics: any[];
+    }[],
+  ) => Promise<IReturnCreateRequest[]>;
   computeRequestId: (
     requestParameters: ICreateParameters,
     signerIdentity: Identity.IIdentity,

--- a/packages/types/src/signature-provider-types.ts
+++ b/packages/types/src/signature-provider-types.ts
@@ -1,10 +1,16 @@
 import * as Identity from './identity-types';
 import * as Signature from './signature-types';
 
+export interface ISignatureBatchParameters {
+  data: any;
+  signer: Identity.IIdentity;
+}
+
 /** Signature provider interface */
 export interface ISignatureProvider {
   supportedMethods: Signature.METHOD[];
   supportedIdentityTypes: Identity.TYPE[];
 
   sign: (data: any, signer: Identity.IIdentity) => Promise<Signature.ISignedData>;
+  batchSign?: (parameters: ISignatureBatchParameters[]) => Promise<Signature.ISignedData[]>;
 }


### PR DESCRIPTION
## Description of the changes

#### Context

Creating multiple encrypted requests in a row can result in performance issues depending on your `SignatureProvider`.

####  Update

This PR introduces several changes to mitigate this issue:
1. The `SignatureProvider` exposes a new method: `batchSign` (optional).
2. The `RequestNetwork` client now exposes the `_batchCreateEncryptedRequests` method. To be able to use this method, the given `SignatureProvider` must implement the batchSign method.

The `SignatureProvider` will be called only once to sign the data.

#### Limitations

When calling this method, if `disableEvents` or `skipRefresh` are `false`, the `SignatureProvider` will be called multiple times during the refresh process.