### PR TITLE
feat: processor for ERC20FeeProxy on Near

### DIFF
--- a/packages/payment-processor/src/index.ts
+++ b/packages/payment-processor/src/index.ts
@@ -8,6 +8,7 @@ export * from './payment/erc777-utils';
 export * from './payment/eth-input-data';
 export * from './payment/near-input-data';
 export * from './payment/near-conversion';
+export * from './payment/near-fungible';
 export * from './payment/eth-proxy';
 export * from './payment/eth-fee-proxy';
 export * from './payment/batch-proxy';

--- a/packages/payment-processor/src/payment/erc20-fee-proxy.ts
+++ b/packages/payment-processor/src/payment/erc20-fee-proxy.ts
@@ -80,9 +80,8 @@ export function _getErc20FeeProxyPaymentUrl(
   feeAmountOverride?: BigNumberish,
 ): string {
   validateRequest(request, ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
-  const { paymentReference, paymentAddress, feeAddress, feeAmount, version } =
+  const { paymentReference, paymentAddress, feeAddress, feeAmount, version, network } =
     getRequestPaymentValues(request);
-  const { network } = request.currencyInfo;
   EvmChains.assertChainSupported(network!);
   const contractAddress = erc20FeeProxyArtifact.getAddress(network, version);
   const amountToPay = getAmountToPay(request, amount);
@@ -92,7 +91,7 @@ export function _getErc20FeeProxyPaymentUrl(
 }
 
 /**
- * Prepate the transaction to pay a request through the ERC20 fee proxy contract, can be used with a Multisig contract.
+ * Prepare the transaction to pay a request through the ERC20 fee proxy contract, can be used with a Multisig contract.
  * @param request request to pay
  * @param signerOrProvider the Web3 provider, or signer. Defaults to window.ethereum.
  * @param amount optionally, the amount to pay. Defaults to remaining amount of the request.

--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -243,9 +243,9 @@ export async function isSolvent(
 ): Promise<boolean> {
   // Near case
   if (NearChains.isChainSupported(currency.network) && providerOptions?.nearWalletConnection) {
-    return isNearAccountSolvent(amount, providerOptions.nearWalletConnection);
+    return isNearAccountSolvent(amount, providerOptions.nearWalletConnection, currency);
   }
-  // Main case (web3)
+  // Main case (EVM)
   if (!providerOptions?.provider) {
     throw new Error('provider missing');
   }

--- a/packages/payment-processor/src/payment/near-fungible.ts
+++ b/packages/payment-processor/src/payment/near-fungible.ts
@@ -16,7 +16,7 @@ import { NearChains } from '@requestnetwork/currency';
  * Processes the transaction to pay a request in fungible token on NEAR with fee (Erc20FeeProxy).
  * @param request the request to pay
  */
-export async function payFungibleNearRequest(
+export async function payNearFungibleRequest(
   request: ClientTypes.IRequestData,
   walletConnection: WalletConnection,
   amount?: BigNumberish,

--- a/packages/payment-processor/src/payment/near-fungible.ts
+++ b/packages/payment-processor/src/payment/near-fungible.ts
@@ -1,0 +1,64 @@
+import { BigNumberish } from 'ethers';
+import { WalletConnection } from 'near-api-js';
+
+import { ClientTypes, ExtensionTypes } from '@requestnetwork/types';
+
+import {
+  getRequestPaymentValues,
+  validateRequest,
+  getAmountToPay,
+  getPaymentExtensionVersion,
+} from './utils';
+import {
+  INearTransactionCallback,
+  isReceiverReady,
+  processNearFungiblePayment,
+} from './utils-near';
+import { NearChains } from '@requestnetwork/currency';
+
+/**
+ * Processes the transaction to pay a request in fungible token on NEAR with fee (Erc20FeeProxy).
+ * @param request the request to pay
+ */
+export async function payFungibleNearRequest(
+  request: ClientTypes.IRequestData,
+  walletConnection: WalletConnection,
+  amount?: BigNumberish,
+  callback?: INearTransactionCallback,
+): Promise<void> {
+  validateRequest(request, ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT);
+
+  const { paymentReference, paymentAddress, feeAddress, feeAmount, network } =
+    getRequestPaymentValues(request);
+
+  if (!paymentReference) {
+    throw new Error('Cannot pay without a paymentReference');
+  }
+
+  if (!network || !NearChains.isChainSupported(network)) {
+    throw new Error('Should be a Near network');
+  }
+  NearChains.assertChainSupported(network);
+
+  const amountToPay = getAmountToPay(request, amount).toString();
+  const version = getPaymentExtensionVersion(request);
+
+  if (!(await isReceiverReady(walletConnection, request.currencyInfo.value, paymentAddress))) {
+    throw new Error(
+      `The paymentAddress is not registered for the token ${request.currencyInfo.value}`,
+    );
+  }
+
+  return processNearFungiblePayment(
+    walletConnection,
+    network,
+    amountToPay,
+    paymentAddress,
+    paymentReference,
+    request.currencyInfo.value,
+    feeAddress || '0x',
+    feeAmount || 0,
+    version,
+    callback,
+  );
+}

--- a/packages/payment-processor/src/payment/swap-any-to-erc20.ts
+++ b/packages/payment-processor/src/payment/swap-any-to-erc20.ts
@@ -77,8 +77,8 @@ export function encodeSwapToPayAnyToErc20Request(
   signerOrProvider: providers.Provider | Signer = getProvider(),
   options: IRequestPaymentOptions,
 ): string {
-  const conversionSettings = options?.conversion;
-  const swapSettings = options?.swap;
+  const conversionSettings = options.conversion;
+  const swapSettings = options.swap;
 
   if (!conversionSettings) {
     throw new Error(`Conversion Settings are required`);
@@ -87,7 +87,7 @@ export function encodeSwapToPayAnyToErc20Request(
     throw new Error(`Swap Settings are required`);
   }
   const currencyManager = conversionSettings.currencyManager || CurrencyManager.getDefault();
-  const network = conversionSettings.currency?.network;
+  const network = conversionSettings.currency.network;
   if (!network) {
     throw new Error(`Currency in conversion settings must have a network`);
   }

--- a/packages/payment-processor/src/payment/swap-erc20-fee-proxy.ts
+++ b/packages/payment-processor/src/payment/swap-erc20-fee-proxy.ts
@@ -114,15 +114,14 @@ export function encodeSwapToPayErc20FeeRequest(
   swapSettings: ISwapSettings,
   options?: IRequestPaymentOptions,
 ): string {
-  const { network } = request.currencyInfo;
+  const { paymentReference, paymentAddress, feeAddress, feeAmount, network } =
+    getRequestPaymentValues(request);
   EvmChains.assertChainSupported(network!);
 
   validateErc20FeeProxyRequest(request, options?.amount, options?.feeAmount);
 
   const signer = getSigner(signerOrProvider);
   const tokenAddress = request.currencyInfo.value;
-  const { paymentReference, paymentAddress, feeAddress, feeAmount } =
-    getRequestPaymentValues(request);
   const amountToPay = getAmountToPay(request, options?.amount);
   const feeToPay = BigNumber.from(options?.feeAmount || feeAmount || 0);
 

--- a/packages/payment-processor/src/payment/utils-near.ts
+++ b/packages/payment-processor/src/payment/utils-near.ts
@@ -4,7 +4,8 @@ import {
   NearConversionNativeTokenPaymentDetector,
   NearNativeTokenPaymentDetector,
 } from '@requestnetwork/payment-detection';
-import { CurrencyTypes } from '@requestnetwork/types';
+import { CurrencyTypes, RequestLogicTypes } from '@requestnetwork/types';
+import { erc20FeeProxyArtifact } from '@requestnetwork/smart-contracts';
 
 /**
  * Callback arguments for the Near web wallet.
@@ -28,14 +29,29 @@ export const isValidNearAddress = async (nearNetwork: Near, address: string): Pr
 export const isNearAccountSolvent = (
   amount: BigNumberish,
   nearWalletConnection: WalletConnection,
+  token?: RequestLogicTypes.ICurrency,
 ): Promise<boolean> => {
-  return nearWalletConnection
-    .account()
-    .state()
-    .then((state) => {
-      const balance = BigNumber.from(state?.amount ?? '0');
-      return balance.gte(amount);
-    });
+  if (!token || token.type === RequestLogicTypes.CURRENCY.ETH) {
+    return nearWalletConnection
+      .account()
+      .state()
+      .then((state) => {
+        const balance = BigNumber.from(state?.amount ?? '0');
+        return balance.gte(amount);
+      });
+  }
+  if (token.type === RequestLogicTypes.CURRENCY.ERC20) {
+    const fungibleContract = new Contract(nearWalletConnection.account(), token.value, {
+      changeMethods: [],
+      viewMethods: ['ft_balance_of'],
+    }) as any;
+    return fungibleContract
+      .ft_balance_of({
+        account_id: nearWalletConnection.account().accountId,
+      })
+      .then((balance: string) => BigNumber.from(balance).gte(amount));
+  }
+  throw new Error(`isNearAccountSolvent not implemented for ${token.type}`);
 };
 
 const GAS_LIMIT_IN_TGAS = 50;
@@ -147,4 +163,99 @@ export const processNearPaymentWithConversion = async (
   } catch (e) {
     throw new Error(`Could not pay Near request. Got ${e.message}`);
   }
+};
+
+export const processNearFungiblePayment = async (
+  walletConnection: WalletConnection,
+  network: CurrencyTypes.NearChainName,
+  amount: BigNumberish,
+  to: string,
+  paymentReference: string,
+  currencyAddress: string,
+  feeAddress: string,
+  feeAmount: BigNumberish,
+  version = '0.1.0',
+  callback: INearTransactionCallback | undefined = undefined,
+): Promise<void> => {
+  const fungibleContract = new Contract(walletConnection.account(), currencyAddress, {
+    changeMethods: ['ft_transfer_call'],
+    viewMethods: [],
+  }) as any;
+
+  const proxyAddress = erc20FeeProxyArtifact.getAddress(network, version);
+  await fungibleContract.ft_transfer_call({
+    args: {
+      receiver_id: proxyAddress,
+      amount,
+      msg: JSON.stringify({
+        fee_address: feeAddress,
+        fee_amount: feeAmount,
+        payment_reference: paymentReference,
+        to,
+      }),
+    },
+    gas: GAS_LIMIT_CONVERSION_TO_NATIVE,
+    amount: '1000000000000000000000000 '.toString(), // 1 yoctoNEAR deposit is mandatory for ft_transfer_call
+    ...callback,
+  });
+};
+
+type StorageBalance = {
+  total: string;
+  available: string;
+};
+
+// min. 0.00125 Ⓝ
+const MIN_STORAGE_FOR_FUNGIBLE = '1250000000000000000000';
+
+/**
+ * Stores the minimum deposit amount on the `paymentAddress` account for `tokenAddress`.
+ * This does not check the existing deposit, if any, and should be called if `isReceiverReady` is false.
+ * @param walletConnection
+ * @param tokenAddress
+ * @param paymentAddress
+ */
+export const storageDeposit = async (
+  walletConnection: WalletConnection,
+  tokenAddress: string,
+  paymentAddress: string,
+): Promise<void> => {
+  const fungibleContract = new Contract(walletConnection.account(), tokenAddress, {
+    changeMethods: ['storage_deposit'],
+    viewMethods: [],
+  }) as any;
+  await fungibleContract.storage_deposit({
+    args: { account_id: paymentAddress },
+    value: MIN_STORAGE_FOR_FUNGIBLE,
+  });
+};
+
+/**
+ * TODO: need to check how I got this error once.
+ * 'Smart contract panicked: The account account.identifier.near is not registered' if `receiver_id` does not exist.
+ *
+ *
+ *
+ * This checks that the receiver `paymentAddress` has enough storage on the `tokenAddress` to receive tokens.
+ *
+ * It returns false if trying to send tokens to the `paymentAddress` would result in:
+ *
+ * - 'Smart contract panicked: The account account.identifier.near is not registered'
+ *
+ */
+export const isReceiverReady = async (
+  walletConnection: WalletConnection,
+  tokenAddress: string,
+  paymentAddress: string,
+): Promise<boolean> => {
+  const fungibleContract = new Contract(walletConnection.account(), tokenAddress, {
+    changeMethods: [],
+    viewMethods: ['storage_balance_of'],
+  }) as any;
+  const storage = (await fungibleContract.storage_balance_of({
+    args: {
+      account_id: paymentAddress,
+    },
+  })) as StorageBalance | null;
+  return !!storage && BigNumber.from(storage?.total).gte(MIN_STORAGE_FOR_FUNGIBLE);
 };

--- a/packages/payment-processor/src/payment/utils-near.ts
+++ b/packages/payment-processor/src/payment/utils-near.ts
@@ -230,12 +230,7 @@ export const storageDeposit = async (
 };
 
 /**
- * TODO: need to check how I got this error once.
- * 'Smart contract panicked: The account account.identifier.near is not registered' if `receiver_id` does not exist.
- *
- *
- *
- * This checks that the receiver `paymentAddress` has enough storage on the `tokenAddress` to receive tokens.
+ * This checks that the `paymentAddress` has enough storage on the `tokenAddress` to receive tokens.
  *
  * It returns false if trying to send tokens to the `paymentAddress` would result in:
  *

--- a/packages/payment-processor/src/payment/utils-near.ts
+++ b/packages/payment-processor/src/payment/utils-near.ts
@@ -57,7 +57,8 @@ export const isNearAccountSolvent = (
 const GAS_LIMIT_IN_TGAS = 50;
 const GAS_LIMIT = ethers.utils.parseUnits(GAS_LIMIT_IN_TGAS.toString(), 12);
 const GAS_LIMIT_NATIVE = GAS_LIMIT.toString();
-const GAS_LIMIT_CONVERSION_TO_NATIVE = GAS_LIMIT.mul(2).toString();
+const GAS_LIMIT_CONVERSION_TO_NATIVE = GAS_LIMIT.mul(2).toString(); // 200 TGas
+const GAS_LIMIT_FUNGIBLE_PROXY = GAS_LIMIT.mul(4).toString(); // 400 TGas
 
 export const processNearPayment = async (
   walletConnection: WalletConnection,
@@ -193,8 +194,8 @@ export const processNearFungiblePayment = async (
         to,
       }),
     },
-    gas: GAS_LIMIT_CONVERSION_TO_NATIVE,
-    amount: '1000000000000000000000000 '.toString(), // 1 yoctoNEAR deposit is mandatory for ft_transfer_call
+    gas: GAS_LIMIT_FUNGIBLE_PROXY,
+    amount: '1'.toString(), // 1 yoctoNEAR deposit is mandatory for ft_transfer_call
     ...callback,
   });
 };
@@ -247,9 +248,7 @@ export const isReceiverReady = async (
     viewMethods: ['storage_balance_of'],
   }) as any;
   const storage = (await fungibleContract.storage_balance_of({
-    args: {
-      account_id: paymentAddress,
-    },
+    account_id: paymentAddress,
   })) as StorageBalance | null;
   return !!storage && BigNumber.from(storage?.total).gte(MIN_STORAGE_FOR_FUNGIBLE);
 };

--- a/packages/payment-processor/src/payment/utils-near.ts
+++ b/packages/payment-processor/src/payment/utils-near.ts
@@ -174,7 +174,6 @@ export const processNearFungiblePayment = async (
   currencyAddress: string,
   feeAddress: string,
   feeAmount: BigNumberish,
-  version = '0.1.0',
   callback: INearTransactionCallback | undefined = undefined,
 ): Promise<void> => {
   const fungibleContract = new Contract(walletConnection.account(), currencyAddress, {
@@ -182,7 +181,7 @@ export const processNearFungiblePayment = async (
     viewMethods: [],
   }) as any;
 
-  const proxyAddress = erc20FeeProxyArtifact.getAddress(network, version);
+  const proxyAddress = erc20FeeProxyArtifact.getAddress(network, 'near');
   await fungibleContract.ft_transfer_call({
     args: {
       receiver_id: proxyAddress,

--- a/packages/payment-processor/src/payment/utils.ts
+++ b/packages/payment-processor/src/payment/utils.ts
@@ -67,9 +67,8 @@ export function getSigner(
 }
 
 /**
- * Utility to access the payment address, reference,
- * and optional feeAmount, feeAddress, expectedFlowRate, expectedStartDate
- * of a Request.
+ * Utility to access payment-related information from a request.
+ * All data is taken from the request's payment extension, except the network that may be retrieved from the request's currency if needed.
  */
 export function getRequestPaymentValues(request: ClientTypes.IRequestData): {
   paymentAddress: string;
@@ -107,7 +106,7 @@ export function getRequestPaymentValues(request: ClientTypes.IRequestData): {
     expectedStartDate,
     tokensAccepted,
     maxRateTimespan,
-    network,
+    network: network ?? request.currencyInfo.network,
     version: extension.version,
   };
 }
@@ -207,7 +206,7 @@ export function validateRequest(
     getRequestPaymentValues(request);
   let extension = request.extensions[paymentNetworkId];
 
-  // FIXME: updating the extension: not needed anymore when "invoicing" will use only ethFeeProxy
+  // FIXME: updating the extension: not needed anymore when ETH_INPUT_DATA gets deprecated
   if (paymentNetworkId === ExtensionTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT && !extension) {
     extension = request.extensions[ExtensionTypes.PAYMENT_NETWORK_ID.ETH_INPUT_DATA];
   }

--- a/packages/payment-processor/test/payment/any-to-near.test.ts
+++ b/packages/payment-processor/test/payment/any-to-near.test.ts
@@ -115,7 +115,7 @@ describe('payNearWithConversionRequest', () => {
     ).rejects.toThrowError(
       'request cannot be processed, or is not an pn-any-to-native-token request',
     );
-    expect(paymentSpy).toHaveBeenCalledTimes(0);
+    expect(paymentSpy).not.toHaveBeenCalled();
   });
   it('throws when trying to pay with an unsupported currency', async () => {
     // A mock is used to bypass Near wallet connection for address validation and contract interaction
@@ -140,7 +140,7 @@ describe('payNearWithConversionRequest', () => {
     await expect(
       payNearConversionRequest(invalidRequest, mockedNearWalletConnection, conversionSettings),
     ).rejects.toThrowError('Near payment with conversion only implemented for fiat denominations.');
-    expect(paymentSpy).toHaveBeenCalledTimes(0);
+    expect(paymentSpy).not.toHaveBeenCalled();
   });
   it('throws when the netwrok is not near', async () => {
     // A mock is used to bypass Near wallet connection for address validation and contract interaction
@@ -171,6 +171,6 @@ describe('payNearWithConversionRequest', () => {
     await expect(
       payNearConversionRequest(invalidRequest, mockedNearWalletConnection, conversionSettings),
     ).rejects.toThrowError('Should be a Near network');
-    expect(paymentSpy).toHaveBeenCalledTimes(0);
+    expect(paymentSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/payment-processor/test/payment/any-to-near.test.ts
+++ b/packages/payment-processor/test/payment/any-to-near.test.ts
@@ -89,7 +89,7 @@ describe('payNearWithConversionRequest', () => {
       },
     );
   });
-  it('throws when tyring to pay another payment extension', async () => {
+  it('throws when trying to pay another payment extension', async () => {
     // A mock is used to bypass Near wallet connection for address validation and contract interaction
     const paymentSpy = jest
       .spyOn(nearUtils, 'processNearPaymentWithConversion')
@@ -117,7 +117,7 @@ describe('payNearWithConversionRequest', () => {
     );
     expect(paymentSpy).toHaveBeenCalledTimes(0);
   });
-  it('throws when tyring to pay with an unsupported currency', async () => {
+  it('throws when trying to pay with an unsupported currency', async () => {
     // A mock is used to bypass Near wallet connection for address validation and contract interaction
     const paymentSpy = jest
       .spyOn(nearUtils, 'processNearPaymentWithConversion')

--- a/packages/payment-processor/test/payment/erc20-fee-proxy-near.test.ts
+++ b/packages/payment-processor/test/payment/erc20-fee-proxy-near.test.ts
@@ -1,0 +1,142 @@
+import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
+import { deepCopy } from '@requestnetwork/utils';
+import { PaymentReferenceCalculator } from '@requestnetwork/payment-detection';
+
+import * as nearUtils from '../../src/payment/utils-near';
+import { payFungibleNearRequest } from '../../src/payment/near-fungible';
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+/* eslint-disable @typescript-eslint/await-thenable */
+
+const fau = {
+  type: RequestLogicTypes.CURRENCY.ERC20,
+  value: 'fau.reqnetwork.testnet',
+  network: 'aurora-testnet',
+};
+
+const salt = 'a6475e4c3d45feb6';
+const paymentAddress = 'issuer.testnet';
+const feeAddress = 'fee.testnet';
+const network = 'aurora-testnet';
+const feeAmount = '5';
+const request: any = {
+  requestId: '0x123',
+  expectedAmount: '100',
+  currencyInfo: fau,
+  extensions: {
+    [ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT]: {
+      events: [],
+      id: ExtensionTypes.PAYMENT_NETWORK_ID.ANY_TO_NATIVE_TOKEN,
+      type: ExtensionTypes.TYPE.PAYMENT_NETWORK,
+      values: {
+        salt,
+        paymentAddress,
+        feeAddress,
+        network,
+        feeAmount,
+      },
+      version: '0.1.0',
+    },
+  },
+};
+let paymentSpy: ReturnType<typeof jest.spyOn>;
+
+describe('payFungibleNearRequest', () => {
+  beforeEach(() => {
+    // A mock is used to bypass Near wallet connection for address validation and contract interaction
+    paymentSpy = jest
+      .spyOn(nearUtils, 'processNearFungiblePayment')
+      .mockReturnValue(Promise.resolve());
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it('pays a FAU-near request (with mock)', async () => {
+    jest.spyOn(nearUtils, 'isReceiverReady').mockReturnValue(Promise.resolve(true));
+    const mockedNearWalletConnection = {
+      account: () => ({
+        functionCall: () => true,
+        account: { viewFunction: () => 'payer.testnet' }, // Check if used
+        // state: () => Promise.resolve({ amount: 100 }),
+      }),
+    } as any;
+
+    const paymentReference = PaymentReferenceCalculator.calculate(
+      request.requestId,
+      salt,
+      paymentAddress,
+    );
+
+    await payFungibleNearRequest(request, mockedNearWalletConnection, undefined, {
+      callbackUrl: 'https://some.callback.url',
+      meta: 'param',
+    });
+    expect(paymentSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'aurora-testnet',
+      '100',
+      paymentAddress,
+      paymentReference,
+      'fau.reqnetwork.testnet',
+      feeAddress,
+      feeAmount,
+      '0.1.0',
+      {
+        callbackUrl: 'https://some.callback.url',
+        meta: 'param',
+      },
+    );
+  });
+  it('throws when tyring to pay another payment extension', async () => {
+    // A mock is used to bypass Near wallet connection for address validation and contract interaction
+    const paymentSpy = jest
+      .spyOn(nearUtils, 'processNearFungiblePayment')
+      .mockReturnValue(Promise.resolve());
+    const mockedNearWalletConnection = {
+      account: () => ({
+        functionCall: () => true,
+        // state: () => Promise.resolve({ amount: 100 }),
+      }),
+    } as any;
+    let invalidRequest = deepCopy(request);
+    invalidRequest = {
+      ...invalidRequest,
+      extensions: {
+        [ExtensionTypes.PAYMENT_NETWORK_ID.ANY_TO_ETH_PROXY]: {
+          ...invalidRequest.extensions[ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT],
+        },
+      },
+    };
+
+    await expect(
+      payFungibleNearRequest(invalidRequest, mockedNearWalletConnection, undefined, undefined),
+    ).rejects.toThrowError(
+      'request cannot be processed, or is not an pn-erc20-fee-proxy-contract request',
+    );
+    expect(paymentSpy).toHaveBeenCalledTimes(0);
+  });
+  it('throws when tyring to pay with a native token', async () => {
+    const mockedNearWalletConnection = {
+      account: () => ({
+        functionCall: () => true,
+        state: () => Promise.resolve({ amount: 100 }),
+      }),
+    } as any;
+    let invalidRequest = deepCopy(request);
+    invalidRequest = {
+      ...invalidRequest,
+      currencyInfo: {
+        type: RequestLogicTypes.CURRENCY.ETH,
+        value: 'NEAR',
+        network: 'aurora',
+      },
+    };
+
+    await expect(
+      payFungibleNearRequest(invalidRequest, mockedNearWalletConnection),
+    ).rejects.toThrowError(
+      'request cannot be processed, or is not an pn-erc20-fee-proxy-contract request',
+    );
+    expect(paymentSpy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/payment-processor/test/payment/erc20-fee-proxy-near.test.ts
+++ b/packages/payment-processor/test/payment/erc20-fee-proxy-near.test.ts
@@ -157,7 +157,7 @@ describe('payNearFungibleRequest', () => {
     ).rejects.toThrowError(
       'request cannot be processed, or is not an pn-erc20-fee-proxy-contract request',
     );
-    expect(paymentSpy).toHaveBeenCalledTimes(0);
+    expect(paymentSpy).not.toHaveBeenCalled();
   });
 
   it('throws when trying to pay with a native token', async () => {
@@ -182,6 +182,6 @@ describe('payNearFungibleRequest', () => {
     ).rejects.toThrowError(
       'request cannot be processed, or is not an pn-erc20-fee-proxy-contract request',
     );
-    expect(paymentSpy).toHaveBeenCalledTimes(0);
+    expect(paymentSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/payment-processor/test/payment/erc20-fee-proxy-near.test.ts
+++ b/packages/payment-processor/test/payment/erc20-fee-proxy-near.test.ts
@@ -3,7 +3,7 @@ import { deepCopy } from '@requestnetwork/utils';
 import { PaymentReferenceCalculator } from '@requestnetwork/payment-detection';
 
 import * as nearUtils from '../../src/payment/utils-near';
-import { payFungibleNearRequest } from '../../src/payment/near-fungible';
+import { payNearFungibleRequest } from '../../src/payment/near-fungible';
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 /* eslint-disable @typescript-eslint/await-thenable */
@@ -41,7 +41,7 @@ const request: any = {
 };
 let paymentSpy: ReturnType<typeof jest.spyOn>;
 
-describe('payFungibleNearRequest', () => {
+describe('payNearFungibleRequest', () => {
   beforeEach(() => {
     // A mock is used to bypass Near wallet connection for address validation and contract interaction
     paymentSpy = jest
@@ -65,7 +65,7 @@ describe('payFungibleNearRequest', () => {
       paymentAddress,
     );
 
-    await payFungibleNearRequest(request, mockedNearWalletConnection, undefined, {
+    await payNearFungibleRequest(request, mockedNearWalletConnection, undefined, {
       callbackUrl: 'https://some.callback.url',
       meta: 'param',
     });
@@ -99,7 +99,7 @@ describe('payFungibleNearRequest', () => {
     } as any;
 
     await expect(async () => {
-      await payFungibleNearRequest(request, mockedNearWalletConnection, undefined, {
+      await payNearFungibleRequest(request, mockedNearWalletConnection, undefined, {
         callbackUrl: 'https://some.callback.url',
         meta: 'param',
       });
@@ -123,7 +123,7 @@ describe('payFungibleNearRequest', () => {
     } as any;
 
     await expect(async () => {
-      await payFungibleNearRequest(request, mockedNearWalletConnection, undefined, {
+      await payNearFungibleRequest(request, mockedNearWalletConnection, undefined, {
         callbackUrl: 'https://some.callback.url',
         meta: 'param',
       });
@@ -153,7 +153,7 @@ describe('payFungibleNearRequest', () => {
     };
 
     await expect(
-      payFungibleNearRequest(invalidRequest, mockedNearWalletConnection, undefined, undefined),
+      payNearFungibleRequest(invalidRequest, mockedNearWalletConnection, undefined, undefined),
     ).rejects.toThrowError(
       'request cannot be processed, or is not an pn-erc20-fee-proxy-contract request',
     );
@@ -178,7 +178,7 @@ describe('payFungibleNearRequest', () => {
     };
 
     await expect(
-      payFungibleNearRequest(invalidRequest, mockedNearWalletConnection),
+      payNearFungibleRequest(invalidRequest, mockedNearWalletConnection),
     ).rejects.toThrowError(
       'request cannot be processed, or is not an pn-erc20-fee-proxy-contract request',
     );

--- a/packages/payment-processor/test/payment/index.test.ts
+++ b/packages/payment-processor/test/payment/index.test.ts
@@ -225,7 +225,7 @@ describe('payNearInputDataRequest', () => {
     await expect(
       payNearInputDataRequest(request, mockedNearWalletConnection, '1'),
     ).rejects.toThrowError('request cannot be processed, or is not an pn-native-token request');
-    expect(paymentSpy).toHaveBeenCalledTimes(0);
+    expect(paymentSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/payment-processor/test/payment/index.test.ts
+++ b/packages/payment-processor/test/payment/index.test.ts
@@ -194,7 +194,7 @@ describe('payNearInputDataRequest', () => {
       { callbackUrl: 'https://some.callback.url', meta: 'param' },
     );
   });
-  it('throws when tyring to pay another payment extension', async () => {
+  it('throws when trying to pay another payment extension', async () => {
     // A mock is used to bypass Near wallet connection for address validation and contract interaction
     const paymentSpy = jest
       .spyOn(nearUtils, 'processNearPayment')

--- a/packages/smart-contracts/src/lib/artifacts/ERC20FeeProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/ERC20FeeProxy/index.ts
@@ -144,6 +144,10 @@ export const erc20FeeProxyArtifact = new ContractArtifact<ERC20FeeProxy>(
           address: 'pay.reqnetwork.testnet',
           creationBlockNumber: 120566834,
         },
+        aurora: {
+          address: 'pay.reqnetwork.near',
+          creationBlockNumber: 89421541,
+        },
       },
     },
     // Additional deployments of same versions, not worth upgrading the version number but worth using within next versions


### PR DESCRIPTION
## Description of the changes

feat: `payment-processor` method for paying an ERC20FeeProxy request on Near, by sending fungible tokens to a proxy contract.

chore: deployment address for mainnet.