### PR TITLE
fix: add ETH_FEE_PROXY_CONTRACT to noConversionNetworks

### DIFF
--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -213,7 +213,10 @@ export async function hasSufficientFunds(
   }
 
   let feeAmount = 0;
-  if (paymentNetwork === ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT) {
+  if (
+    paymentNetwork === ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT ||
+    paymentNetwork === ExtensionTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT
+  ) {
     feeAmount = request.extensions[paymentNetwork].values.feeAmount || 0;
   }
   return isSolvent(

--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -30,6 +30,7 @@ export const noConversionNetworks = [
   ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_TRANSFERABLE_RECEIVABLE,
   ExtensionTypes.PAYMENT_NETWORK_ID.ETH_INPUT_DATA,
   ExtensionTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN,
+  ExtensionTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT,
 ];
 
 export interface IConversionPaymentSettings {


### PR DESCRIPTION
# Problem

Hackers at ETHBarcelona 2023 were unable to use the `hasSufficientFunds()` function with `ETH_FEE_PROXY_CONTRACT` requests because of the following check:

https://github.com/RequestNetwork/requestNetwork/blob/master/packages/payment-processor/src/payment/index.ts#L206-L208
```
  if (!paymentNetwork || !noConversionNetworks.includes(paymentNetwork)) {
    throw new UnsupportedNetworkError(paymentNetwork);
  }
```

# Solution

Add `ETH_FEE_PROXY_CONTRACT` to `noConversionNetworks`

# Questions

1. Are there any other payment networks that should be added?