### PR TITLE
fix(storage): in memory indexer metadata, use methods

### DIFF
--- a/packages/data-access/src/combined-data-access.ts
+++ b/packages/data-access/src/combined-data-access.ts
@@ -4,12 +4,7 @@ export abstract class CombinedDataAccess implements DataAccessTypes.IDataAccess 
   constructor(
     protected reader: DataAccessTypes.IDataRead,
     protected writer: DataAccessTypes.IDataWrite,
-  ) {
-    this.getTransactionsByChannelId = this.reader.getTransactionsByChannelId.bind(this.reader);
-    this.getChannelsByTopic = this.reader.getChannelsByTopic.bind(this.reader);
-    this.getChannelsByMultipleTopics = this.reader.getChannelsByMultipleTopics.bind(this.reader);
-    this.persistTransaction = this.writer.persistTransaction.bind(this.writer);
-  }
+  ) {}
 
   async initialize(): Promise<void> {
     await this.reader.initialize();
@@ -21,22 +16,30 @@ export abstract class CombinedDataAccess implements DataAccessTypes.IDataAccess 
     await this.reader.close();
   }
 
-  getTransactionsByChannelId: (
+  async getTransactionsByChannelId(
     channelId: string,
     updatedBetween?: DataAccessTypes.ITimestampBoundaries | undefined,
-  ) => Promise<DataAccessTypes.IReturnGetTransactions>;
+  ): Promise<DataAccessTypes.IReturnGetTransactions> {
+    return await this.reader.getTransactionsByChannelId(channelId, updatedBetween);
+  }
 
-  getChannelsByTopic: (
+  async getChannelsByTopic(
     topic: string,
     updatedBetween?: DataAccessTypes.ITimestampBoundaries | undefined,
-  ) => Promise<DataAccessTypes.IReturnGetChannelsByTopic>;
-  getChannelsByMultipleTopics: (
+  ): Promise<DataAccessTypes.IReturnGetChannelsByTopic> {
+    return await this.reader.getChannelsByTopic(topic, updatedBetween);
+  }
+  async getChannelsByMultipleTopics(
     topics: string[],
     updatedBetween?: DataAccessTypes.ITimestampBoundaries,
-  ) => Promise<DataAccessTypes.IReturnGetChannelsByTopic>;
-  persistTransaction: (
+  ): Promise<DataAccessTypes.IReturnGetChannelsByTopic> {
+    return await this.reader.getChannelsByMultipleTopics(topics, updatedBetween);
+  }
+  async persistTransaction(
     transactionData: DataAccessTypes.ITransaction,
     channelId: string,
     topics?: string[] | undefined,
-  ) => Promise<DataAccessTypes.IReturnPersistTransaction>;
+  ): Promise<DataAccessTypes.IReturnPersistTransaction> {
+    return await this.writer.persistTransaction(transactionData, channelId, topics);
+  }
 }

--- a/packages/data-access/src/in-memory-indexer.ts
+++ b/packages/data-access/src/in-memory-indexer.ts
@@ -86,14 +86,14 @@ export class InMemoryIndexer implements StorageTypes.IIndexer {
       .flat()
       .map(
         (item): StorageTypes.IIndexedTransaction => ({
-          blockNumber: 0,
-          blockTimestamp: 0,
+          blockNumber: item.meta.ethereum?.blockNumber ?? 0,
+          blockTimestamp: item.meta.ethereum?.blockTimestamp ?? 0,
           channelId: item.channelId,
           hash: item.locationId,
-          size: '0',
-          smartContractAddress: '',
+          size: String(item.meta.ipfs?.size ?? 0),
+          smartContractAddress: item.meta.ethereum?.smartContractAddress ?? '',
           topics: [],
-          transactionHash: '',
+          transactionHash: item.meta.ethereum?.transactionHash ?? '',
           data: item.transaction.data,
           encryptedData: item.transaction.encryptedData,
           encryptionMethod: item.transaction.encryptionMethod,

--- a/packages/request-client.js/test/index.test.ts
+++ b/packages/request-client.js/test/index.test.ts
@@ -1314,7 +1314,6 @@ describe('request-client.js', () => {
 
     // This test checks that 2 payments with reference `c19da4923539c37f` have reached 0xc12F17Da12cd01a9CDBB216949BA0b41A6Ffc4EB
     it('can get the balance of an ETH request', async () => {
-      jest.useFakeTimers();
       const etherscanMock = new EtherscanProviderMock();
       ethers.providers.EtherscanProvider.prototype.getHistory = jest
         .fn()
@@ -1350,8 +1349,8 @@ describe('request-client.js', () => {
         requestInfo,
         signer: TestData.payee.identity,
       });
+      await request.waitForConfirmation();
 
-      jest.advanceTimersByTime(150);
       const data = await request.refresh();
 
       // Payment reference should be fixed
@@ -1363,7 +1362,6 @@ describe('request-client.js', () => {
         ),
       ).toBe('efce79375b2db9f7');
 
-      jest.advanceTimersByTime(150);
       const dataAfterRefresh = await request.refresh();
 
       expect(dataAfterRefresh.balance?.balance).toBe('12300000000');
@@ -1374,7 +1372,6 @@ describe('request-client.js', () => {
       expect(dataAfterRefresh.balance?.events[0].parameters!.txHash).toBe(
         '0x06d95c3889dcd974106e82fa27358549d9392d6fee6ea14fe1acedadc1013114',
       );
-      jest.useRealTimers();
     });
 
     it('can disable and enable the get the balance of a request', async () => {

--- a/packages/thegraph-data-access/src/data-access.ts
+++ b/packages/thegraph-data-access/src/data-access.ts
@@ -34,11 +34,11 @@ export class TheGraphDataAccess extends CombinedDataAccess {
   }
 
   /** intercept events so that confirmation is emitted only once the transaction is indexed */
-  persistTransaction = async (
+  async persistTransaction(
     transactionData: DataAccessTypes.ITransaction,
     channelId: string,
     topics?: string[] | undefined,
-  ): Promise<DataAccessTypes.IReturnPersistTransaction> => {
+  ): Promise<DataAccessTypes.IReturnPersistTransaction> {
     const eventEmitter = new EventEmitter() as DataAccessTypes.PersistTransactionEmitter;
     const result = await this.writer.persistTransaction(transactionData, channelId, topics);
     result.on('confirmed', (receipt) => {
@@ -48,7 +48,7 @@ export class TheGraphDataAccess extends CombinedDataAccess {
     });
     result.on('error', (e) => eventEmitter.emit('error', e));
     return Object.assign(eventEmitter, { meta: result.meta, result: result.result });
-  };
+  }
 
   /**
    * We wait until the data is indexed on TheGraph


### PR DESCRIPTION
This metadata is used for balance events, and use class methods in CombinedDataAccess so that they can be overriden