### PR TITLE
docs: remove reference to eccrypto-js

### DIFF
--- a/packages/utils/test/crypto/data/crypto-browser.ts
+++ b/packages/utils/test/crypto/data/crypto-browser.ts
@@ -1,7 +1,7 @@
 /**
  * This file contains random strings and its encrypted version.
  * The data was encrypted by the library `eccrypto` using the browser (JS-only) implementation.
- * Any replacement library (like `eccrypto-js`) should be able to decrypt this encrypted data.
+ * Any replacement library should be able to decrypt this encrypted data.
  * More info on how this data was generated: https://github.com/RequestNetwork/requestNetwork/issues/1227
  */
 

--- a/packages/utils/test/crypto/data/crypto-native.ts
+++ b/packages/utils/test/crypto/data/crypto-native.ts
@@ -1,7 +1,7 @@
 /**
  * This file contains random strings and its encrypted version.
  * The data was encrypted by the library `eccrypto` using the native C++ implementation.
- * Any replacement library (like `eccrypto-js`) should be able to decrypt this encrypted data.
+ * Any replacement library should be able to decrypt this encrypted data.
  * More info on how this data was generated: https://github.com/RequestNetwork/requestNetwork/issues/1227
  */
 


### PR DESCRIPTION
## Description of the changes

We are not using `eccrypto-js` in the end (see https://github.com/RequestNetwork/requestNetwork/pull/1229) so it might be confusing to keep this in the comments.