### PR TITLE
ci: fix creation of storage subgraph

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ references:
       cd storage-subgraph
       yarn
       yarn codegen  ./subgraph-private.yaml
-      yarn create-local ./subgraph-private.yaml
+      yarn create-local
       yarn deploy-local --version-label v0.0.1 ./subgraph-private.yaml
       sleep 5
   step_wait_for_node: &step_wait_for_node


### PR DESCRIPTION
Fix the graph node integration test, after the update of `@graphprotocol/graph-cli` in https://github.com/RequestNetwork/storage-subgraph/pull/4