### PR TITLE
fix(gas-fee): catch estimation errors

### DIFF
--- a/packages/ethereum-storage/src/gas-fee-definer.ts
+++ b/packages/ethereum-storage/src/gas-fee-definer.ts
@@ -1,15 +1,19 @@
 import { BigNumber, providers, constants } from 'ethers';
 import { GasDefinerProps } from './ethereum-storage-ethers';
 import { estimateGasFees } from '@requestnetwork/utils';
+import { LogTypes } from '@requestnetwork/types';
 
 export class GasFeeDefiner {
+  private readonly logger: LogTypes.ILogger;
   private readonly provider: providers.JsonRpcProvider;
   private readonly gasPriceMin: BigNumber;
 
   constructor({
+    logger,
     provider,
     gasPriceMin,
-  }: GasDefinerProps & { provider: providers.JsonRpcProvider }) {
+  }: GasDefinerProps & { logger?: LogTypes.ILogger; provider: providers.JsonRpcProvider }) {
+    this.logger = logger || console;
     this.provider = provider;
     this.gasPriceMin = gasPriceMin || constants.Zero;
   }
@@ -18,6 +22,10 @@ export class GasFeeDefiner {
     maxFeePerGas?: BigNumber;
     maxPriorityFeePerGas?: BigNumber;
   }> {
-    return estimateGasFees({ provider: this.provider, gasPriceMin: this.gasPriceMin });
+    return estimateGasFees({
+      logger: this.logger,
+      provider: this.provider,
+      gasPriceMin: this.gasPriceMin,
+    });
   }
 }

--- a/packages/smart-contracts/scripts-create2/contract-setup/adminTasks.ts
+++ b/packages/smart-contracts/scripts-create2/contract-setup/adminTasks.ts
@@ -283,7 +283,7 @@ export const getSignerAndGasFees = async (
   const signer = new hre.ethers.Wallet(hre.config.xdeploy.signer).connect(provider);
 
   const txOverrides = (await isEip1559Supported(provider))
-    ? await estimateGasFees({ provider })
+    ? await estimateGasFees({ logger: console, provider })
     : {};
 
   return {

--- a/packages/smart-contracts/scripts-create2/xdeployer.ts
+++ b/packages/smart-contracts/scripts-create2/xdeployer.ts
@@ -79,7 +79,7 @@ export const xdeploy = async (
     let txOverrides: Overrides = {};
 
     if (await isEip1559Supported(provider, console)) {
-      txOverrides = await estimateGasFees({ provider });
+      txOverrides = await estimateGasFees({ logger: console, provider });
     }
     txOverrides.gasLimit = hre.config.xdeploy.gasLimit;
 

--- a/packages/utils/test/estimate-gas-fee.test.ts
+++ b/packages/utils/test/estimate-gas-fee.test.ts
@@ -21,15 +21,15 @@ const checkEstimation = (
 
 describe('Gas fee estimation', () => {
   it('Should not be undefined', async () => {
-    const estimation = await estimateGasFees({ provider });
+    const estimation = await estimateGasFees({ logger: console, provider });
     expect(estimation.maxFeePerGas).toBeDefined();
     expect(estimation.maxPriorityFeePerGas).toBeDefined();
   });
 
   it('Should return a lower estimation when the previous block is empty', async () => {
-    const firstEstimation = await estimateGasFees({ provider });
+    const firstEstimation = await estimateGasFees({ logger: console, provider });
     await provider.send('evm_mine', []);
-    const secondEstimation = await estimateGasFees({ provider });
+    const secondEstimation = await estimateGasFees({ logger: console, provider });
 
     expect(
       firstEstimation.maxFeePerGas?.sub(secondEstimation.maxFeePerGas || 0).toNumber(),
@@ -45,7 +45,7 @@ describe('Gas fee estimation', () => {
       });
     }
 
-    const estimation = await estimateGasFees({ provider });
+    const estimation = await estimateGasFees({ logger: console, provider });
     const tx = await wallet.sendTransaction({
       to: dummyAddress,
       value: BigNumber.from(1),

--- a/packages/utils/test/estimate-gas-fee.test.ts
+++ b/packages/utils/test/estimate-gas-fee.test.ts
@@ -75,9 +75,10 @@ describe('Gas fee estimation', () => {
           0.5290747666666666, 0.49240453333333334, 0.4615576, 0.49407083333333335, 0.4669053,
         ],
         oldestBlock: '0xfab8ac',
-        // here return only rewards > 5 Gwei
-        // thus all blocks would be considered as outlier blocks in https://github.com/rainbow-me/fee-suggestions/blob/main/src/utils.ts#L123C11-L123C22
-        // thus triggering an error
+        // Here, return all rewards as > 5 Gwei.
+        // This is so that all blocks would be considered as outlier blocks in
+        // https://github.com/rainbow-me/fee-suggestions/blob/76b9fe14d3740c9df7cedf40b2f85cd8871ff9c2/src/utils.ts#L123C11-L123C22
+        // thus triggering an error.
         reward: [
           // 6000000000 wei
           ['x165A0BC00'],


### PR DESCRIPTION
## Description of the changes

It can happen, rarely, that `@rainbow-me/fee-suggestions` fails to estimate gas fees, especially on chains other than Ethereum mainnet (related to https://github.com/rainbow-me/fee-suggestions/issues/23).

This PR catches,  logs, and handles those errors by returning an empty object, thus letting the RPC provider choose how to configure gas fee / gas price (either by using defaults for the EIP-1559 transaction fields or falling back to a legacy, non-EIP 1559, transaction).