### PR TITLE
chore: migrate to @noble/curves and ecies/js

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@requestnetwork/types": "0.37.0",
     "@toruslabs/eccrypto": "4.0.0",
+    "eciesjs": "^0.4.5",
     "ethers": "5.5.1",
     "secp256k1": "4.0.2",
     "tslib": "2.5.0"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -40,11 +40,10 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
+    "@noble/curves": "1.2.0",
     "@requestnetwork/types": "0.37.0",
-    "@toruslabs/eccrypto": "4.0.0",
-    "eciesjs": "^0.4.5",
+    "eciesjs": "0.4.5",
     "ethers": "5.5.1",
-    "secp256k1": "4.0.2",
     "tslib": "2.5.0"
   },
   "devDependencies": {

--- a/packages/utils/test/crypto/ec-utils.test.ts
+++ b/packages/utils/test/crypto/ec-utils.test.ts
@@ -97,15 +97,15 @@ describe('Utils/EcUtils', () => {
 
   describe('encrypt', () => {
     it('can encrypt', async () => {
-      const encryptedData = await ecEncrypt(rawId.publicKey, anyData);
+      const encryptedData = ecEncrypt(rawId.publicKey, anyData);
       // 'encrypt() error'
       expect(encryptedData.length).toBe(226);
       // 'decrypt() error'
-      expect(await ecDecrypt(rawId.privateKey, encryptedData)).toBe(anyData);
+      expect(ecDecrypt(rawId.privateKey, encryptedData)).toBe(anyData);
     });
 
     it('can encrypt with other public key formats', async () => {
-      const encryptedData = await ecEncrypt(
+      const encryptedData = ecEncrypt(
         '0396212fc129c2f78771218b2e93da7a5aac63490a42bb41b97848c39c14fe65cd',
         anyData,
       );
@@ -113,7 +113,7 @@ describe('Utils/EcUtils', () => {
     });
 
     it('cannot encrypt data with a wrong public key', async () => {
-      await expect(ecEncrypt('cf4a', anyData)).rejects.toThrowError(
+      expect(() => ecEncrypt('cf4a', anyData)).toThrow(
         'The public key must be a string representing 64 bytes',
       );
     });
@@ -121,7 +121,7 @@ describe('Utils/EcUtils', () => {
 
   describe('decrypt', () => {
     it('can decrypt', async () => {
-      const data = await ecDecrypt(
+      const data = ecDecrypt(
         rawId.privateKey,
         '307bac038efaa5bf8a0ac8db53fd4de8024a0c0baf37283a9e6671589eba18edc12b3915ff0df66e6ffad862440228a65ead99e3320e50aa90008961e3d68acc35b314e98020e3280bf4ce4258419dbb775185e60b43e7b88038a776a9322ff7cb3e886b2d92060cff2951ef3beedcc70a',
       );
@@ -130,36 +130,36 @@ describe('Utils/EcUtils', () => {
     });
 
     it('cannot decrypt data with a wrong private key', async () => {
-      await expect(
+      expect(() =>
         ecDecrypt(
           '0xaa',
           '307bac038efaa5bf8a0ac8db53fd4de8024a0c0baf37283a9e6671589eba18edc12b3915ff0df66e6ffad862440228a65ead99e3320e50aa90008961e3d68acc35b314e98020e3280bf4ce4258419dbb775185e60b43e7b88038a776a9322ff7cb3e886b2d92060cff2951ef3beedcc70a',
         ),
-      ).rejects.toThrowError('The private key must be a string representing 32 bytes');
+      ).toThrow('The private key must be a string representing 32 bytes');
     });
 
     it('cannot decrypt data with a wrong encrypted data: public key too short', async () => {
-      await expect(ecDecrypt(rawId.privateKey, 'aa')).rejects.toThrowError(
+      expect(() => ecDecrypt(rawId.privateKey, 'aa')).toThrow(
         'The encrypted data is not well formatted',
       );
     });
 
     it('cannot decrypt data with a wrong encrypted data: public key not parsable', async () => {
-      await expect(
+      expect(() =>
         ecDecrypt(
           rawId.privateKey,
           'e50aa90008961e3d68acc35b314e98020e3280bf4ce4258419dbb775185e60b43e7b88038a776a9322ff7cb3e886b2d92060cff2951ef3beedcc7',
         ),
-      ).rejects.toThrowError('The encrypted data is not well formatted');
+      ).toThrow('The encrypted data is not well formatted');
     });
 
     it('cannot decrypt data with a wrong encrypted data: bad MAC', async () => {
-      await expect(
+      expect(() =>
         ecDecrypt(
           rawId.privateKey,
           '307bac038efaa5bf8a0ac8db53fd4de8024a0c0baf37283a9e6671589eba18edc12b3915ff0df66e6ffad862440228a65ead99e3320e50aa90008961e3d68acc35b314e98020e3280bf4ce4258419dbb775185e60b43e7b88038a776a9322ff7cb3e886b2d92060cff2951ef3beedcc7',
         ),
-      ).rejects.toThrowError('The encrypted data is not well formatted');
+      ).toThrow('The encrypted data is not well formatted');
     });
 
     it.each([
@@ -168,22 +168,22 @@ describe('Utils/EcUtils', () => {
     ])('should be compatible with legacy $type implementation of eccrypto', async ({ array }) => {
       for (const row of array) {
         const { data, key, encrypted } = row;
-        const decrypted = await ecDecrypt(key, encrypted);
+        const decrypted = ecDecrypt(key, encrypted);
         expect(decrypted).toBe(data);
       }
     });
   });
 
   it('can encrypt()', async () => {
-    const encryptedData = await ecEncrypt(rawId.publicKey, anyData);
+    const encryptedData = ecEncrypt(rawId.publicKey, anyData);
     // 'encrypt() error'
     expect(encryptedData.length).toBe(226);
     // 'decrypt() error'
-    expect(await ecDecrypt(rawId.privateKey, encryptedData)).toBe(anyData);
+    expect(ecDecrypt(rawId.privateKey, encryptedData)).toBe(anyData);
   });
 
   it('can decrypt()', async () => {
-    const data = await ecDecrypt(
+    const data = ecDecrypt(
       rawId.privateKey,
       '307bac038efaa5bf8a0ac8db53fd4de8024a0c0baf37283a9e6671589eba18edc12b3915ff0df66e6ffad862440228a65ead99e3320e50aa90008961e3d68acc35b314e98020e3280bf4ce4258419dbb775185e60b43e7b88038a776a9322ff7cb3e886b2d92060cff2951ef3beedcc70a',
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3871,10 +3871,27 @@
     bn.js "5.2.1"
     borsh "^0.7.0"
 
+"@noble/ciphers@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-0.3.0.tgz#6ba3090afdc7a7051393486f6af210e62e0f04ec"
+  integrity sha512-ldbrnOjmNRwFdXcTM6uXDcxpMIFrbzAWNnpBPp4oTJTFF0XByGD6vf45WrehZGXRQTRVV+Zm8YP+EgEf+e4cWA==
+
+"@noble/curves@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
+  integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
+  dependencies:
+    "@noble/hashes" "1.3.2"
+
 "@noble/hashes@1.2.0", "@noble/hashes@~1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz"
   integrity sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==
+
+"@noble/hashes@1.3.2", "@noble/hashes@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
+  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
 
 "@noble/secp256k1@1.7.1", "@noble/secp256k1@~1.7.0":
   version "1.7.1"
@@ -9491,6 +9508,15 @@ ecdsa-sig-formatter@1.0.11:
   integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
   dependencies:
     safe-buffer "^5.0.1"
+
+eciesjs@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/eciesjs/-/eciesjs-0.4.5.tgz#35c48963e6942687da2bc93eb5b612ebf6a0bbfb"
+  integrity sha512-2zSRIygO48LpdS95Rwt9ryIkJNO37IdbkjRsnYyAn7gx7e4WPBNimnk6jGNdx2QQYr/VJRPnSVdwQpO5bycYZw==
+  dependencies:
+    "@noble/ciphers" "^0.3.0"
+    "@noble/curves" "^1.2.0"
+    "@noble/hashes" "^1.3.2"
 
 ee-first@1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4590,13 +4590,6 @@
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@toruslabs/eccrypto@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@toruslabs/eccrypto/-/eccrypto-4.0.0.tgz#0b27ed2d1e9483e77f42a7619a2c3c19cb802f44"
-  integrity sha512-Z3EINkbsgJx1t6jCDVIJjLSUEGUtNIeDjhMWmeDGOWcP/+v/yQ1hEvd1wfxEz4q5WqIHhevacmPiVxiJ4DljGQ==
-  dependencies:
-    elliptic "^6.5.4"
-
 "@truffle/abi-utils@^0.2.11":
   version "0.2.11"
   resolved "https://registry.npmjs.org/@truffle/abi-utils/-/abi-utils-0.2.11.tgz"
@@ -9509,7 +9502,7 @@ ecdsa-sig-formatter@1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
-eciesjs@^0.4.5:
+eciesjs@0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/eciesjs/-/eciesjs-0.4.5.tgz#35c48963e6942687da2bc93eb5b612ebf6a0bbfb"
   integrity sha512-2zSRIygO48LpdS95Rwt9ryIkJNO37IdbkjRsnYyAn7gx7e4WPBNimnk6jGNdx2QQYr/VJRPnSVdwQpO5bycYZw==
@@ -18776,7 +18769,7 @@ scuid@^1.1.0:
   resolved "https://registry.npmjs.org/scuid/-/scuid-1.1.0.tgz"
   integrity sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==
 
-secp256k1@4.0.2, secp256k1@^4.0.1:
+secp256k1@^4.0.1:
   version "4.0.2"
   resolved "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz"
   integrity sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==


### PR DESCRIPTION
## Description of the changes

- use `@noble/curves` for signature instead of `secp256k1`
- use `ecies/js` for encryption (which uses `@noble/curves` under the hood) instead of `eccrypto`'s fork
- `@noble/curves` is an audited library, and now the industry standard used by `ethers` and `viem`

## What's missing
For the moment we can't decrypto old data because `ecies/js` uses `AES-256-GCM` while `eccrypto` uses `AES-256-CBC`, see https://github.com/ecies/js/issues/747