### PR TITLE
refactor(toolbox): addAggregator immutable args

### DIFF
--- a/packages/toolbox/src/commands/chainlink/addAggregator.ts
+++ b/packages/toolbox/src/commands/chainlink/addAggregator.ts
@@ -71,7 +71,7 @@ export const handler = async (args: Options): Promise<void> => {
     inputAddress = inputCcy.hash;
   }
 
-  let outputAddress = input;
+  let outputAddress = output;
   if (!outputAddress.startsWith('0x')) {
     assert(outputCcy, `output ${output} not found`);
     outputAddress = outputCcy.hash;


### PR DESCRIPTION
## Description of the changes

This is a follow-up to @olivier7delf 's comment ([here](https://github.com/RequestNetwork/requestNetwork/pull/1134#discussion_r1297086909)) on https://github.com/RequestNetwork/requestNetwork/pull/1134

This makes the args immutable (replaced `let` by `const`) and variable manipulations a bit clearer.