### PR TITLE
chore: test cancel after paid

### DIFF
--- a/packages/integration-test/test/node-client.test.ts
+++ b/packages/integration-test/test/node-client.test.ts
@@ -656,7 +656,7 @@ describe('ETH localhost request creation and detection test', () => {
     payer: payerIdentity,
   };
 
-  it('can create ETH requests and pay with ETH Fee proxy', async () => {
+  it('can create ETH requests and pay with ETH Fee proxy and cancel after paid', async () => {
     const currencies = [...CurrencyManager.getDefaultList()];
     const requestNetwork = new RequestNetwork({
       signatureProvider,
@@ -696,6 +696,10 @@ describe('ETH localhost request creation and detection test', () => {
     expect(event?.parameters?.feeAddress).toBe('0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2');
     // amount in crypto after apply the rates of the fake aggregators
     expect(event?.parameters?.to).toBe('0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB');
+
+    // Cancel the request
+    const cancelData = await request.cancel(payeeIdentity);
+    expect(data.state).toBe(Types.RequestLogic.STATE.CANCELED);
   });
 
   it('can create & pay a request with any to eth proxy', async () => {

--- a/packages/integration-test/test/node-client.test.ts
+++ b/packages/integration-test/test/node-client.test.ts
@@ -700,8 +700,8 @@ describe('ETH localhost request creation and detection test', () => {
     // Cancel the request
     const requestDataCancel = await request.cancel(payeeIdentity);
     const requestDataCancelConfirmed = await waitForConfirmation(requestDataCancel);
-    console.log(JSON.stringify(requestDataCancelConfirmed));
     expect(requestDataCancelConfirmed.state).toBe(Types.RequestLogic.STATE.CANCELED);
+    expect(requestDataCancelConfirmed.balance?.balance).toBe('1000');
   });
 
   it('can create & pay a request with any to eth proxy', async () => {

--- a/packages/integration-test/test/node-client.test.ts
+++ b/packages/integration-test/test/node-client.test.ts
@@ -699,7 +699,7 @@ describe('ETH localhost request creation and detection test', () => {
 
     // Cancel the request
     const cancelData = await request.cancel(payeeIdentity);
-    expect(data.state).toBe(Types.RequestLogic.STATE.CANCELED);
+    expect(cancelData.state).toBe(Types.RequestLogic.STATE.CANCELED);
   });
 
   it('can create & pay a request with any to eth proxy', async () => {

--- a/packages/integration-test/test/node-client.test.ts
+++ b/packages/integration-test/test/node-client.test.ts
@@ -698,8 +698,10 @@ describe('ETH localhost request creation and detection test', () => {
     expect(event?.parameters?.to).toBe('0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB');
 
     // Cancel the request
-    const cancelData = await request.cancel(payeeIdentity);
-    expect(cancelData.state).toBe(Types.RequestLogic.STATE.CANCELED);
+    const requestDataCancel = await request.cancel(payeeIdentity);
+    const requestDataCancelConfirmed = await waitForConfirmation(requestDataCancel);
+    console.log(JSON.stringify(requestDataCancelConfirmed));
+    expect(requestDataCancelConfirmed.state).toBe(Types.RequestLogic.STATE.CANCELED);
   });
 
   it('can create & pay a request with any to eth proxy', async () => {


### PR DESCRIPTION
## Description of the changes

* Update existing test so that it also cancels a request after it is paid
  * Renamed test to `can create ETH requests and pay with ETH Fee proxy and cancel after paid`

## Motivation

Request Finance user asked to void a paid invoice because they want to edit their description. @kevindavee asked: Is it possible to cancel a request that has already been paid?

## Conclusion

Yes. it is possible to cancel a request that has already been paid. :white_check_mark: 

## Details

<details>
<summary>The returned request data, after cancel, shows `state` is `canceled` and the balance remains `1000`. (click to expand)
</summary>

```json
{
  "_events": {},
  "_eventsCount": 0,
  "currency": "ETH-private-private",
  "expectedAmount": "1000",
  "payee": {
    "type": "ethereumAddress",
    "value": "0x627306090abab3a6e1400e9345bc60c78a8bef57"
  },
  "payer": {
    "type": "ethereumAddress",
    "value": "0xf17f52151ebef6c7334fad080c5704d77216b732"
  },
  "extensionsData": [
    {
      "action": "create",
      "id": "pn-eth-fee-proxy-contract",
      "parameters": {
        "feeAddress": "0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2",
        "feeAmount": "200",
        "paymentAddress": "0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB",
        "salt": "925378a092cd0e7e"
      },
      "version": "0.2.0"
    }
  ],
  "timestamp": 1698686580,
  "extensions": {
    "pn-eth-fee-proxy-contract": {
      "events": [
        {
          "name": "create",
          "parameters": {
            "feeAddress": "0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2",
            "feeAmount": "200",
            "paymentAddress": "0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB",
            "salt": "925378a092cd0e7e"
          },
          "timestamp": 0
        }
      ],
      "id": "pn-eth-fee-proxy-contract",
      "type": "payment-network",
      "values": {
        "salt": "925378a092cd0e7e",
        "receivedPaymentAmount": "0",
        "receivedRefundAmount": "0",
        "sentPaymentAmount": "0",
        "sentRefundAmount": "0",
        "paymentAddress": "0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB",
        "feeAddress": "0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2",
        "feeAmount": "200",
        "feeBalance": {
          "events": [
            {
              "amount": "1000",
              "name": "payment",
              "parameters": {
                "block": 114,
                "txHash": "0xdacd538bed432b3c1fb8746b1a7f3581644650aae8040e4a65f3fb5c180b54ed",
                "to": "0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB",
                "feeAddress": "0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2",
                "feeAmount": "200"
              },
              "timestamp": 1698686581
            }
          ],
          "balance": "200"
        }
      },
      "version": "0.2.0"
    }
  },
  "requestId": "01ebf48926c505d6e6dff7a6d95568ab5b3c3a05ddee531847c305ba3a5439f144",
  "version": "2.0.3",
  "events": [
    {
      "actionSigner": {
        "type": "ethereumAddress",
        "value": "0x627306090abaB3A6e1400e9345bC60c78a8BEf57"
      },
      "name": "create",
      "parameters": {
        "expectedAmount": "1000",
        "extensionsDataLength": 1,
        "isSignedRequest": false
      },
      "timestamp": 0
    },
    {
      "actionSigner": {
        "type": "ethereumAddress",
        "value": "0x627306090abaB3A6e1400e9345bC60c78a8BEf57"
      },
      "name": "cancel",
      "parameters": { "extensionsDataLength": 0 },
      "timestamp": 0
    }
  ],
  "state": "canceled",
  "creator": {
    "type": "ethereumAddress",
    "value": "0x627306090abab3a6e1400e9345bc60c78a8bef57"
  },
  "balance": {
    "balance": "1000",
    "events": [
      {
        "amount": "1000",
        "name": "payment",
        "parameters": {
          "block": 114,
          "txHash": "0xdacd538bed432b3c1fb8746b1a7f3581644650aae8040e4a65f3fb5c180b54ed",
          "to": "0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB",
          "feeAddress": "0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2",
          "feeAmount": "200"
        },
        "timestamp": 1698686581
      }
    ],
    "escrowEvents": []
  },
  "contentData": null,
  "currencyInfo": { "network": "private", "type": "ETH", "value": "ETH" },
  "meta": {
    "ignoredTransactions": [],
    "transactionManagerMeta": {
      "dataAccessMeta": {
        "transactionsStorageLocation": [
          "0149189f20e8088485013cc9c004cbcc8e9a09c27c56e549b9c2d79e6743c7a8a8",
          "01e98d5a4954cb0b97cd719615c38f780cc6e31fde9d0c44a47f1c7dcb26d10263"
        ],
        "storageMeta": [
          {
            "ethereum": {
              "blockConfirmation": 0,
              "blockNumber": 0,
              "blockTimestamp": 0,
              "networkName": "mock",
              "smartContractAddress": "",
              "transactionHash": ""
            },
            "ipfs": { "size": 0 },
            "state": "confirmed",
            "storageType": "ethereumIpfs",
            "timestamp": 0
          },
          {
            "ethereum": {
              "blockConfirmation": 0,
              "blockNumber": 0,
              "blockTimestamp": 0,
              "networkName": "mock",
              "smartContractAddress": "",
              "transactionHash": ""
            },
            "ipfs": { "size": 0 },
            "state": "confirmed",
            "storageType": "ethereumIpfs",
            "timestamp": 0
          }
        ]
      },
      "ignoredTransactions": [null, null]
    }
  },
  "pending": null
}
```

</details>

## Analysis

* Is the ability to cancel a request after it's paid the desired behavior?
  * I, @MantisClone, argue Yes, this is the desired behavior. :+1: 
* What are the implications of canceling a request that is already paid?
  * Certain lenders may ignore requests that are `canceled` so this may negatively affect the payee's ability to use this request as proof of income when borrowing.
* What can the payee do after canceling a request that is already paid (for the purpose of changing the description)?
  * Option 1: Payee refunds the full amount, creates a new request with the fixed description, payer pays the new request.
  * Option 2: Payee creates a new declarative request with the fixed description. Payer declares payment sent and references the payment associated with the canceled request. Payee declares the payment received.
* Is it possible to change the description (`contentData`) of a request after it's been created?
  * No :no_good: 
* Should we make it possible to update the `contentData`?
  * Maybe :thinking: If we did, then any downstream logic that depends on the `contentData` would also need to check the `extensions.contentData.events` to see if the `contentData` has changed since the request was created.
