### PR TITLE
chore: make validate currency as public method

### DIFF
--- a/packages/advanced-logic/src/extensions/payment-network/address-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/address-based.ts
@@ -167,7 +167,7 @@ export default abstract class AddressBasedPaymentNetwork<
     if (!currency) {
       throw new UnsupportedCurrencyError({ value: symbol, network });
     }
-    return CurrencyManager.validateAddress(address, currency);
+    return currencyManager.validateAddress(address, currency);
   }
 
   /**

--- a/packages/currency/src/currencyManager.ts
+++ b/packages/currency/src/currencyManager.ts
@@ -262,14 +262,14 @@ export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta>
   /**
    * Validate the correctness of a Storage Currency
    */
-  static validateCurrency(currency: StorageCurrency): boolean {
+  validateCurrency(currency: StorageCurrency): boolean {
     if (
       currency.type === RequestLogicTypes.CURRENCY.ISO4217 ||
       currency.type === RequestLogicTypes.CURRENCY.ETH ||
       currency.type === RequestLogicTypes.CURRENCY.BTC
     )
       return true;
-    return this.validateAddress(currency.value, currency);
+    return CurrencyManager.validateAddress(currency.value, currency);
   }
 
   /**

--- a/packages/currency/src/currencyManager.ts
+++ b/packages/currency/src/currencyManager.ts
@@ -236,7 +236,7 @@ export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta>
    * Validates an address for a given currency.
    * Throws if the currency is an ISO4217 currency.
    */
-  static validateAddress(address: string, currency: CurrencyInput | StorageCurrency): boolean {
+  validateAddress(address: string, currency: CurrencyInput | StorageCurrency): boolean {
     if (currency.type === RequestLogicTypes.CURRENCY.ISO4217) {
       throw new Error(`Could not validate an address for an ISO4217 currency`);
     }
@@ -269,7 +269,7 @@ export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta>
       currency.type === RequestLogicTypes.CURRENCY.BTC
     )
       return true;
-    return CurrencyManager.validateAddress(currency.value, currency);
+    return this.validateAddress(currency.value, currency);
   }
 
   /**

--- a/packages/currency/src/types.ts
+++ b/packages/currency/src/types.ts
@@ -129,6 +129,7 @@ export interface ICurrencyManager<TMeta = unknown> {
     network: string,
   ): string[] | null;
   supportsConversion(currency: Pick<CurrencyDefinition, 'hash'>, network: string): boolean;
+  validateAddress(address: string, currency: CurrencyInput | StorageCurrency): boolean;
   validateCurrency(currency: StorageCurrency): boolean;
 }
 

--- a/packages/currency/src/types.ts
+++ b/packages/currency/src/types.ts
@@ -129,6 +129,7 @@ export interface ICurrencyManager<TMeta = unknown> {
     network: string,
   ): string[] | null;
   supportsConversion(currency: Pick<CurrencyDefinition, 'hash'>, network: string): boolean;
+  validateCurrency(currency: StorageCurrency): boolean;
 }
 
 /**

--- a/packages/currency/test/currencyManager.test.ts
+++ b/packages/currency/test/currencyManager.test.ts
@@ -527,7 +527,7 @@ describe('CurrencyManager', () => {
       if (!currency) {
         throw new Error('currency is undefined');
       }
-      const result = CurrencyManager.validateAddress(address, currency);
+      const result = currencyManager.validateAddress(address, currency);
       expect(result).toBe(expectedResult);
     };
 
@@ -590,7 +590,7 @@ describe('CurrencyManager', () => {
           it(`should throw for ${currencyTemplate.symbol} currency`, () => {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const currency = currencyManager.from(currencyTemplate.symbol)!;
-            expect(() => CurrencyManager.validateAddress('anyAddress', currency)).toThrow();
+            expect(() => currencyManager.validateAddress('anyAddress', currency)).toThrow();
           });
         });
       });

--- a/packages/currency/test/currencyManager.test.ts
+++ b/packages/currency/test/currencyManager.test.ts
@@ -649,7 +649,7 @@ describe('CurrencyManager', () => {
         },
       ];
       it.each(currencies)('Should validate $label', ({ currency }) => {
-        const result = CurrencyManager.validateCurrency(currency);
+        const result = currencyManager.validateCurrency(currency);
         expect(result).toBe(true);
       });
     });
@@ -682,7 +682,7 @@ describe('CurrencyManager', () => {
         },
       ];
       it.each(currencies)('Should not validate an invalid $label', ({ currency }) => {
-        const result = CurrencyManager.validateCurrency(currency);
+        const result = currencyManager.validateCurrency(currency);
         expect(result).toBe(false);
       });
     });

--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -391,7 +391,7 @@ export default class RequestNetwork {
     const topics = parameters.topics?.slice() || [];
 
     // Check that currency is valid
-    if (!CurrencyManager.validateCurrency(currency)) {
+    if (!this.currencyManager.validateCurrency(currency)) {
       throw new Error('The currency is not valid');
     }
 


### PR DESCRIPTION
## Description of the changes

The purpose of this change is to allow users to provide a custom `validateCurrency` & `validateAddress` method for currency which not supported by the library.
Updated: 
- method access as public
- updated usage in the request-client