### PR TITLE
feat: ERC20TransferableReceivable contract gas optimizations

### DIFF
--- a/packages/advanced-logic/src/extensions/payment-network/erc20/transferable-receivable.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/transferable-receivable.ts
@@ -1,7 +1,7 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { FeeReferenceBasedPaymentNetwork } from '../fee-reference-based';
 
-const CURRENT_VERSION = '0.1.0';
+const CURRENT_VERSION = '0.2.0';
 
 /**
  * Implementation of the payment network to pay in ERC20 based on a transferable receivable contract.

--- a/packages/payment-detection/src/erc20/transferable-receivable.ts
+++ b/packages/payment-detection/src/erc20/transferable-receivable.ts
@@ -14,6 +14,7 @@ import ProxyERC20InfoRetriever from './proxy-info-retriever';
 
 const ERC20_TRANSFERABLE_RECEIVABLE_CONTRACT_ADDRESS_MAP = {
   ['0.1.0']: '0.1.0',
+  ['0.2.0']: '0.2.0',
 };
 
 /**

--- a/packages/payment-processor/package.json
+++ b/packages/payment-processor/package.json
@@ -43,6 +43,7 @@
     "@requestnetwork/currency": "0.9.0",
     "@requestnetwork/payment-detection": "0.36.0",
     "@requestnetwork/smart-contracts": "0.29.0",
+    "@requestnetwork/multi-format": "0.15.10",
     "@requestnetwork/types": "0.36.0",
     "@requestnetwork/utils": "0.36.0",
     "@superfluid-finance/sdk-core": "0.5.0",

--- a/packages/payment-processor/package.json
+++ b/packages/payment-processor/package.json
@@ -43,7 +43,6 @@
     "@requestnetwork/currency": "0.9.0",
     "@requestnetwork/payment-detection": "0.36.0",
     "@requestnetwork/smart-contracts": "0.29.0",
-    "@requestnetwork/multi-format": "0.15.10",
     "@requestnetwork/types": "0.36.0",
     "@requestnetwork/utils": "0.36.0",
     "@superfluid-finance/sdk-core": "0.5.0",

--- a/packages/payment-processor/src/payment/erc20-transferable-receivable.ts
+++ b/packages/payment-processor/src/payment/erc20-transferable-receivable.ts
@@ -14,6 +14,7 @@ import {
 } from '@requestnetwork/payment-detection';
 import { ERC20TransferableReceivable__factory } from '@requestnetwork/smart-contracts/types';
 import { ClientTypes } from '@requestnetwork/types';
+import MultiFormat from '@requestnetwork/multi-format';
 
 import { ITransactionOverrides } from './transaction-overrides';
 import {
@@ -115,7 +116,7 @@ export function encodeMintErc20TransferableReceivableRequest(
   validateERC20TransferableReceivable(request);
 
   const tokenAddress = request.currencyInfo.value;
-  const metadata = Buffer.from(request.requestId).toString('base64'); // metadata is requestId
+  const requestIdDeserialized = MultiFormat.deserialize(request.requestId).value;
 
   const { paymentReference, paymentAddress } = getRequestPaymentValues(request);
   const amount = getAmountToPay(request);
@@ -126,7 +127,7 @@ export function encodeMintErc20TransferableReceivableRequest(
     `0x${paymentReference}`,
     amount,
     tokenAddress,
-    metadata,
+    requestIdDeserialized,
   ]);
 }
 
@@ -204,10 +205,11 @@ export async function encodePayErc20TransferableReceivableRequest(
 
   const receivableContract = ERC20TransferableReceivable__factory.createInterface();
 
+  // get tokenId from requestId
   const receivableTokenId = await getReceivableTokenIdForRequest(request, signerOrProvider);
 
   return receivableContract.encodeFunctionData('payOwner', [
-    receivableTokenId, // get tokenId from requestId
+    receivableTokenId,
     amountToPay,
     `0x${paymentReference}`,
     feeToPay,

--- a/packages/payment-processor/src/payment/erc20-transferable-receivable.ts
+++ b/packages/payment-processor/src/payment/erc20-transferable-receivable.ts
@@ -14,7 +14,6 @@ import {
 } from '@requestnetwork/payment-detection';
 import { ERC20TransferableReceivable__factory } from '@requestnetwork/smart-contracts/types';
 import { ClientTypes } from '@requestnetwork/types';
-import MultiFormat from '@requestnetwork/multi-format';
 
 import { ITransactionOverrides } from './transaction-overrides';
 import {
@@ -116,7 +115,6 @@ export function encodeMintErc20TransferableReceivableRequest(
   validateERC20TransferableReceivable(request);
 
   const tokenAddress = request.currencyInfo.value;
-  const requestIdDeserialized = MultiFormat.deserialize(request.requestId).value;
 
   const { paymentReference, paymentAddress } = getRequestPaymentValues(request);
   const amount = getAmountToPay(request);
@@ -127,7 +125,6 @@ export function encodeMintErc20TransferableReceivableRequest(
     `0x${paymentReference}`,
     amount,
     tokenAddress,
-    requestIdDeserialized,
   ]);
 }
 
@@ -205,7 +202,7 @@ export async function encodePayErc20TransferableReceivableRequest(
 
   const receivableContract = ERC20TransferableReceivable__factory.createInterface();
 
-  // get tokenId from requestId
+  // get tokenId from request
   const receivableTokenId = await getReceivableTokenIdForRequest(request, signerOrProvider);
 
   return receivableContract.encodeFunctionData('payOwner', [

--- a/packages/payment-processor/test/payment/erc20-transferable-receivable.test.ts
+++ b/packages/payment-processor/test/payment/erc20-transferable-receivable.test.ts
@@ -118,7 +118,8 @@ describe('erc20-transferable-receivable', () => {
     it('rejects paying without minting', async () => {
       // Different request without a minted receivable
       const request = deepCopy(validRequest) as ClientTypes.IRequestData;
-      request.requestId = '0x01';
+      // Change the request id
+      request.requestId = '0188791633ff0ec72a7dbdefb886d2db6cccfa98287320839c2f173c7a4e3ce7e2';
 
       await expect(payErc20TransferableReceivableRequest(request, wallet)).rejects.toThrowError(
         'The receivable for this request has not been minted yet. Please check with the payee.',
@@ -235,7 +236,8 @@ describe('erc20-transferable-receivable', () => {
     it('other wallets can mint receivable for owner', async () => {
       // Request without a receivable minted yet
       const request = deepCopy(validRequest) as ClientTypes.IRequestData;
-      request.requestId = '0x01';
+      // Change the request id
+      request.requestId = '0188791633ff0ec72a7dbdefb886d2db6cccfa98287320839c2f173c7a4e3ce7e3';
 
       const mintTx = await mintErc20TransferableReceivable(request, thirdPartyWallet, {
         gasLimit: BigNumber.from('20000000'),
@@ -268,7 +270,8 @@ describe('erc20-transferable-receivable', () => {
     it('rejects paying unless minted to correct owner', async () => {
       // Request without a receivable minted yet
       const request = deepCopy(validRequest) as ClientTypes.IRequestData;
-      request.requestId = '0x02';
+      // Change the request id
+      request.requestId = '0188791633ff0ec72a7dbdefb886d2db6cccfa98287320839c2f173c7a4e3ce7e4';
 
       let shortReference = PaymentReferenceCalculator.calculate(
         request.requestId,

--- a/packages/payment-processor/test/payment/erc20-transferable-receivable.test.ts
+++ b/packages/payment-processor/test/payment/erc20-transferable-receivable.test.ts
@@ -25,7 +25,7 @@ import { getProxyAddress } from '../../src/payment/utils';
 const erc20ContractAddress = '0x9FBDa871d559710256a2502A2517b794B482Db40';
 
 const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
-const feeAddress = '0xC5fdf4076b8F3A5357c5E395ab970B5B54098Fef';
+const feeAddress = '0x75c35C980C0d37ef46DF04d31A140b65503c0eEd';
 const provider = new providers.JsonRpcProvider('http://localhost:8545');
 const payeeWallet = Wallet.createRandom().connect(provider);
 const thirdPartyWallet = Wallet.createRandom().connect(provider);
@@ -61,7 +61,7 @@ const validRequest: ClientTypes.IRequestData = {
         paymentAddress,
         salt: '0ee84db293a752c6',
       },
-      version: '0.1.0',
+      version: '0.2.0',
     },
   },
   payee: {
@@ -193,7 +193,7 @@ describe('erc20-transferable-receivable', () => {
           .hexZeroPad(tokenId.toHexString(), 16)
           .substring(
             2,
-          )}000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c5fdf4076b8f3a5357c5e395ab970b5b54098fef0000000000000000000000000000000000000000000000000000000000000008${shortReference}000000000000000000000000000000000000000000000000`,
+          )}000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000075c35c980c0d37ef46df04d31a140b65503c0eed0000000000000000000000000000000000000000000000000000000000000008${shortReference}000000000000000000000000000000000000000000000000`,
         gasPrice: '20000000000',
         to: '0xF426505ac145abE033fE77C666840063757Be9cd',
         value: 0,
@@ -279,14 +279,12 @@ describe('erc20-transferable-receivable', () => {
           .salt,
         paymentAddress,
       );
-      let metadata = Buffer.from(request.requestId).toString('base64');
       let receivableContract = ERC20TransferableReceivable__factory.createInterface();
       let data = receivableContract.encodeFunctionData('mint', [
         thirdPartyWallet.address,
         `0x${shortReference}`,
         '100',
         erc20ContractAddress,
-        metadata,
       ]);
       let tx = await thirdPartyWallet.sendTransaction({
         data,
@@ -312,14 +310,12 @@ describe('erc20-transferable-receivable', () => {
           .salt,
         paymentAddress,
       );
-      metadata = Buffer.from(request.requestId).toString('base64');
       receivableContract = ERC20TransferableReceivable__factory.createInterface();
       data = receivableContract.encodeFunctionData('mint', [
         paymentAddress,
         `0x${shortReference}`,
         '100',
         erc20ContractAddress,
-        metadata,
       ]);
       tx = await thirdPartyWallet.sendTransaction({
         data,

--- a/packages/smart-contracts/scripts/test-deploy-erc20-transferable-receivable.ts
+++ b/packages/smart-contracts/scripts/test-deploy-erc20-transferable-receivable.ts
@@ -18,6 +18,7 @@ export async function deployERC20TransferableReceivable(
           'tREC',
           mainPaymentAddresses.ERC20FeeProxyAddress,
         ],
+        version: '0.2.0',
       },
     );
 

--- a/packages/smart-contracts/src/contracts/ERC20TransferableReceivable.sol
+++ b/packages/smart-contracts/src/contracts/ERC20TransferableReceivable.sol
@@ -29,6 +29,7 @@ contract ERC20TransferableReceivable is ERC721 {
 
   /**
    * @notice Mapping for looking up a receivable given a paymentReference and minter address
+   * @dev Prevents minting multiple tokens for a given paymentReference and minter address
    */
   mapping(bytes32 => uint256) public receivableTokenIdMapping;
 

--- a/packages/smart-contracts/src/contracts/ERC20TransferableReceivable.sol
+++ b/packages/smart-contracts/src/contracts/ERC20TransferableReceivable.sol
@@ -28,8 +28,8 @@ contract ERC20TransferableReceivable is ERC721 {
   }
 
   /**
-   * @notice Mapping for looking up a receivable given a paymentReference and minter address
-   * @dev Prevents minting multiple tokens for a given paymentReference and minter address
+   * @notice Mapping for looking up a receivable given an initial owner address and paymentReference
+   * @dev Prevents minting multiple tokens for a given initial owner address and paymentReference
    */
   mapping(bytes32 => uint256) public receivableTokenIdMapping;
 

--- a/packages/smart-contracts/src/contracts/ERC20TransferableReceivable.sol
+++ b/packages/smart-contracts/src/contracts/ERC20TransferableReceivable.sol
@@ -14,11 +14,6 @@ contract ERC20TransferableReceivable is ERC721 {
   using Counters for Counters.Counter;
 
   /**
-   * @dev Counter for uniquely identifying payments
-   */
-  Counters.Counter private _paymentId;
-
-  /**
    * @dev Counter for uniquely identifying receivables
    */
   Counters.Counter private _receivableTokenId;
@@ -30,7 +25,6 @@ contract ERC20TransferableReceivable is ERC721 {
     address tokenAddress;
     uint256 amount;
     uint256 balance;
-    bytes32 requestID;
   }
 
   /**
@@ -53,20 +47,14 @@ contract ERC20TransferableReceivable is ERC721 {
    * @param sender The address of the sender
    * @param recipient The address of the recipient of the payment
    * @param amount The amount of the payment
-   * @param paymentProxy The address of the payment proxy contract
    * @param receivableTokenId The ID of the receivable being paid
-   * @param tokenAddress The address of the ERC20 token used to pay the receivable
-   * @param paymentId The ID of the payment
    * @param paymentReference The reference for the payment
    */
   event TransferableReceivablePayment(
     address sender,
     address recipient,
     uint256 amount,
-    address paymentProxy,
     uint256 receivableTokenId,
-    address tokenAddress,
-    uint256 paymentId,
     bytes indexed paymentReference
   );
 
@@ -121,7 +109,6 @@ contract ERC20TransferableReceivable is ERC721 {
   ) external {
     require(amount != 0, 'Zero amount provided');
     address owner = ownerOf(receivableTokenId);
-    _paymentId.increment();
 
     ReceivableInfo storage receivableInfo = receivableInfoMapping[receivableTokenId];
     address tokenAddress = receivableInfo.tokenAddress;
@@ -144,10 +131,7 @@ contract ERC20TransferableReceivable is ERC721 {
       msg.sender,
       owner,
       amount,
-      paymentProxy,
       receivableTokenId,
-      tokenAddress,
-      _paymentId.current(),
       paymentReference
     );
   }
@@ -158,16 +142,13 @@ contract ERC20TransferableReceivable is ERC721 {
    * @param paymentReference A reference for the payment.
    * @param amount The amount of ERC20 tokens to be paid.
    * @param erc20Addr The address of the ERC20 token to be used as payment.
-   * @param requestID The ID of the request associated with the receivable.
-   *                  Useful for retrieving details of the request from the Request Network.
    * @dev Anyone can pay for the mint of a receivable on behalf of a user
    */
   function mint(
     address owner,
     bytes calldata paymentReference,
     uint256 amount,
-    address erc20Addr,
-    bytes32 requestID
+    address erc20Addr
   ) external {
     require(paymentReference.length > 0, 'Zero paymentReference provided');
     require(amount > 0, 'Zero amount provided');
@@ -184,8 +165,7 @@ contract ERC20TransferableReceivable is ERC721 {
     receivableInfoMapping[currentReceivableTokenId] = ReceivableInfo({
       tokenAddress: erc20Addr,
       amount: amount,
-      balance: 0,
-      requestID: requestID
+      balance: 0
     });
 
     _mint(owner, currentReceivableTokenId);

--- a/packages/smart-contracts/src/lib/artifacts/ERC20TransferableReceivable/0.2.0.json
+++ b/packages/smart-contracts/src/lib/artifacts/ERC20TransferableReceivable/0.2.0.json
@@ -162,26 +162,8 @@
         },
         {
           "indexed": false,
-          "internalType": "address",
-          "name": "paymentProxy",
-          "type": "address"
-        },
-        {
-          "indexed": false,
           "internalType": "uint256",
           "name": "receivableTokenId",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "tokenAddress",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "paymentId",
           "type": "uint256"
         },
         {
@@ -254,25 +236,6 @@
       "inputs": [
         {
           "internalType": "address",
-          "name": "_owner",
-          "type": "address"
-        }
-      ],
-      "name": "getTokenIds",
-      "outputs": [
-        {
-          "internalType": "uint256[]",
-          "name": "",
-          "type": "uint256[]"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
           "name": "owner",
           "type": "address"
         },
@@ -316,9 +279,9 @@
           "type": "address"
         },
         {
-          "internalType": "string",
-          "name": "newTokenURI",
-          "type": "string"
+          "internalType": "bytes32",
+          "name": "requestID",
+          "type": "bytes32"
         }
       ],
       "name": "mint",
@@ -428,6 +391,11 @@
           "internalType": "uint256",
           "name": "balance",
           "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "requestID",
+          "type": "bytes32"
         }
       ],
       "stateMutability": "view",
@@ -557,49 +525,6 @@
       "inputs": [
         {
           "internalType": "uint256",
-          "name": "index",
-          "type": "uint256"
-        }
-      ],
-      "name": "tokenByIndex",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "owner",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "index",
-          "type": "uint256"
-        }
-      ],
-      "name": "tokenOfOwnerByIndex",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
           "name": "tokenId",
           "type": "uint256"
         }
@@ -610,19 +535,6 @@
           "internalType": "string",
           "name": "",
           "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "totalSupply",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
         }
       ],
       "stateMutability": "view",

--- a/packages/smart-contracts/src/lib/artifacts/ERC20TransferableReceivable/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/ERC20TransferableReceivable/index.ts
@@ -1,6 +1,7 @@
 import { ContractArtifact } from '../../ContractArtifact';
 
 import { abi as ABI_0_1_0 } from './0.1.0.json';
+import { abi as ABI_0_2_0 } from './0.2.0.json';
 // @ts-ignore Cannot find module
 import type { ERC20TransferableReceivable } from '../../../types/ERC20TransferableReceivable';
 
@@ -28,6 +29,15 @@ export const erc20TransferableReceivableArtifact =
           },
         },
       },
+      '0.2.0': {
+        abi: ABI_0_2_0,
+        deployment: {
+          private: {
+            address: '0xF426505ac145abE033fE77C666840063757Be9cd',
+            creationBlockNumber: 0,
+          },
+        },
+      },
     },
-    '0.1.0',
+    '0.2.0',
   );

--- a/packages/smart-contracts/test/contracts/ERC20TransferableReceivable.test.ts
+++ b/packages/smart-contracts/test/contracts/ERC20TransferableReceivable.test.ts
@@ -106,18 +106,6 @@ describe('contract: ERC20TransferableReceivable', () => {
           testToken.address,
           '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
         );
-    });
-
-    it('revert when trying to mint a receivable for the same request', async function () {
-      await receivable
-        .connect(user1)
-        .mint(
-          user1Addr,
-          '0x01',
-          1,
-          testToken.address,
-          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
-        );
       await expect(
         receivable
           .connect(user1)
@@ -292,10 +280,17 @@ describe('contract: ERC20TransferableReceivable', () => {
 
     it('allows user to mint on behalf of another user', async function () {
       paymentRef = '0x02' as BytesLike;
-      await receivable.connect(user1).mint(user2Addr, paymentRef, amount, testToken.address, '1');
+      await receivable
+        .connect(user1)
+        .mint(
+          user2Addr,
+          paymentRef,
+          amount,
+          testToken.address,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        );
       const key = ethers.utils.solidityKeccak256(['address', 'bytes'], [user2Addr, paymentRef]);
-      const ids = await receivable.getTokenIds(user2Addr);
-      tokenId = ids[0];
+      tokenId = BN.from(2);
       expect(await receivable.receivableTokenIdMapping(key)).to.equals(tokenId);
     });
 

--- a/packages/smart-contracts/test/contracts/ERC20TransferableReceivable.test.ts
+++ b/packages/smart-contracts/test/contracts/ERC20TransferableReceivable.test.ts
@@ -41,82 +41,161 @@ describe('contract: ERC20TransferableReceivable', () => {
     await testToken.approve(receivable.address, ethers.constants.MaxUint256);
   });
 
-  async function verifyReceivables(userAddr: string, receivableIds: any) {
-    const ids = await receivable.getTokenIds(userAddr);
-    expect(ids.toString()).to.equals(receivableIds.toString());
+  async function verifyReceivables(userAddr: string, tokenIds: any) {
+    for (let tokenId of tokenIds) {
+      expect(await receivable.ownerOf(tokenId)).to.equals(userAddr);
+    }
   }
 
   describe('mint', async function () {
     it('revert with empty paymentReference', async function () {
-      await expect(receivable.mint(user1Addr, [], 1, testToken.address, '')).to.be.revertedWith(
-        'Zero paymentReference provided',
-      );
+      await expect(
+        receivable.mint(
+          user1Addr,
+          [],
+          1,
+          testToken.address,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        ),
+      ).to.be.revertedWith('Zero paymentReference provided');
     });
 
     it('revert with zero amount', async function () {
-      await expect(receivable.mint(user1Addr, '0x01', 0, testToken.address, '')).to.be.revertedWith(
-        'Zero amount provided',
-      );
+      await expect(
+        receivable.mint(
+          user1Addr,
+          '0x01',
+          0,
+          testToken.address,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        ),
+      ).to.be.revertedWith('Zero amount provided');
     });
 
     it('revert with empty asset address', async function () {
       await expect(
-        receivable.mint(user1Addr, '0x01', 1, ethers.constants.AddressZero, ''),
+        receivable.mint(
+          user1Addr,
+          '0x01',
+          1,
+          ethers.constants.AddressZero,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        ),
       ).to.be.revertedWith('Zero address provided');
     });
 
     it('revert with empty owner address', async function () {
       await expect(
-        receivable.mint(ethers.constants.AddressZero, '0x01', 1, testToken.address, ''),
+        receivable.mint(
+          ethers.constants.AddressZero,
+          '0x01',
+          1,
+          testToken.address,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        ),
       ).to.be.revertedWith('Zero address provided for owner');
     });
 
     it('revert with duplicated receivableId', async function () {
-      await receivable.connect(user1).mint(user1Addr, '0x01', 1, testToken.address, '');
+      await receivable
+        .connect(user1)
+        .mint(
+          user1Addr,
+          '0x01',
+          1,
+          testToken.address,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        );
+    });
+
+    it('revert when trying to mint a receivable for the same request', async function () {
+      await receivable
+        .connect(user1)
+        .mint(
+          user1Addr,
+          '0x01',
+          1,
+          testToken.address,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        );
       await expect(
-        receivable.connect(user1).mint(user1Addr, '0x01', 2, testToken.address, ''),
+        receivable
+          .connect(user1)
+          .mint(
+            user1Addr,
+            '0x01',
+            2,
+            testToken.address,
+            '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+          ),
       ).to.be.revertedWith('Receivable has already been minted for this user and request');
     });
 
     it('success', async function () {
-      const receivableId = '0x0134cc5f0224acb0544a9d325f8f2160c53130ba4671849472f2a96a35c93a78d6';
-      const metadata = ethers.utils.base64.encode(receivableId);
+      const requestID = '0x34cc5f0224acb0544a9d325f8f2160c53130ba4671849472f2a96a35c93a78d6';
       const paymentRef = '0x01' as BytesLike;
       await receivable
         .connect(user1)
-        .mint(user1Addr, paymentRef, BASE_DECIMAL, testToken.address, metadata);
-      const ids = await receivable.getTokenIds(user1Addr);
-      const tokenId = ids[0];
+        .mint(user1Addr, paymentRef, BASE_DECIMAL, testToken.address, requestID);
+      const tokenId = 1;
       expect(await receivable.ownerOf(tokenId)).to.equals(user1Addr);
-      expect(await receivable.tokenURI(tokenId)).to.equals(metadata);
       const key = ethers.utils.solidityKeccak256(['address', 'bytes'], [user1Addr, paymentRef]);
       expect(await receivable.receivableTokenIdMapping(key)).to.equals(tokenId);
-      const info = await receivable.receivableInfoMapping(tokenId);
-      expect(info[0]).to.equals(testToken.address);
-      expect(info[1]).to.equals(BASE_DECIMAL);
-      expect(info[2]).to.equals(0);
-    });
 
-    it('mints with tokenURI set', async function () {
-      const receivableId = '0x0134cc5f0224acb0544a9d325f8f2160c53130ba4671849472f2a96a35c93a78d6';
-      const paymentRef = '0x01' as BytesLike;
-      await receivable
-        .connect(user1)
-        .mint(user1Addr, paymentRef, BASE_DECIMAL, testToken.address, receivableId);
-      const ids = await receivable.getTokenIds(user1Addr);
-      const tokenId = ids[0];
-
-      const tokenURI = await receivable.tokenURI(tokenId);
-      expect(tokenURI).to.equal(receivableId);
+      const receivableInfo = await receivable.receivableInfoMapping(tokenId);
+      expect(receivableInfo.tokenAddress).to.equal(testToken.address);
+      expect(receivableInfo.amount).to.equal(BASE_DECIMAL);
+      expect(receivableInfo.balance).to.equal(0);
+      expect(receivableInfo.requestID).to.equal(requestID);
     });
 
     it('list receivables', async function () {
-      await receivable.connect(user1).mint(user1Addr, '0x01', BASE_DECIMAL, testToken.address, '1');
-      await receivable.connect(user1).mint(user1Addr, '0x02', BASE_DECIMAL, testToken.address, '2');
-      await receivable.connect(user1).mint(user1Addr, '0x03', BASE_DECIMAL, testToken.address, '3');
+      await receivable
+        .connect(user1)
+        .mint(
+          user1Addr,
+          '0x01',
+          BASE_DECIMAL,
+          testToken.address,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        );
+      await receivable
+        .connect(user1)
+        .mint(
+          user1Addr,
+          '0x02',
+          BASE_DECIMAL,
+          testToken.address,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        );
+      await receivable
+        .connect(user1)
+        .mint(
+          user1Addr,
+          '0x03',
+          BASE_DECIMAL,
+          testToken.address,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        );
       await verifyReceivables(user1Addr, [1, 2, 3]);
-      await receivable.connect(user2).mint(user2Addr, '0x04', BASE_DECIMAL, testToken.address, '4');
-      await receivable.connect(user2).mint(user2Addr, '0x05', BASE_DECIMAL, testToken.address, '5');
+      await receivable
+        .connect(user2)
+        .mint(
+          user2Addr,
+          '0x04',
+          BASE_DECIMAL,
+          testToken.address,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        );
+      await receivable
+        .connect(user2)
+        .mint(
+          user2Addr,
+          '0x05',
+          BASE_DECIMAL,
+          testToken.address,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        );
       await verifyReceivables(user2Addr, [4, 5]);
       await receivable.connect(user1).transferFrom(user1Addr, user2Addr, 1);
       await verifyReceivables(user1Addr, [3, 2]);
@@ -149,9 +228,16 @@ describe('contract: ERC20TransferableReceivable', () => {
     beforeEach(async () => {
       paymentRef = '0x01' as BytesLike;
       amount = BN.from(100).mul(BASE_DECIMAL);
-      await receivable.connect(user1).mint(user1Addr, paymentRef, amount, testToken.address, '1');
-      const ids = await receivable.getTokenIds(await user1.getAddress());
-      tokenId = ids[0];
+      await receivable
+        .connect(user1)
+        .mint(
+          user1Addr,
+          paymentRef,
+          amount,
+          testToken.address,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        );
+      tokenId = BN.from(1);
       feeAmount = BN.from(10).mul(BASE_DECIMAL);
     });
 
@@ -191,7 +277,15 @@ describe('contract: ERC20TransferableReceivable', () => {
     });
 
     it('allow multiple mints per receivable', async function () {
-      await receivable.connect(user2).mint(user2Addr, paymentRef, amount, testToken.address, '1');
+      await receivable
+        .connect(user2)
+        .mint(
+          user2Addr,
+          paymentRef,
+          amount,
+          testToken.address,
+          '0x744383081b5ce5d256b385c914e51a2a5b3dde687d65ea163bc8b76f3f0bf40f',
+        );
       const key = ethers.utils.solidityKeccak256(['address', 'bytes'], [user1Addr, paymentRef]);
       expect(await receivable.receivableTokenIdMapping(key)).to.equals(tokenId);
     });
@@ -206,6 +300,7 @@ describe('contract: ERC20TransferableReceivable', () => {
     });
 
     it('payment greater than amount', async function () {
+      const receivableInfoBefore = await receivable.receivableInfoMapping(tokenId);
       const beforeBal = await testToken.balanceOf(user1Addr);
       await expect(
         receivable.payOwner(tokenId, amount.mul(2), paymentRef, 0, ethers.constants.AddressZero),
@@ -219,11 +314,12 @@ describe('contract: ERC20TransferableReceivable', () => {
           0,
           ethers.constants.AddressZero,
         );
+      const receivableInfoAfter = await receivable.receivableInfoMapping(tokenId);
       const afterBal = await testToken.balanceOf(user1Addr);
       expect(amount.mul(2)).to.equals(afterBal.sub(beforeBal));
-
-      const receivableInfo = await receivable.receivableInfoMapping(tokenId);
-      expect(amount.mul(2)).to.equals(receivableInfo.balance);
+      expect(amount.mul(2)).to.equals(
+        receivableInfoAfter.balance.sub(receivableInfoBefore.balance),
+      );
     });
 
     it('payment less than amount', async function () {


### PR DESCRIPTION
This pull request aims to cut gas costs on the ERC20TransferableReceivable contract. The changes proposed are based on the findings of a gas profiler and include the following optimizations:

- Remove the ERC721Enumerable functionality since it is not critical to the final product. Request Finance already knows all of a user's invoices and can map each one to their respective receivables. Previously we only used this to power our demo experience on the Huma dApp.
- Stop using ERC721URIStorage as a glorified storage field for requestID. This is a significant waste of gas since strings need to be processed and stored. Instead, revert to the base ERC721 URI storage and create a new field requestID in the ReceivableInfo struct.
    - This still allows for us to upgrade the receivables contract with metadata hosted on a storage service like IPFS.
      - One note for projects using this contract is that they won't be able to lookup the request ID directly from this contract. For Huma's integration, Request will pass the request ID during invoice factoring for Huma to verify receivables information.

Using hardhat-gas-reporter, I measured a decrease in mint call costs from 320k to 177k. These changes cut gas costs per mint by almost half, resulting in savings of approximately $8-10 per mint on mainnet with current gas prices. 

---

## Before
<img width="897" alt="Screen Shot 2023-04-04 at 1 10 10 PM" src="https://user-images.githubusercontent.com/4820950/229934348-247e0a9e-7dbc-4ed1-9fd2-3b3b2343fb24.png">

## After
<img width="917" alt="Screen Shot 2023-04-04 at 2 35 16 PM" src="https://user-images.githubusercontent.com/4820950/229934378-2401a618-e8bd-46b5-9ea6-889445722606.png">
