### PR TITLE
fix(payment-detection): differenciate decentralized network case

### DIFF
--- a/packages/payment-detection/src/thegraph/client.ts
+++ b/packages/payment-detection/src/thegraph/client.ts
@@ -38,10 +38,23 @@ export type TheGraphClientOptions = {
   timeout?: number;
   /** constraint to select indexers that have at least parsed this block */
   minIndexedBlock?: number | undefined;
+  /** is this client targeting TheGraph decentralized network? */
+  decentralizedNetwork?: boolean;
 };
 
 const extractClientOptions = (options?: TheGraphClientOptions) => {
   return pick(options, 'timeout');
+};
+
+const populateSdkWithOptions = (
+  sdk: TheGraphClient<any>,
+  url: string,
+  options?: TheGraphClientOptions,
+) => {
+  sdk.options = {
+    decentralizedNetwork: url.startsWith('https://gateway-arbitrum.network.thegraph.com/'),
+    ...options,
+  };
 };
 
 export const getTheGraphClient = (network: string, url: string, options?: TheGraphClientOptions) =>
@@ -53,7 +66,7 @@ export const getTheGraphEvmClient = (url: string, options?: TheGraphClientOption
   const sdk: TheGraphClient<CurrencyTypes.EvmChainName> = getSdk(
     new GraphQLClient(url, extractClientOptions(options)),
   );
-  sdk.options = options;
+  populateSdkWithOptions(sdk, url, options);
   return sdk;
 };
 
@@ -61,7 +74,7 @@ export const getTheGraphNearClient = (url: string, options?: TheGraphClientOptio
   const sdk: TheGraphClient<CurrencyTypes.NearChainName> = getNearSdk(
     new GraphQLClient(url, extractClientOptions(options)),
   );
-  sdk.options = options;
+  populateSdkWithOptions(sdk, url, options);
   return sdk;
 };
 

--- a/packages/payment-detection/src/thegraph/conversion-info-retriever.ts
+++ b/packages/payment-detection/src/thegraph/conversion-info-retriever.ts
@@ -22,7 +22,11 @@ export class TheGraphConversionInfoRetriever extends TheGraphInfoRetriever<Conve
   ): Promise<PaymentTypes.AllNetworkEvents<PaymentTypes.IERC20FeePaymentEventParameters>> {
     const { payments } = params.acceptedTokens
       ? await this.client.GetAnyToFungiblePayments({
-          blockFilter: { number_gte: this.client.options?.minIndexedBlock || 0 },
+          blockFilter: this.client.options?.minIndexedBlock
+            ? { number_gte: this.client.options.minIndexedBlock }
+            : this.client.options?.decentralizedNetwork
+            ? {}
+            : undefined,
           reference: utils.keccak256(`0x${params.paymentReference}`),
           to: params.toAddress.toLowerCase(),
           currency: params.requestCurrency.hash.toLowerCase(),
@@ -30,7 +34,11 @@ export class TheGraphConversionInfoRetriever extends TheGraphInfoRetriever<Conve
           contractAddress: params.contractAddress.toLowerCase(),
         })
       : await this.client.GetAnyToNativePayments({
-          blockFilter: { number_gte: this.client.options?.minIndexedBlock || 0 },
+          blockFilter: this.client.options?.minIndexedBlock
+            ? { number_gte: this.client.options.minIndexedBlock }
+            : this.client.options?.decentralizedNetwork
+            ? {}
+            : undefined,
           reference: utils.keccak256(`0x${params.paymentReference}`),
           to: params.toAddress.toLowerCase(),
           currency: params.requestCurrency.hash.toLowerCase(),

--- a/packages/payment-detection/src/thegraph/conversion-info-retriever.ts
+++ b/packages/payment-detection/src/thegraph/conversion-info-retriever.ts
@@ -22,11 +22,7 @@ export class TheGraphConversionInfoRetriever extends TheGraphInfoRetriever<Conve
   ): Promise<PaymentTypes.AllNetworkEvents<PaymentTypes.IERC20FeePaymentEventParameters>> {
     const { payments } = params.acceptedTokens
       ? await this.client.GetAnyToFungiblePayments({
-          blockFilter: this.client.options?.minIndexedBlock
-            ? { number_gte: this.client.options.minIndexedBlock }
-            : this.client.options?.decentralizedNetwork
-            ? {}
-            : undefined,
+          blockFilter: this.client.options?.blockFilter,
           reference: utils.keccak256(`0x${params.paymentReference}`),
           to: params.toAddress.toLowerCase(),
           currency: params.requestCurrency.hash.toLowerCase(),
@@ -34,11 +30,7 @@ export class TheGraphConversionInfoRetriever extends TheGraphInfoRetriever<Conve
           contractAddress: params.contractAddress.toLowerCase(),
         })
       : await this.client.GetAnyToNativePayments({
-          blockFilter: this.client.options?.minIndexedBlock
-            ? { number_gte: this.client.options.minIndexedBlock }
-            : this.client.options?.decentralizedNetwork
-            ? {}
-            : undefined,
+          blockFilter: this.client.options?.blockFilter,
           reference: utils.keccak256(`0x${params.paymentReference}`),
           to: params.toAddress.toLowerCase(),
           currency: params.requestCurrency.hash.toLowerCase(),

--- a/packages/payment-detection/src/thegraph/info-retriever.ts
+++ b/packages/payment-detection/src/thegraph/info-retriever.ts
@@ -25,11 +25,7 @@ export class TheGraphInfoRetriever<TGraphQuery extends TransferEventsParams = Tr
       throw new Error('TheGraphInfoRetriever only supports no or 1 acceptedToken.');
     }
     const { payments, escrowEvents } = await this.client.GetPaymentsAndEscrowState({
-      blockFilter: this.client.options?.minIndexedBlock
-        ? { number_gte: this.client.options.minIndexedBlock }
-        : this.client.options?.decentralizedNetwork
-        ? {}
-        : undefined,
+      blockFilter: this.client.options?.blockFilter,
       reference: utils.keccak256(`0x${params.paymentReference}`),
       to: params.toAddress.toLowerCase(),
       tokenAddress: params.acceptedTokens ? params.acceptedTokens[0].toLowerCase() : null,
@@ -50,11 +46,7 @@ export class TheGraphInfoRetriever<TGraphQuery extends TransferEventsParams = Tr
       throw new Error('TheGraphInfoRetriever only supports no or 1 acceptedToken.');
     }
     const { payments, escrowEvents } = await this.client.GetPaymentsAndEscrowStateForReceivables({
-      blockFilter: this.client.options?.minIndexedBlock
-        ? { number_gte: this.client.options.minIndexedBlock }
-        : this.client.options?.decentralizedNetwork
-        ? {}
-        : undefined,
+      blockFilter: this.client.options?.blockFilter,
       reference: utils.keccak256(`0x${params.paymentReference}`),
       tokenAddress: params.acceptedTokens ? params.acceptedTokens[0].toLowerCase() : null,
       contractAddress: params.contractAddress.toLowerCase(),

--- a/packages/payment-detection/src/thegraph/info-retriever.ts
+++ b/packages/payment-detection/src/thegraph/info-retriever.ts
@@ -25,7 +25,11 @@ export class TheGraphInfoRetriever<TGraphQuery extends TransferEventsParams = Tr
       throw new Error('TheGraphInfoRetriever only supports no or 1 acceptedToken.');
     }
     const { payments, escrowEvents } = await this.client.GetPaymentsAndEscrowState({
-      blockFilter: { number_gte: this.client.options?.minIndexedBlock || 0 },
+      blockFilter: this.client.options?.minIndexedBlock
+        ? { number_gte: this.client.options.minIndexedBlock }
+        : this.client.options?.decentralizedNetwork
+        ? {}
+        : undefined,
       reference: utils.keccak256(`0x${params.paymentReference}`),
       to: params.toAddress.toLowerCase(),
       tokenAddress: params.acceptedTokens ? params.acceptedTokens[0].toLowerCase() : null,
@@ -46,7 +50,11 @@ export class TheGraphInfoRetriever<TGraphQuery extends TransferEventsParams = Tr
       throw new Error('TheGraphInfoRetriever only supports no or 1 acceptedToken.');
     }
     const { payments, escrowEvents } = await this.client.GetPaymentsAndEscrowStateForReceivables({
-      blockFilter: { number_gte: this.client.options?.minIndexedBlock || 0 },
+      blockFilter: this.client.options?.minIndexedBlock
+        ? { number_gte: this.client.options.minIndexedBlock }
+        : this.client.options?.decentralizedNetwork
+        ? {}
+        : undefined,
       reference: utils.keccak256(`0x${params.paymentReference}`),
       tokenAddress: params.acceptedTokens ? params.acceptedTokens[0].toLowerCase() : null,
       contractAddress: params.contractAddress.toLowerCase(),

--- a/packages/payment-detection/src/thegraph/queries/GetPaymentsAndEscrowState.graphql
+++ b/packages/payment-detection/src/thegraph/queries/GetPaymentsAndEscrowState.graphql
@@ -28,7 +28,7 @@ fragment EscrowEventResult on EscrowEvent {
 }
 
 query GetPaymentsAndEscrowState(
-  $blockFilter: Block_height!
+  $blockFilter: Block_height
   $reference: Bytes!
   $to: Bytes!
   $tokenAddress: Bytes
@@ -60,7 +60,7 @@ query GetPaymentsAndEscrowState(
 
 # AnyToErc20 payments: denominated in request $currency payable with many token addresses
 query GetAnyToFungiblePayments(
-  $blockFilter: Block_height!
+  $blockFilter: Block_height
   $reference: Bytes!
   $to: Bytes!
   $currency: Bytes!
@@ -85,7 +85,7 @@ query GetAnyToFungiblePayments(
 
 # AnyToETH payments: denominated in request $currency payable with the EVM native token
 query GetAnyToNativePayments(
-  $blockFilter: Block_height!
+  $blockFilter: Block_height
   $reference: Bytes!
   $to: Bytes!
   $currency: Bytes!
@@ -109,7 +109,7 @@ query GetAnyToNativePayments(
 
 # Receivables can be transferred to different owners, so searching by to could drop balance events.
 query GetPaymentsAndEscrowStateForReceivables(
-  $blockFilter: Block_height!
+  $blockFilter: Block_height
   $reference: Bytes!
   $tokenAddress: Bytes!
   $contractAddress: Bytes!


### PR DESCRIPTION
This is a fixup for https://github.com/RequestNetwork/requestNetwork/pull/1262 and https://github.com/RequestNetwork/requestNetwork/pull/1265

## Context

When using TheGraph decentralized network, different GQL queries can target different indexers. For consistency, we can ask to target only indexers that have processed specific blocks using a block filter.

For more info, see [here](https://thegraph.com/docs/en/cookbook/upgrading-a-subgraph/) or [here](https://thegraph.com/blog/how-to-migrate-ethereum-subgraph/), look for `number_gte` in these pages.

## Description of the change

When we don't have the data for which minimum block an indexer should have processed, we must set a default value. After several unsuccessful tries, here is what I've found regarding generating a default value that works with both a normal TheGraph Node and the decentralized gateway:

| Block Filter                      | TheGraph Node                                             | TheGraph Gateway (decentralized)                                            |
|-----------------------------------|-----------------------------------------------------------|-----------------------------------------------------------------------------|
| `undefined`                         | ✅                                                         | ❌ `Invalid query: Failed to determine block constraints.`                     |
| `null`                         | ✅                                                         | ❌ `Invalid query: Failed to determine block constraints.`                     |
| empty object: `{}`                   | ❌ `Invalid value provided for argument block: Object({})` | ✅                                                                           |
| default to zero: `{ number_gte: 0 }` | ✅                                                         | ❌ `Invalid query: Requested block before minimum startBlock of manifest: 0` |


This shows that no default value is compatible with both setups. We need to differentiate between both. I've added a new `decentralizedNetwork` boolean option that auto-populates depending on the URL value and allows to distinguish between both cases.