### PR TITLE
fix: default getTheGraphClient accounts for Near

### DIFF
--- a/packages/payment-detection/src/payment-network-factory.ts
+++ b/packages/payment-detection/src/payment-network-factory.ts
@@ -25,7 +25,7 @@ import { EthFeeProxyPaymentDetector, EthInputDataPaymentDetector } from './eth';
 import { AnyToERC20PaymentDetector, AnyToEthFeeProxyPaymentDetector } from './any';
 import { NearConversionNativeTokenPaymentDetector, NearNativeTokenPaymentDetector } from './near';
 import { getPaymentNetworkExtension } from './utils';
-import { getTheGraphClient } from './thegraph';
+import { defaultGetTheGraphClient } from './thegraph';
 import { getDefaultProvider } from 'ethers';
 
 const PN_ID = ExtensionTypes.PAYMENT_NETWORK_ID;
@@ -104,13 +104,7 @@ export class PaymentNetworkFactory {
 
   private buildOptions(options: Partial<PaymentNetworkOptions>): PaymentNetworkOptions {
     const defaultOptions: PaymentNetworkOptions = {
-      getSubgraphClient: (network) => {
-        return network === 'private'
-          ? undefined
-          : getTheGraphClient(
-              `https://api.thegraph.com/subgraphs/name/requestnetwork/request-payments-${network}`,
-            );
-      },
+      getSubgraphClient: defaultGetTheGraphClient,
       explorerApiKeys: {},
       getRpcProvider: getDefaultProvider,
     };

--- a/packages/payment-detection/src/thegraph/client.ts
+++ b/packages/payment-detection/src/thegraph/client.ts
@@ -1,8 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { CurrencyTypes } from '@requestnetwork/types';
+import { NearChains } from '@requestnetwork/currency';
 import { GraphQLClient } from 'graphql-request';
 import { getSdk } from './generated/graphql';
 import { getSdk as getNearSdk } from './generated/graphql-near';
+
+const HOSTED_THE_GRAPH_URL =
+  'https://api.thegraph.com/subgraphs/name/requestnetwork/request-payments-';
 
 // NB: the GraphQL client is automatically generated based on files present in ./queries,
 // using graphql-codegen.
@@ -26,3 +30,11 @@ export const getTheGraphClient = (url: string, options?: TheGraphClientOptions) 
 
 export const getTheGraphNearClient = (url: string, options?: TheGraphClientOptions) =>
   getNearSdk(new GraphQLClient(url, options));
+
+export const defaultGetTheGraphClient = (network: CurrencyTypes.ChainName) => {
+  return network === 'private'
+    ? undefined
+    : NearChains.isChainSupported(network)
+    ? getTheGraphNearClient(`${HOSTED_THE_GRAPH_URL}${network.replace('aurora', 'near')}`)
+    : getTheGraphClient(`${HOSTED_THE_GRAPH_URL}${network}`);
+};

--- a/packages/request-client.js/test/declarative-payments.test.ts
+++ b/packages/request-client.js/test/declarative-payments.test.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import { mocked } from 'ts-jest/utils';
 
 import {
   ClientTypes,
@@ -18,7 +17,6 @@ import {
   PaymentReferenceCalculator,
   getPaymentReference,
   getPaymentNetworkExtension,
-  getTheGraphNearClient,
 } from '@requestnetwork/payment-detection';
 import { IRequestDataWithEvents } from '../src/types';
 import { CurrencyManager } from '@requestnetwork/currency';

--- a/packages/request-client.js/test/declarative-payments.test.ts
+++ b/packages/request-client.js/test/declarative-payments.test.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { mocked } from 'ts-jest/utils';
 
 import {
   ClientTypes,
@@ -17,6 +18,7 @@ import {
   PaymentReferenceCalculator,
   getPaymentReference,
   getPaymentNetworkExtension,
+  getTheGraphNearClient,
 } from '@requestnetwork/payment-detection';
 import { IRequestDataWithEvents } from '../src/types';
 import { CurrencyManager } from '@requestnetwork/currency';
@@ -331,7 +333,7 @@ describe('request-client.js: declarative payments', () => {
             type: RequestLogicTypes.CURRENCY.ERC20,
             address: '0x38cf23c52bb4b13f051aec09580a2de845a7fa35',
             decimals: 18,
-            network: 'private',
+            network: 'private', // private network forces RPC-based `getLogs`
             symbol: 'FAKE',
           },
         ],


### PR DESCRIPTION
## Description of the changes
Main:
fix: PaymentNetworkFactory default subraph getter supports NEAR
Secondary:
chore: test declarative events in NEAR native payment detector