### PR TITLE
chore(ethereum-storage-ethers): return nonce in append meta

### DIFF
--- a/packages/ethereum-storage/src/ethereum-storage-ethers.ts
+++ b/packages/ethereum-storage/src/ethereum-storage-ethers.ts
@@ -69,13 +69,14 @@ export class EthereumStorageEthers implements StorageTypes.IStorageWrite {
         ipfs: { size: ipfsSize },
         local: { location: ipfsHash },
         ethereum: {
+          nonce: tx.nonce,
+          transactionHash: tx.hash,
           blockConfirmation: tx.confirmations,
           blockNumber: Number(tx.blockNumber),
           // wrong value, but this metadata will not be used, as it's in Pending state
           blockTimestamp: -1,
           networkName: this.network,
           smartContractAddress: this.txSubmitter.hashSubmitterAddress,
-          transactionHash: tx.hash,
         },
         state: StorageTypes.ContentState.PENDING,
         storageType: StorageTypes.StorageSystemType.LOCAL,

--- a/packages/types/src/storage-types.ts
+++ b/packages/types/src/storage-types.ts
@@ -136,6 +136,8 @@ export interface IEthereumMetadata {
   fee?: string;
   /** gas fee in wei of the transaction that stored the data id */
   gasFee?: string;
+  /** nonce of the transaction that stored the data id */
+  nonce?: number;
 }
 
 /** Ethereum network id */


### PR DESCRIPTION
## Description of the changes

For debug purposes, it would be nice to have access to the nonce of the transaction that persisted the request.