### PR TITLE
feat(payment-detection): add minIndexedBlock option for TheGraph

### DIFF
--- a/packages/payment-detection/src/index.ts
+++ b/packages/payment-detection/src/index.ts
@@ -10,7 +10,7 @@ import { DeclarativePaymentDetector } from './declarative';
 import * as Erc20PaymentNetwork from './erc20';
 import { AnyToERC20PaymentDetector, AnyToEthFeeProxyPaymentDetector } from './any';
 import { EthFeeProxyPaymentDetector, EthInputDataPaymentDetector } from './eth';
-import { getTheGraphClient, getTheGraphNearClient } from './thegraph';
+import { getTheGraphEvmClient, getTheGraphNearClient } from './thegraph';
 import {
   calculateEscrowState,
   formatAddress,
@@ -52,7 +52,7 @@ export {
   setProviderFactory,
   initPaymentDetectionApiKeys,
   getDefaultProvider,
-  getTheGraphClient,
+  getTheGraphEvmClient,
   getTheGraphNearClient,
   parseLogArgs,
   padAmountForChainlink,

--- a/packages/payment-detection/src/thegraph/client.ts
+++ b/packages/payment-detection/src/thegraph/client.ts
@@ -23,9 +23,14 @@ const THE_GRAPH_URL_MANTLE =
  * @type TGraphClientVariant: null if no variant, 'near' if native token payments detection on Near
  */
 export type TheGraphClient<TChain extends CurrencyTypes.VMChainName = CurrencyTypes.EvmChainName> =
-  TChain extends CurrencyTypes.NearChainName
+  (TChain extends CurrencyTypes.NearChainName
     ? ReturnType<typeof getTheGraphNearClient>
-    : ReturnType<typeof getTheGraphClient>;
+    : ReturnType<typeof getTheGraphClient>) & {
+    options?: {
+      /** constraint to select indexers that have at least parsed this block */
+      subgraphMinIndexedBlock?: number | undefined;
+    };
+  };
 
 export type TheGraphClientOptions = {
   timeout?: number;

--- a/packages/payment-detection/src/thegraph/client.ts
+++ b/packages/payment-detection/src/thegraph/client.ts
@@ -18,6 +18,7 @@ const THE_GRAPH_URL_MANTLE =
 // NB: the GraphQL client is automatically generated based on files present in ./queries,
 // using graphql-codegen.
 // To generate types, run `yarn codegen`, then open the generated files so that the code editor picks up the changes.
+
 /**
  * A GraphQL client to query Request's subgraph.
  *
@@ -39,6 +40,11 @@ export type TheGraphClientOptions = {
 const extractClientOptions = (options?: TheGraphClientOptions) => {
   return pick(options, 'timeout');
 };
+
+export const getTheGraphClient = (network: string, url: string, options?: TheGraphClientOptions) =>
+  NearChains.isChainSupported(network)
+    ? getTheGraphNearClient(url, options)
+    : getTheGraphEvmClient(url, options);
 
 export const getTheGraphEvmClient = (url: string, options?: TheGraphClientOptions) => {
   const sdk: TheGraphClient<CurrencyTypes.EvmChainName> = getSdk(

--- a/packages/payment-detection/src/thegraph/conversion-info-retriever.ts
+++ b/packages/payment-detection/src/thegraph/conversion-info-retriever.ts
@@ -22,8 +22,8 @@ export class TheGraphConversionInfoRetriever extends TheGraphInfoRetriever<Conve
   ): Promise<PaymentTypes.AllNetworkEvents<PaymentTypes.IERC20FeePaymentEventParameters>> {
     const { payments } = params.acceptedTokens
       ? await this.client.GetAnyToFungiblePayments({
-          blockFilter: this.client.options?.subgraphMinIndexedBlock
-            ? { number_gte: this.client.options.subgraphMinIndexedBlock }
+          blockFilter: this.client.options?.minIndexedBlock
+            ? { number_gte: this.client.options.minIndexedBlock }
             : undefined,
           reference: utils.keccak256(`0x${params.paymentReference}`),
           to: params.toAddress.toLowerCase(),
@@ -32,8 +32,8 @@ export class TheGraphConversionInfoRetriever extends TheGraphInfoRetriever<Conve
           contractAddress: params.contractAddress.toLowerCase(),
         })
       : await this.client.GetAnyToNativePayments({
-          blockFilter: this.client.options?.subgraphMinIndexedBlock
-            ? { number_gte: this.client.options.subgraphMinIndexedBlock }
+          blockFilter: this.client.options?.minIndexedBlock
+            ? { number_gte: this.client.options.minIndexedBlock }
             : undefined,
           reference: utils.keccak256(`0x${params.paymentReference}`),
           to: params.toAddress.toLowerCase(),

--- a/packages/payment-detection/src/thegraph/conversion-info-retriever.ts
+++ b/packages/payment-detection/src/thegraph/conversion-info-retriever.ts
@@ -22,6 +22,9 @@ export class TheGraphConversionInfoRetriever extends TheGraphInfoRetriever<Conve
   ): Promise<PaymentTypes.AllNetworkEvents<PaymentTypes.IERC20FeePaymentEventParameters>> {
     const { payments } = params.acceptedTokens
       ? await this.client.GetAnyToFungiblePayments({
+          blockFilter: this.client.options?.subgraphMinIndexedBlock
+            ? { number_gte: this.client.options.subgraphMinIndexedBlock }
+            : undefined,
           reference: utils.keccak256(`0x${params.paymentReference}`),
           to: params.toAddress.toLowerCase(),
           currency: params.requestCurrency.hash.toLowerCase(),
@@ -29,6 +32,9 @@ export class TheGraphConversionInfoRetriever extends TheGraphInfoRetriever<Conve
           contractAddress: params.contractAddress.toLowerCase(),
         })
       : await this.client.GetAnyToNativePayments({
+          blockFilter: this.client.options?.subgraphMinIndexedBlock
+            ? { number_gte: this.client.options.subgraphMinIndexedBlock }
+            : undefined,
           reference: utils.keccak256(`0x${params.paymentReference}`),
           to: params.toAddress.toLowerCase(),
           currency: params.requestCurrency.hash.toLowerCase(),

--- a/packages/payment-detection/src/thegraph/info-retriever.ts
+++ b/packages/payment-detection/src/thegraph/info-retriever.ts
@@ -25,8 +25,8 @@ export class TheGraphInfoRetriever<TGraphQuery extends TransferEventsParams = Tr
       throw new Error('TheGraphInfoRetriever only supports no or 1 acceptedToken.');
     }
     const { payments, escrowEvents } = await this.client.GetPaymentsAndEscrowState({
-      blockFilter: this.client.options?.subgraphMinIndexedBlock
-        ? { number_gte: this.client.options.subgraphMinIndexedBlock }
+      blockFilter: this.client.options?.minIndexedBlock
+        ? { number_gte: this.client.options.minIndexedBlock }
         : undefined,
       reference: utils.keccak256(`0x${params.paymentReference}`),
       to: params.toAddress.toLowerCase(),
@@ -48,8 +48,8 @@ export class TheGraphInfoRetriever<TGraphQuery extends TransferEventsParams = Tr
       throw new Error('TheGraphInfoRetriever only supports no or 1 acceptedToken.');
     }
     const { payments, escrowEvents } = await this.client.GetPaymentsAndEscrowStateForReceivables({
-      blockFilter: this.client.options?.subgraphMinIndexedBlock
-        ? { number_gte: this.client.options.subgraphMinIndexedBlock }
+      blockFilter: this.client.options?.minIndexedBlock
+        ? { number_gte: this.client.options.minIndexedBlock }
         : undefined,
       reference: utils.keccak256(`0x${params.paymentReference}`),
       tokenAddress: params.acceptedTokens ? params.acceptedTokens[0].toLowerCase() : null,

--- a/packages/payment-detection/src/thegraph/info-retriever.ts
+++ b/packages/payment-detection/src/thegraph/info-retriever.ts
@@ -25,6 +25,9 @@ export class TheGraphInfoRetriever<TGraphQuery extends TransferEventsParams = Tr
       throw new Error('TheGraphInfoRetriever only supports no or 1 acceptedToken.');
     }
     const { payments, escrowEvents } = await this.client.GetPaymentsAndEscrowState({
+      blockFilter: this.client.options?.subgraphMinIndexedBlock
+        ? { number_gte: this.client.options.subgraphMinIndexedBlock }
+        : undefined,
       reference: utils.keccak256(`0x${params.paymentReference}`),
       to: params.toAddress.toLowerCase(),
       tokenAddress: params.acceptedTokens ? params.acceptedTokens[0].toLowerCase() : null,
@@ -45,6 +48,9 @@ export class TheGraphInfoRetriever<TGraphQuery extends TransferEventsParams = Tr
       throw new Error('TheGraphInfoRetriever only supports no or 1 acceptedToken.');
     }
     const { payments, escrowEvents } = await this.client.GetPaymentsAndEscrowStateForReceivables({
+      blockFilter: this.client.options?.subgraphMinIndexedBlock
+        ? { number_gte: this.client.options.subgraphMinIndexedBlock }
+        : undefined,
       reference: utils.keccak256(`0x${params.paymentReference}`),
       tokenAddress: params.acceptedTokens ? params.acceptedTokens[0].toLowerCase() : null,
       contractAddress: params.contractAddress.toLowerCase(),

--- a/packages/payment-detection/src/thegraph/queries/GetPaymentsAndEscrowState.graphql
+++ b/packages/payment-detection/src/thegraph/queries/GetPaymentsAndEscrowState.graphql
@@ -28,12 +28,14 @@ fragment EscrowEventResult on EscrowEvent {
 }
 
 query GetPaymentsAndEscrowState(
+  $blockFilter: Block_height
   $reference: Bytes!
   $to: Bytes!
   $tokenAddress: Bytes
   $contractAddress: Bytes!
 ) {
   payments(
+    block: $blockFilter
     where: {
       reference: $reference
       to: $to
@@ -46,13 +48,19 @@ query GetPaymentsAndEscrowState(
   ) {
     ...PaymentEventResult
   }
-  escrowEvents(where: { reference: $reference }, orderBy: timestamp, orderDirection: asc) {
+  escrowEvents(
+    block: $blockFilter
+    where: { reference: $reference }
+    orderBy: timestamp
+    orderDirection: asc
+  ) {
     ...EscrowEventResult
   }
 }
 
 # AnyToErc20 payments: denominated in request $currency payable with many token addresses
 query GetAnyToFungiblePayments(
+  $blockFilter: Block_height
   $reference: Bytes!
   $to: Bytes!
   $currency: Bytes!
@@ -60,6 +68,7 @@ query GetAnyToFungiblePayments(
   $contractAddress: Bytes!
 ) {
   payments(
+    block: $blockFilter
     where: {
       reference: $reference
       to: $to
@@ -76,12 +85,14 @@ query GetAnyToFungiblePayments(
 
 # AnyToETH payments: denominated in request $currency payable with the EVM native token
 query GetAnyToNativePayments(
+  $blockFilter: Block_height
   $reference: Bytes!
   $to: Bytes!
   $currency: Bytes!
   $contractAddress: Bytes!
 ) {
   payments(
+    block: $blockFilter
     where: {
       reference: $reference
       to: $to
@@ -98,18 +109,25 @@ query GetAnyToNativePayments(
 
 # Receivables can be transferred to different owners, so searching by to could drop balance events.
 query GetPaymentsAndEscrowStateForReceivables(
+  $blockFilter: Block_height
   $reference: Bytes!
   $tokenAddress: Bytes!
   $contractAddress: Bytes!
 ) {
   payments(
+    block: $blockFilter
     where: { reference: $reference, tokenAddress: $tokenAddress, contractAddress: $contractAddress }
     orderBy: timestamp
     orderDirection: asc
   ) {
     ...PaymentEventResult
   }
-  escrowEvents(where: { reference: $reference }, orderBy: timestamp, orderDirection: asc) {
+  escrowEvents(
+    block: $blockFilter
+    where: { reference: $reference }
+    orderBy: timestamp
+    orderDirection: asc
+  ) {
     ...EscrowEventResult
   }
 }

--- a/packages/payment-detection/src/thegraph/queries/graphql.config.yml
+++ b/packages/payment-detection/src/thegraph/queries/graphql.config.yml
@@ -1,0 +1,1 @@
+schema: https://api.thegraph.com/subgraphs/name/requestnetwork/request-payments-goerli

--- a/packages/payment-detection/src/thegraph/queries/near/graphql.config.yml
+++ b/packages/payment-detection/src/thegraph/queries/near/graphql.config.yml
@@ -1,0 +1,1 @@
+schema: https://api.thegraph.com/subgraphs/name/requestnetwork/request-payments-near-testnet

--- a/packages/payment-detection/src/thegraph/queries/superfluid/graphql.config.yml
+++ b/packages/payment-detection/src/thegraph/queries/superfluid/graphql.config.yml
@@ -1,0 +1,1 @@
+schema: https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli

--- a/packages/payment-detection/test/any/any-to-erc20-proxy-contract.test.ts
+++ b/packages/payment-detection/test/any/any-to-erc20-proxy-contract.test.ts
@@ -9,11 +9,13 @@ import {
 } from '@requestnetwork/types';
 import { CurrencyManager } from '@requestnetwork/currency';
 import { ERC20__factory } from '@requestnetwork/smart-contracts/types';
-import { AnyToERC20PaymentDetector, getTheGraphEvmClient } from '../../src';
+import { AnyToERC20PaymentDetector, TheGraphClient } from '../../src';
 import { mockAdvancedLogicBase } from '../utils';
 
 jest.mock('../../src/thegraph/client');
-const theGraphClientMock = jest.mocked(getTheGraphEvmClient(''));
+const theGraphClientMock = {
+  GetAnyToFungiblePayments: jest.fn(),
+} as jest.MockedObjectDeep<TheGraphClient>;
 
 let anyToErc20Proxy: AnyToERC20PaymentDetector;
 const currencyManager = CurrencyManager.getDefault();

--- a/packages/payment-detection/test/any/any-to-erc20-proxy-contract.test.ts
+++ b/packages/payment-detection/test/any/any-to-erc20-proxy-contract.test.ts
@@ -9,11 +9,11 @@ import {
 } from '@requestnetwork/types';
 import { CurrencyManager } from '@requestnetwork/currency';
 import { ERC20__factory } from '@requestnetwork/smart-contracts/types';
-import { AnyToERC20PaymentDetector, getTheGraphClient } from '../../src';
+import { AnyToERC20PaymentDetector, getTheGraphEvmClient } from '../../src';
 import { mockAdvancedLogicBase } from '../utils';
 
 jest.mock('../../src/thegraph/client');
-const theGraphClientMock = jest.mocked(getTheGraphClient(''));
+const theGraphClientMock = jest.mocked(getTheGraphEvmClient(''));
 
 let anyToErc20Proxy: AnyToERC20PaymentDetector;
 const currencyManager = CurrencyManager.getDefault();

--- a/packages/payment-detection/test/any/any-to-eth.test.ts
+++ b/packages/payment-detection/test/any/any-to-eth.test.ts
@@ -3,12 +3,12 @@ import { CurrencyManager } from '@requestnetwork/currency';
 import { ExtensionTypes, IdentityTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { AnyToEthFeeProxyPaymentDetector } from '../../src/any';
-import { getTheGraphClient } from '../../src/thegraph';
+import { getTheGraphEvmClient } from '../../src/thegraph';
 
 const getLogs = jest.spyOn(StaticJsonRpcProvider.prototype, 'getLogs');
 
 jest.mock('../../src/thegraph/client');
-const theGraphClientMock = jest.mocked(getTheGraphClient(''));
+const theGraphClientMock = jest.mocked(getTheGraphEvmClient(''));
 describe('Any to ETH payment detection', () => {
   const mockRequest: RequestLogicTypes.IRequest = {
     creator: { type: IdentityTypes.TYPE.ETHEREUM_ADDRESS, value: '0x2' },

--- a/packages/payment-detection/test/any/any-to-eth.test.ts
+++ b/packages/payment-detection/test/any/any-to-eth.test.ts
@@ -3,7 +3,7 @@ import { CurrencyManager } from '@requestnetwork/currency';
 import { ExtensionTypes, IdentityTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { AnyToEthFeeProxyPaymentDetector } from '../../src/any';
-import { getTheGraphEvmClient, TheGraphClient } from '../../src/thegraph';
+import { TheGraphClient } from '../../src/thegraph';
 
 const getLogs = jest.spyOn(StaticJsonRpcProvider.prototype, 'getLogs');
 

--- a/packages/payment-detection/test/any/any-to-eth.test.ts
+++ b/packages/payment-detection/test/any/any-to-eth.test.ts
@@ -3,12 +3,15 @@ import { CurrencyManager } from '@requestnetwork/currency';
 import { ExtensionTypes, IdentityTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { AnyToEthFeeProxyPaymentDetector } from '../../src/any';
-import { getTheGraphEvmClient } from '../../src/thegraph';
+import { getTheGraphEvmClient, TheGraphClient } from '../../src/thegraph';
 
 const getLogs = jest.spyOn(StaticJsonRpcProvider.prototype, 'getLogs');
 
 jest.mock('../../src/thegraph/client');
-const theGraphClientMock = jest.mocked(getTheGraphEvmClient(''));
+const theGraphClientMock = {
+  GetAnyToNativePayments: jest.fn(),
+} as jest.MockedObjectDeep<TheGraphClient>;
+
 describe('Any to ETH payment detection', () => {
   const mockRequest: RequestLogicTypes.IRequest = {
     creator: { type: IdentityTypes.TYPE.ETHEREUM_ADDRESS, value: '0x2' },

--- a/packages/payment-detection/test/erc20/proxy-contract.test.ts
+++ b/packages/payment-detection/test/erc20/proxy-contract.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@requestnetwork/types';
 import { CurrencyManager } from '@requestnetwork/currency';
 import { ERC20ProxyPaymentDetector } from '../../src/erc20';
-import { getTheGraphClient } from '../../src';
+import { getTheGraphEvmClient } from '../../src';
 import { mockAdvancedLogicBase } from '../utils';
 
 let erc20ProxyContract: ERC20ProxyPaymentDetector;
@@ -18,7 +18,7 @@ const createAddPaymentInstructionAction = jest.fn();
 const createAddRefundInstructionAction = jest.fn();
 
 jest.mock('../../src/thegraph/client');
-const theGraphClientMock = jest.mocked(getTheGraphClient(''));
+const theGraphClientMock = jest.mocked(getTheGraphEvmClient(''));
 const mockAdvancedLogic: AdvancedLogicTypes.IAdvancedLogic = {
   ...mockAdvancedLogicBase,
   extensions: {

--- a/packages/payment-detection/test/erc20/proxy-contract.test.ts
+++ b/packages/payment-detection/test/erc20/proxy-contract.test.ts
@@ -6,8 +6,8 @@ import {
 } from '@requestnetwork/types';
 import { CurrencyManager } from '@requestnetwork/currency';
 import { ERC20ProxyPaymentDetector } from '../../src/erc20';
-import { getTheGraphEvmClient } from '../../src';
 import { mockAdvancedLogicBase } from '../utils';
+import { TheGraphClient } from '../../src';
 
 let erc20ProxyContract: ERC20ProxyPaymentDetector;
 
@@ -18,7 +18,10 @@ const createAddPaymentInstructionAction = jest.fn();
 const createAddRefundInstructionAction = jest.fn();
 
 jest.mock('../../src/thegraph/client');
-const theGraphClientMock = jest.mocked(getTheGraphEvmClient(''));
+const theGraphClientMock = {
+  GetPaymentsAndEscrowState: jest.fn(),
+} as jest.MockedObjectDeep<TheGraphClient>;
+
 const mockAdvancedLogic: AdvancedLogicTypes.IAdvancedLogic = {
   ...mockAdvancedLogicBase,
   extensions: {

--- a/packages/payment-detection/test/eth/input-data.test.ts
+++ b/packages/payment-detection/test/eth/input-data.test.ts
@@ -5,12 +5,12 @@ import {
   PaymentTypes,
   RequestLogicTypes,
 } from '@requestnetwork/types';
-import { getTheGraphEvmClient } from '../../src/thegraph';
+import { TheGraphClient } from '../../src/thegraph';
 import { EthInputDataPaymentDetector } from '../../src/eth/input-data';
 import { mockAdvancedLogicBase } from '../utils';
 
 jest.mock('../../src/thegraph/client');
-const theGraphClientMock = jest.mocked(getTheGraphEvmClient(''));
+const theGraphClientMock = {} as jest.MockedObjectDeep<TheGraphClient>;
 
 let ethInputData: EthInputDataPaymentDetector;
 

--- a/packages/payment-detection/test/eth/input-data.test.ts
+++ b/packages/payment-detection/test/eth/input-data.test.ts
@@ -5,12 +5,12 @@ import {
   PaymentTypes,
   RequestLogicTypes,
 } from '@requestnetwork/types';
-import { getTheGraphClient } from '../../src/thegraph';
+import { getTheGraphEvmClient } from '../../src/thegraph';
 import { EthInputDataPaymentDetector } from '../../src/eth/input-data';
 import { mockAdvancedLogicBase } from '../utils';
 
 jest.mock('../../src/thegraph/client');
-const theGraphClientMock = jest.mocked(getTheGraphClient(''));
+const theGraphClientMock = jest.mocked(getTheGraphEvmClient(''));
 
 let ethInputData: EthInputDataPaymentDetector;
 


### PR DESCRIPTION
supersedes https://github.com/RequestNetwork/requestNetwork/pull/1253

## Context

When using TheGraph decentralized network, different GQL queries can target different indexers. For consistency, we can ask to target only indexers that have processed specific blocks using a block filter.

For more info, see [here](https://thegraph.com/docs/en/cookbook/upgrading-a-subgraph/) or [here](https://thegraph.com/blog/how-to-migrate-ethereum-subgraph/), look for `number_gte` in these pages.

## Description of the changes

- Added a new `minIndexedBlock` option to TheGraph client in order to handle this