### PR TITLE
fix: remove hardcoded chainlink rate age (#1171)

### DIFF
--- a/packages/payment-processor/src/payment/settings.ts
+++ b/packages/payment-processor/src/payment/settings.ts
@@ -24,8 +24,6 @@ export interface ISwapSettings {
    * ['0xPaymentCurrency', '0xIntermediate1', ..., '0xRequestCurrency']
    */
   path: string[];
-  /** maximum time in seconds of how old chainlink rate can be used, default is zero for infinitely old */
-  maxRateAge?: number;
 }
 
 export interface IConversionSettings {
@@ -35,6 +33,8 @@ export interface IConversionSettings {
   maxToSpend?: BigNumberish;
   /** a currency manager to access currencies property, like decimals */
   currencyManager?: ICurrencyManager;
+  /** maximum time in seconds of how old chainlink rate can be used, default is zero for infinitely old */
+  maxRateAge?: number;
 }
 
 /**

--- a/packages/payment-processor/src/payment/settings.ts
+++ b/packages/payment-processor/src/payment/settings.ts
@@ -24,6 +24,8 @@ export interface ISwapSettings {
    * ['0xPaymentCurrency', '0xIntermediate1', ..., '0xRequestCurrency']
    */
   path: string[];
+  /** maximum time in seconds of how old chainlink rate can be used, default is zero for infinitely old */
+  maxRateAge?: number;
 }
 
 export interface IConversionSettings {

--- a/packages/payment-processor/src/payment/swap-any-to-erc20.ts
+++ b/packages/payment-processor/src/payment/swap-any-to-erc20.ts
@@ -167,6 +167,6 @@ export function encodeSwapToPayAnyToErc20Request(
     feeToPay, // _requestFeeAmount: BigNumberish,
     feeAddress || constants.AddressZero, // _feeAddress: string,
     Math.round(swapSettings.deadline / 1000), // _uniswapDeadline: BigNumberish,
-    0, // _chainlinkMaxRateTimespan: BigNumberish,
+    swapSettings.maxRateAge || 0, // _chainlinkMaxRateTimespan: BigNumberish,
   ]);
 }

--- a/packages/payment-processor/src/payment/swap-any-to-erc20.ts
+++ b/packages/payment-processor/src/payment/swap-any-to-erc20.ts
@@ -167,6 +167,6 @@ export function encodeSwapToPayAnyToErc20Request(
     feeToPay, // _requestFeeAmount: BigNumberish,
     feeAddress || constants.AddressZero, // _feeAddress: string,
     Math.round(swapSettings.deadline / 1000), // _uniswapDeadline: BigNumberish,
-    swapSettings.maxRateAge || 0, // _chainlinkMaxRateTimespan: BigNumberish,
+    conversionSettings.maxRateAge ?? 0, // _chainlinkMaxRateTimespan: BigNumberish,
   ]);
 }


### PR DESCRIPTION
Fixes #1144

Hi, a new contributor here!
Trying to fix the issue #1144

## Description of the changes
I've added an optional parameter `maxRateAge` in ~`ISwapSettings`~ `IConversionSettings`. It defaults to 0.
We can keep it required too, wdyt?