### PR TITLE
chore: disable unused rules

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,8 +16,6 @@ import * as StorageTypes from './storage-types';
 import * as TransactionTypes from './transaction-types';
 import * as TypesUtils from './utils';
 
-const unusedvar = '';
-
 export {
   AdvancedLogicTypes,
   ClientTypes,


### PR DESCRIPTION
These rules are very annoying while developping. Anyway it's not typescript responsability to check that, it's already covered by `eslint`