### PR TITLE
fix: zksync networks names to lowercase

### DIFF
--- a/packages/currency/src/chains/evm/index.ts
+++ b/packages/currency/src/chains/evm/index.ts
@@ -57,6 +57,6 @@ export const chains: Record<CurrencyTypes.EvmChainName, EvmChain> = {
   sokol: SokolDefinition,
   tombchain: TombchainDefinition,
   xdai: XDaiDefinition,
-  zkSyncEraTestnet: ZkSyncEraTestnetDefinition,
-  zkSyncEra: ZkSyncEraDefinition,
+  zksynceratestnet: ZkSyncEraTestnetDefinition,
+  zksyncera: ZkSyncEraDefinition,
 };

--- a/packages/currency/src/native.ts
+++ b/packages/currency/src/native.ts
@@ -151,13 +151,13 @@ export const nativeCurrencies: Record<RequestLogicTypes.CURRENCY.ETH, NativeEthC
       symbol: 'ETH-zksync',
       decimals: 18,
       name: 'Ether',
-      network: 'zkSyncEra',
+      network: 'zksyncera',
     },
     {
       symbol: 'ETH-zksync-testnet',
       decimals: 18,
       name: 'Ether',
-      network: 'zkSyncEraTestnet',
+      network: 'zksynceratestnet',
     },
   ],
   [RequestLogicTypes.CURRENCY.BTC]: [

--- a/packages/payment-detection/src/eth/multichainExplorerApiProvider.ts
+++ b/packages/payment-detection/src/eth/multichainExplorerApiProvider.ts
@@ -15,8 +15,8 @@ const networks: Record<string, ethers.providers.Network> = {
   mantle: { chainId: 5000, name: 'mantle' },
   'mantle-testnet': { chainId: 5001, name: 'mantle-testnet' },
   core: { chainId: 1116, name: 'core' },
-  zkSyncEraTestnet: { chainId: 280, name: 'zkSyncEraTestnet' },
-  zkSyncEra: { chainId: 324, name: 'zkSyncEra' },
+  zksynceratestnet: { chainId: 280, name: 'zksynceratestnet' },
+  zksyncera: { chainId: 324, name: 'zksyncera' },
 };
 
 /**
@@ -68,9 +68,9 @@ export class MultichainExplorerApiProvider extends ethers.providers.EtherscanPro
         return 'https://explorer.testnet.mantle.xyz/api';
       case 'core':
         return 'https://openapi.coredao.org/';
-      case 'zkSyncEraTestnet':
+      case 'zksynceratestnet':
         return 'https://goerli.explorer.zksync.io/';
-      case 'zkSyncEra':
+      case 'zksyncera':
         return 'https://explorer.zksync.io/';
       default:
         return super.getBaseUrl();

--- a/packages/smart-contracts/README.md
+++ b/packages/smart-contracts/README.md
@@ -222,7 +222,7 @@ yarn hardhat deploy-live-payments --network private --force --dry-run
 To compile the contracts with the zkSync compiler, we use the same compile task but with the zkSync network specified.
 
 ```bash
-yarn hardhat compile --network zkSyncEra
+yarn hardhat compile --network zksyncera
 ```
 
 The compiled results go in separate directories build-zk and cache-zk.
@@ -238,13 +238,13 @@ We deploy with the following commands:
 First deploy the Proxy contracts:
 
 ```bash
-yarn hardhat deploy-zksync --script deploy-zk-proxy-contracts --network zkSyncEra
+yarn hardhat deploy-zksync --script deploy-zk-proxy-contracts --network zksyncera
 ```
 
 Then deploy the Batch contract:
 
 ```bash
-yarn hardhat deploy-zksync --script deploy-zk-batch-contracts --network zkSyncEra
+yarn hardhat deploy-zksync --script deploy-zk-batch-contracts --network zksyncera
 ```
 
 We don't have deploy scripts for our Conversion proxy because there is no Chainlink feed yet on this chain.

--- a/packages/smart-contracts/hardhat.config.ts
+++ b/packages/smart-contracts/hardhat.config.ts
@@ -166,15 +166,15 @@ export default {
       chainId: 1116,
       accounts,
     },
-    zkSyncEraTestnet: {
-      url: url('zkSyncEraTestnet'),
+    zksynceratestnet: {
+      url: url('zksynceratestnet'),
       ethNetwork: 'goerli',
       zksync: true,
       verifyURL: 'https://zksync2-testnet-explorer.zksync.dev/contract_verification',
       accounts,
     },
-    zkSyncEra: {
-      url: url('zkSyncEra'),
+    zksyncera: {
+      url: url('zksyncera'),
       ethNetwork: 'mainnet',
       zksync: true,
       verifyURL: 'https://zksync2-mainnet-explorer.zksync.io/contract_verification',

--- a/packages/smart-contracts/src/lib/artifacts/BatchConversionPayments/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/BatchConversionPayments/index.ts
@@ -64,11 +64,11 @@ export const batchConversionPaymentsArtifact = new ContractArtifact<BatchConvers
           creationBlockNumber: 19856206,
         },
         // Caution: no ETHConversion, ERC20Conversion, and chainlinkConversionPath proxies on zkSyncEra
-        zkSyncEra: {
+        zksyncera: {
           address: '0x0C41700ee1B363DB2ebC1a985f65cAf6eC4b1023',
           creationBlockNumber: 19545614,
         },
-        zkSyncEraTestnet: {
+        zksynceratestnet: {
           address: '0x9959F193498e75A2a46A04647fC15a031e308a0b',
           creationBlockNumber: 13769945,
         },

--- a/packages/smart-contracts/src/lib/artifacts/BatchPayments/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/BatchPayments/index.ts
@@ -65,6 +65,10 @@ export const batchPaymentsArtifact = new ContractArtifact<BatchPayments>(
           address: '0x0C41700ee1B363DB2ebC1a985f65cAf6eC4b1023',
           creationBlockNumber: 19545614,
         },
+        zksynceratestnet: {
+          address: '0x276A92F78aA527b8e157B0E47cEB63b4239dfa0b',
+          creationBlockNumber: 13814862,
+        },
       },
     },
   },

--- a/packages/smart-contracts/src/lib/artifacts/BatchPayments/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/BatchPayments/index.ts
@@ -61,7 +61,7 @@ export const batchPaymentsArtifact = new ContractArtifact<BatchPayments>(
           address: '0x0DD57FFe83a53bCbd657e234B16A3e74fEDb8fBA',
           creationBlockNumber: 35498688,
         },
-        zkSyncEra: {
+        zksyncera: {
           address: '0x0C41700ee1B363DB2ebC1a985f65cAf6eC4b1023',
           creationBlockNumber: 19545614,
         },

--- a/packages/smart-contracts/src/lib/artifacts/ERC20FeeProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/ERC20FeeProxy/index.ts
@@ -147,11 +147,11 @@ export const erc20FeeProxyArtifact = new ContractArtifact<ERC20FeeProxy>(
           address: '0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE',
           creationBlockNumber: 8317450,
         },
-        zkSyncEraTestnet: {
+        zksynceratestnet: {
           address: '0xb4E10de047b72Af2a44F64892419d248d58d9dF5',
           creationBlockNumber: 13616167,
         },
-        zkSyncEra: {
+        zksyncera: {
           address: '0x6e28Cc56C2E64c9250f39Cb134686C87dB196532',
           creationBlockNumber: 19545285,
         },

--- a/packages/smart-contracts/src/lib/artifacts/EthereumFeeProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/EthereumFeeProxy/index.ts
@@ -134,11 +134,11 @@ export const ethereumFeeProxyArtifact = new ContractArtifact<EthereumFeeProxy>(
           address: '0xe11BF2fDA23bF0A98365e1A4c04A87C9339e8687',
           creationBlockNumber: 8317446,
         },
-        zkSyncEraTestnet: {
+        zksynceratestnet: {
           address: '0x0de6a1FB56a141086E0192269399af8b8a9e334A',
           creationBlockNumber: 13616655,
         },
-        zkSyncEra: {
+        zksyncera: {
           address: '0xE9A708db0D30409e39810C44cA240fd15cdA9b1a',
           creationBlockNumber: 19545294,
         },

--- a/packages/types/src/currency-types.ts
+++ b/packages/types/src/currency-types.ts
@@ -26,8 +26,8 @@ export type EvmChainName =
   | 'sokol'
   | 'tombchain'
   | 'xdai'
-  | 'zkSyncEraTestnet'
-  | 'zkSyncEra';
+  | 'zksynceratestnet'
+  | 'zksyncera';
 
 /**
  * List of supported BTC chains

--- a/packages/utils/src/providers.ts
+++ b/packages/utils/src/providers.ts
@@ -49,8 +49,8 @@ const networkRpcs: Record<string, string> = {
   mantle: 'https://rpc.mantle.xyz/',
   'mantle-testnet': 'https://rpc.testnet.mantle.xyz/',
   core: 'https://rpc.coredao.org/',
-  zkSyncEraTestnet: 'https://testnet.era.zksync.dev',
-  zkSyncEra: 'https://mainnet.era.zksync.io',
+  zksynceratestnet: 'https://testnet.era.zksync.dev',
+  zksyncera: 'https://mainnet.era.zksync.io',
 };
 
 /**


### PR DESCRIPTION
## Description of the changes

We rely on that all network names are in lowercase in Invoicing, with the mixed letters the UI could not match the currency chain with the chainList from currency API.

Also added the batch contract address from zksync testnet.