### PR TITLE
chore(currency): add TMeta generic to getDefaultList

### DIFF
--- a/packages/currency/src/currencyManager.ts
+++ b/packages/currency/src/currencyManager.ts
@@ -284,7 +284,7 @@ export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta>
    * - NEAR, YEL, ZIL, BTC
    * - ETH-rinkeby, FAU-rinkeby, CTBK-rinkeby
    */
-  static getDefaultList(): CurrencyDefinition[] {
+  static getDefaultList<TMeta = unknown>(): CurrencyDefinition<TMeta>[] {
     const isoCurrencies: CurrencyInput[] = iso4217.map((cc) => ({
       decimals: cc.digits,
       name: cc.currency,
@@ -306,7 +306,7 @@ export class CurrencyManager<TMeta = unknown> implements ICurrencyManager<TMeta>
       .concat(erc777Currencies)
       .concat(eth)
       .concat(btc)
-      .map(CurrencyManager.fromInput);
+      .map(CurrencyManager.fromInput<TMeta>);
   }
 
   /**


### PR DESCRIPTION
## Description of the changes
Pass generic to `CurrencyDefinition` to avoid type casting with `as` upon usage.