### PR TITLE
feat(advanced-logic): use currency manager instance

### DIFF
--- a/packages/advanced-logic/src/advanced-logic.ts
+++ b/packages/advanced-logic/src/advanced-logic.ts
@@ -56,26 +56,30 @@ export default class AdvancedLogic implements AdvancedLogicTypes.IAdvancedLogic 
     erc20TransferableReceivable: Erc20TransferableReceivablePaymentNetwork;
   };
 
+  private currencyManager: ICurrencyManager;
+
   constructor(currencyManager?: ICurrencyManager) {
     if (!currencyManager) {
       currencyManager = CurrencyManager.getDefault();
     }
+
+    this.currencyManager = currencyManager;
     this.extensions = {
       addressBasedBtc: new AddressBasedBtc(),
-      addressBasedErc20: new AddressBasedErc20(),
+      addressBasedErc20: new AddressBasedErc20(currencyManager),
       addressBasedTestnetBtc: new AddressBasedTestnetBtc(),
       contentData: new ContentData(),
       anyToErc20Proxy: new AnyToErc20Proxy(currencyManager),
       declarative: new Declarative(),
-      ethereumInputData: new EthereumInputData(),
-      feeProxyContractErc20: new FeeProxyContractErc20(),
-      proxyContractErc20: new ProxyContractErc20(),
-      erc777Stream: new Erc777Stream(),
-      feeProxyContractEth: new FeeProxyContractEth(),
+      ethereumInputData: new EthereumInputData(currencyManager),
+      feeProxyContractErc20: new FeeProxyContractErc20(currencyManager),
+      proxyContractErc20: new ProxyContractErc20(currencyManager),
+      erc777Stream: new Erc777Stream(currencyManager),
+      feeProxyContractEth: new FeeProxyContractEth(currencyManager),
       anyToEthProxy: new AnyToEthProxy(currencyManager),
-      nativeToken: [new NearNative(), new NearTestnetNative()],
+      nativeToken: [new NearNative(currencyManager), new NearTestnetNative(currencyManager)],
       anyToNativeToken: [new AnyToNear(currencyManager), new AnyToNearTestnet(currencyManager)],
-      erc20TransferableReceivable: new Erc20TransferableReceivablePaymentNetwork(),
+      erc20TransferableReceivable: new Erc20TransferableReceivablePaymentNetwork(currencyManager),
     };
   }
 
@@ -173,7 +177,7 @@ export default class AdvancedLogic implements AdvancedLogicTypes.IAdvancedLogic 
 
   public getFeeProxyContractErc20ForNetwork(network?: string): FeeProxyContractErc20 {
     return NearChains.isChainSupported(network)
-      ? new FeeProxyContractErc20(undefined, undefined, network)
+      ? new FeeProxyContractErc20(this.currencyManager, undefined, undefined, network)
       : this.extensions.feeProxyContractErc20;
   }
 

--- a/packages/advanced-logic/src/extensions/payment-network/address-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/address-based.ts
@@ -1,4 +1,4 @@
-import { CurrencyManager, UnsupportedCurrencyError } from '@requestnetwork/currency';
+import { ICurrencyManager, UnsupportedCurrencyError } from '@requestnetwork/currency';
 import {
   CurrencyTypes,
   ExtensionTypes,
@@ -16,6 +16,7 @@ export default abstract class AddressBasedPaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnAddressBased.ICreationParameters = ExtensionTypes.PnAddressBased.ICreationParameters,
 > extends DeclarativePaymentNetwork<TCreationParameters> {
   protected constructor(
+    protected currencyManager: ICurrencyManager,
     extensionId: ExtensionTypes.PAYMENT_NETWORK_ID,
     currentVersion: string,
     public readonly supportedCurrencyType: RequestLogicTypes.CURRENCY,
@@ -162,12 +163,11 @@ export default abstract class AddressBasedPaymentNetwork<
     symbol: string,
     network: CurrencyTypes.ChainName,
   ): boolean {
-    const currencyManager = CurrencyManager.getDefault();
-    const currency = currencyManager.from(symbol, network);
+    const currency = this.currencyManager.from(symbol, network);
     if (!currency) {
       throw new UnsupportedCurrencyError({ value: symbol, network });
     }
-    return currencyManager.validateAddress(address, currency);
+    return this.currencyManager.validateAddress(address, currency);
   }
 
   /**

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
@@ -10,12 +10,12 @@ const CURRENT_VERSION = '0.1.0';
 
 export default class AnyToErc20ProxyPaymentNetwork extends Erc20FeeProxyPaymentNetwork {
   public constructor(
-    private currencyManager: ICurrencyManager,
+    currencyManager: ICurrencyManager,
     extensionId: ExtensionTypes.PAYMENT_NETWORK_ID = ExtensionTypes.PAYMENT_NETWORK_ID
       .ANY_TO_ERC20_PROXY,
     currentVersion: string = CURRENT_VERSION,
   ) {
-    super(extensionId, currentVersion);
+    super(currencyManager, extensionId, currentVersion);
   }
 
   /**

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-eth-proxy.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-eth-proxy.ts
@@ -5,8 +5,8 @@ import EthereumFeeProxyPaymentNetwork from './ethereum/fee-proxy-contract';
 const CURRENT_VERSION = '0.2.0';
 
 export default class AnyToEthProxyPaymentNetwork extends EthereumFeeProxyPaymentNetwork {
-  public constructor(private currencyManager: ICurrencyManager) {
-    super(ExtensionTypes.PAYMENT_NETWORK_ID.ANY_TO_ETH_PROXY, CURRENT_VERSION);
+  public constructor(currencyManager: ICurrencyManager) {
+    super(currencyManager, ExtensionTypes.PAYMENT_NETWORK_ID.ANY_TO_ETH_PROXY, CURRENT_VERSION);
   }
 
   /**

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-native.ts
@@ -1,14 +1,16 @@
 import { FeeReferenceBasedPaymentNetwork } from './fee-reference-based';
 import { CurrencyTypes, ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { InvalidPaymentAddressError, UnsupportedNetworkError } from './address-based';
+import { ICurrencyManager } from '@requestnetwork/currency';
 
 export default abstract class AnyToNativeTokenPaymentNetwork extends FeeReferenceBasedPaymentNetwork {
   protected constructor(
+    currencyManager: ICurrencyManager,
     extensionId: ExtensionTypes.PAYMENT_NETWORK_ID,
     currentVersion: string,
     public readonly supportedNetworks: CurrencyTypes.ChainName[],
   ) {
-    super(extensionId, currentVersion, RequestLogicTypes.CURRENCY.ETH);
+    super(currencyManager, extensionId, currentVersion, RequestLogicTypes.CURRENCY.ETH);
   }
 
   public createCreationAction(

--- a/packages/advanced-logic/src/extensions/payment-network/erc20/address-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/address-based.ts
@@ -1,5 +1,6 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import AddressBasedPaymentNetwork from '../address-based';
+import { ICurrencyManager } from '@requestnetwork/currency';
 
 const CURRENT_VERSION = '0.1.0';
 
@@ -10,8 +11,9 @@ const CURRENT_VERSION = '0.1.0';
  * Important: the addresses must be exclusive to the request
  */
 export default class Erc20AddressBasedPaymentNetwork extends AddressBasedPaymentNetwork {
-  public constructor() {
+  public constructor(currencyManager: ICurrencyManager) {
     super(
+      currencyManager,
       ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_ADDRESS_BASED,
       CURRENT_VERSION,
       RequestLogicTypes.CURRENCY.ERC20,

--- a/packages/advanced-logic/src/extensions/payment-network/erc20/fee-proxy-contract.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/fee-proxy-contract.ts
@@ -1,5 +1,5 @@
 import { CurrencyTypes, ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
-import { NearChains, isSameChain } from '@requestnetwork/currency';
+import { ICurrencyManager, NearChains, isSameChain } from '@requestnetwork/currency';
 import { UnsupportedNetworkError } from '../address-based';
 import { FeeReferenceBasedPaymentNetwork } from '../fee-reference-based';
 
@@ -16,12 +16,14 @@ export default class Erc20FeeProxyPaymentNetwork<
    * @param network is only relevant for non-EVM chains (Near and Near testnet)
    */
   public constructor(
+    currencyManager: ICurrencyManager,
     extensionId: ExtensionTypes.PAYMENT_NETWORK_ID = ExtensionTypes.PAYMENT_NETWORK_ID
       .ERC20_FEE_PROXY_CONTRACT,
     currentVersion?: string | undefined,
     protected network?: string | undefined,
   ) {
     super(
+      currencyManager,
       extensionId,
       currentVersion ?? Erc20FeeProxyPaymentNetwork.getDefaultCurrencyVersion(network),
       RequestLogicTypes.CURRENCY.ERC20,

--- a/packages/advanced-logic/src/extensions/payment-network/erc20/proxy-contract.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/proxy-contract.ts
@@ -1,4 +1,5 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
+import { ICurrencyManager } from '@requestnetwork/currency';
 import ReferenceBasedPaymentNetwork from '../reference-based';
 
 const CURRENT_VERSION = '0.1.0';
@@ -9,8 +10,9 @@ const CURRENT_VERSION = '0.1.0';
 export default class Erc20ProxyPaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnReferenceBased.ICreationParameters = ExtensionTypes.PnReferenceBased.ICreationParameters,
 > extends ReferenceBasedPaymentNetwork<TCreationParameters> {
-  public constructor() {
+  public constructor(currencyManager: ICurrencyManager) {
     super(
+      currencyManager,
       ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_PROXY_CONTRACT,
       CURRENT_VERSION,
       RequestLogicTypes.CURRENCY.ERC20,

--- a/packages/advanced-logic/src/extensions/payment-network/erc20/transferable-receivable.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/transferable-receivable.ts
@@ -1,5 +1,6 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { FeeReferenceBasedPaymentNetwork } from '../fee-reference-based';
+import { ICurrencyManager } from '@requestnetwork/currency';
 
 const CURRENT_VERSION = '0.2.0';
 
@@ -10,10 +11,11 @@ export default class Erc20TransferableReceivablePaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
 > extends FeeReferenceBasedPaymentNetwork<TCreationParameters> {
   public constructor(
+    currencyManager: ICurrencyManager,
     extensionId: ExtensionTypes.PAYMENT_NETWORK_ID = ExtensionTypes.PAYMENT_NETWORK_ID
       .ERC20_TRANSFERABLE_RECEIVABLE,
     currentVersion: string = CURRENT_VERSION,
   ) {
-    super(extensionId, currentVersion, RequestLogicTypes.CURRENCY.ERC20);
+    super(currencyManager, extensionId, currentVersion, RequestLogicTypes.CURRENCY.ERC20);
   }
 }

--- a/packages/advanced-logic/src/extensions/payment-network/erc777/stream.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc777/stream.ts
@@ -1,6 +1,7 @@
 import { ExtensionTypes, RequestLogicTypes, TypesUtils } from '@requestnetwork/types';
 import ReferenceBasedPaymentNetwork from '../reference-based';
 import { isValidAmount } from '@requestnetwork/utils';
+import { ICurrencyManager } from '@requestnetwork/currency';
 const CURRENT_VERSION = '0.1.0';
 
 /**
@@ -9,8 +10,9 @@ const CURRENT_VERSION = '0.1.0';
 export default class Erc777StreamPaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnStreamReferenceBased.ICreationParameters = ExtensionTypes.PnStreamReferenceBased.ICreationParameters,
 > extends ReferenceBasedPaymentNetwork<TCreationParameters> {
-  public constructor() {
+  public constructor(currencyManager: ICurrencyManager) {
     super(
+      currencyManager,
       ExtensionTypes.PAYMENT_NETWORK_ID.ERC777_STREAM,
       CURRENT_VERSION,
       RequestLogicTypes.CURRENCY.ERC777,

--- a/packages/advanced-logic/src/extensions/payment-network/ethereum/fee-proxy-contract.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/ethereum/fee-proxy-contract.ts
@@ -1,5 +1,6 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { FeeReferenceBasedPaymentNetwork } from '../fee-reference-based';
+import { ICurrencyManager } from '@requestnetwork/currency';
 
 const CURRENT_VERSION = '0.2.0';
 
@@ -10,10 +11,11 @@ export default class EthereumFeeProxyPaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
 > extends FeeReferenceBasedPaymentNetwork<TCreationParameters> {
   public constructor(
+    currencyManager: ICurrencyManager,
     extensionId: ExtensionTypes.PAYMENT_NETWORK_ID = ExtensionTypes.PAYMENT_NETWORK_ID
       .ETH_FEE_PROXY_CONTRACT,
     currentVersion: string = CURRENT_VERSION,
   ) {
-    super(extensionId, currentVersion, RequestLogicTypes.CURRENCY.ETH);
+    super(currencyManager, extensionId, currentVersion, RequestLogicTypes.CURRENCY.ETH);
   }
 }

--- a/packages/advanced-logic/src/extensions/payment-network/ethereum/input-data.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/ethereum/input-data.ts
@@ -1,5 +1,6 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import ReferenceBasedPaymentNetwork from '../reference-based';
+import { ICurrencyManager } from '@requestnetwork/currency';
 
 const CURRENT_VERSION = '0.3.0';
 
@@ -9,10 +10,11 @@ const CURRENT_VERSION = '0.3.0';
  */
 export default class EthInputPaymentNetwork extends ReferenceBasedPaymentNetwork {
   public constructor(
+    currencyManager: ICurrencyManager,
     extensionId: ExtensionTypes.PAYMENT_NETWORK_ID = ExtensionTypes.PAYMENT_NETWORK_ID
       .ETH_INPUT_DATA,
     currentVersion: string = CURRENT_VERSION,
   ) {
-    super(extensionId, currentVersion, RequestLogicTypes.CURRENCY.ETH);
+    super(currencyManager, extensionId, currentVersion, RequestLogicTypes.CURRENCY.ETH);
   }
 }

--- a/packages/advanced-logic/src/extensions/payment-network/fee-reference-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/fee-reference-based.ts
@@ -1,6 +1,7 @@
 import { ExtensionTypes, IdentityTypes, RequestLogicTypes } from '@requestnetwork/types';
 import ReferenceBasedPaymentNetwork from './reference-based';
 import { areEqualIdentities, deepCopy, isValidAmount } from '@requestnetwork/utils';
+import { ICurrencyManager } from '@requestnetwork/currency';
 
 /**
  * Core of the reference based with fee payment networks
@@ -10,11 +11,12 @@ export abstract class FeeReferenceBasedPaymentNetwork<
   TCreationParameters extends ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
 > extends ReferenceBasedPaymentNetwork<TCreationParameters> {
   protected constructor(
+    currencyManager: ICurrencyManager,
     extensionId: ExtensionTypes.PAYMENT_NETWORK_ID,
     currentVersion: string,
     supportedCurrencyType: RequestLogicTypes.CURRENCY,
   ) {
-    super(extensionId, currentVersion, supportedCurrencyType);
+    super(currencyManager, extensionId, currentVersion, supportedCurrencyType);
     this.actions = {
       ...this.actions,
       [ExtensionTypes.PnFeeReferenceBased.ACTION.ADD_FEE]: this.applyAddFee.bind(this),

--- a/packages/advanced-logic/src/extensions/payment-network/native-token.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/native-token.ts
@@ -2,17 +2,19 @@ import { CurrencyTypes, ExtensionTypes, RequestLogicTypes } from '@requestnetwor
 import { InvalidPaymentAddressError, UnsupportedNetworkError } from './address-based';
 
 import ReferenceBasedPaymentNetwork from './reference-based';
+import { ICurrencyManager } from '@requestnetwork/currency';
 
 /**
  * Implementation of the payment network to pay in ETH based on input data.
  */
 export default abstract class NativeTokenPaymentNetwork extends ReferenceBasedPaymentNetwork {
   public constructor(
+    currencyManager: ICurrencyManager,
     extensionId: ExtensionTypes.PAYMENT_NETWORK_ID,
     currentVersion: string,
     public readonly supportedNetworks: CurrencyTypes.ChainName[],
   ) {
-    super(extensionId, currentVersion, RequestLogicTypes.CURRENCY.ETH);
+    super(currencyManager, extensionId, currentVersion, RequestLogicTypes.CURRENCY.ETH);
   }
 
   public createCreationAction(

--- a/packages/advanced-logic/src/extensions/payment-network/near/any-to-near.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/near/any-to-near.ts
@@ -11,7 +11,7 @@ const CURRENT_VERSION = '0.1.0';
 
 export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetwork {
   public constructor(
-    private currencyManager: ICurrencyManager,
+    currencyManager: ICurrencyManager,
     supportedNetworks: CurrencyTypes.NearChainName[] = [
       'aurora',
       // FIXME: enable near network support
@@ -19,7 +19,12 @@ export default class AnyToNearPaymentNetwork extends AnyToNativeTokenPaymentNetw
     ],
     currentVersion: string = CURRENT_VERSION,
   ) {
-    super(ExtensionTypes.PAYMENT_NETWORK_ID.ANY_TO_NATIVE_TOKEN, currentVersion, supportedNetworks);
+    super(
+      currencyManager,
+      ExtensionTypes.PAYMENT_NETWORK_ID.ANY_TO_NATIVE_TOKEN,
+      currentVersion,
+      supportedNetworks,
+    );
   }
 
   /**

--- a/packages/advanced-logic/src/extensions/payment-network/near/near-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/near/near-native.ts
@@ -1,5 +1,6 @@
 import { CurrencyTypes, ExtensionTypes } from '@requestnetwork/types';
 import NativeTokenPaymentNetwork from '../native-token';
+import { ICurrencyManager } from '@requestnetwork/currency';
 
 const CURRENT_VERSION = '0.2.0';
 
@@ -8,6 +9,7 @@ const CURRENT_VERSION = '0.2.0';
  */
 export default class NearNativePaymentNetwork extends NativeTokenPaymentNetwork {
   public constructor(
+    currencyManager: ICurrencyManager,
     supportedNetworks: CurrencyTypes.NearChainName[] = [
       'aurora',
       // FIXME: enable near network support
@@ -15,7 +17,12 @@ export default class NearNativePaymentNetwork extends NativeTokenPaymentNetwork 
     ],
     currentVersion: string = CURRENT_VERSION,
   ) {
-    super(ExtensionTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN, currentVersion, supportedNetworks);
+    super(
+      currencyManager,
+      ExtensionTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN,
+      currentVersion,
+      supportedNetworks,
+    );
   }
 
   /**

--- a/packages/advanced-logic/src/extensions/payment-network/near/near-testnet-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/near/near-testnet-native.ts
@@ -1,12 +1,13 @@
 import NearNativePaymentNetwork from './near-native';
+import { ICurrencyManager } from '@requestnetwork/currency';
 
 /**
  * Implementation of the payment network to pay in Near on testnet based on input data.
  */
 export default class NearTestnetNativeNativePaymentNetwork extends NearNativePaymentNetwork {
-  public constructor() {
+  public constructor(currencyManager: ICurrencyManager) {
     // testnet PN version is the same as mainnet, can be overridden here if needed
-    super(['aurora-testnet', 'near-testnet']);
+    super(currencyManager, ['aurora-testnet', 'near-testnet']);
   }
 
   /**

--- a/packages/advanced-logic/test/extensions/payment-network/address-based.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/address-based.test.ts
@@ -1,4 +1,4 @@
-import { UnsupportedCurrencyError } from '@requestnetwork/currency';
+import { CurrencyManager, UnsupportedCurrencyError } from '@requestnetwork/currency';
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import AddressBasedPaymentNetwork from '../../../src/extensions/payment-network/address-based';
 
@@ -10,7 +10,7 @@ describe('extensions/payment-network/address-based', () => {
         currentVersion: string,
         supportedCurrencyType: RequestLogicTypes.CURRENCY,
       ) {
-        super(extensionId, currentVersion, supportedCurrencyType);
+        super(CurrencyManager.getDefault(), extensionId, currentVersion, supportedCurrencyType);
       }
       public testIsValidAddress() {
         this.isValidAddress('test');
@@ -34,7 +34,7 @@ describe('extensions/payment-network/address-based', () => {
         currentVersion: string,
         supportedCurrencyType: RequestLogicTypes.CURRENCY,
       ) {
-        super(extensionId, currentVersion, supportedCurrencyType);
+        super(CurrencyManager.getDefault(), extensionId, currentVersion, supportedCurrencyType);
       }
       public testIsValidAddress() {
         this.isValidAddressForSymbolAndNetwork('test', 'test', 'mainnet');

--- a/packages/advanced-logic/test/extensions/payment-network/erc20/address-based.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/erc20/address-based.test.ts
@@ -1,3 +1,4 @@
+import { CurrencyManager } from '@requestnetwork/currency';
 import Erc20AddressBasedPaymentNetwork from '../../../../src/extensions/payment-network/erc20/address-based';
 
 import * as DataERC20AddPaymentAddress from '../../../utils/payment-network/erc20/address-based-add-payment-address-data-generator';
@@ -5,7 +6,9 @@ import * as DataERC20Create from '../../../utils/payment-network/erc20/address-b
 import * as TestData from '../../../utils/test-data-generator';
 import { deepCopy } from '@requestnetwork/utils';
 
-const erc20AddressBasedPaymentNetwork = new Erc20AddressBasedPaymentNetwork();
+const erc20AddressBasedPaymentNetwork = new Erc20AddressBasedPaymentNetwork(
+  CurrencyManager.getDefault(),
+);
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 describe('extensions/payment-network/erc20/mainnet-address-based', () => {
   describe('createCreationAction', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/erc20/proxy-contract.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/erc20/proxy-contract.test.ts
@@ -1,4 +1,5 @@
 import { ExtensionTypes, RequestLogicTypes, IdentityTypes } from '@requestnetwork/types';
+import { CurrencyManager } from '@requestnetwork/currency';
 
 import Erc20ProxyContract from '../../../../src/extensions/payment-network/erc20/proxy-contract';
 
@@ -7,7 +8,7 @@ import * as DataERC20Create from '../../../utils/payment-network/erc20/proxy-con
 import * as TestData from '../../../utils/test-data-generator';
 import { deepCopy } from '@requestnetwork/utils';
 
-const erc20ProxyContract = new Erc20ProxyContract();
+const erc20ProxyContract = new Erc20ProxyContract(CurrencyManager.getDefault());
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 describe('extensions/payment-network/erc20/proxy-contract', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/erc777/stream.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/erc777/stream.test.ts
@@ -1,5 +1,6 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { deepCopy } from '@requestnetwork/utils';
+import { CurrencyManager } from '@requestnetwork/currency';
 
 import Erc777StreamPaymentNetwork from '../../../../src/extensions/payment-network/erc777/stream';
 
@@ -7,7 +8,7 @@ import * as DataERC777StreamAddData from '../../../utils/payment-network/erc777/
 import * as DataERC777StreamCreate from '../../../utils/payment-network/erc777/stream-create-data-generator';
 import * as TestData from '../../../utils/test-data-generator';
 
-const erc777StreamPaymentNetwork = new Erc777StreamPaymentNetwork();
+const erc777StreamPaymentNetwork = new Erc777StreamPaymentNetwork(CurrencyManager.getDefault());
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 describe('extensions/payment-network/erc777/stream', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/ethereum/fee-proxy-contract.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/ethereum/fee-proxy-contract.test.ts
@@ -1,4 +1,5 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
+import { CurrencyManager } from '@requestnetwork/currency';
 
 import EthereumFeeProxyContract from '../../../../src/extensions/payment-network/ethereum/fee-proxy-contract';
 
@@ -7,7 +8,7 @@ import * as DataEthFeeCreate from '../../../utils/payment-network/ethereum/fee-p
 import * as TestData from '../../../utils/test-data-generator';
 import { deepCopy } from '@requestnetwork/utils';
 
-const ethFeeProxyContract = new EthereumFeeProxyContract();
+const ethFeeProxyContract = new EthereumFeeProxyContract(CurrencyManager.getDefault());
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 describe('extensions/payment-network/ethereum/fee-proxy-contract', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/ethereum/input-data.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/ethereum/input-data.test.ts
@@ -1,5 +1,6 @@
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
 import { deepCopy } from '@requestnetwork/utils';
+import { CurrencyManager } from '@requestnetwork/currency';
 
 import EthereumInputDataPaymentNetwork from '../../../../src/extensions/payment-network/ethereum/input-data';
 
@@ -7,7 +8,9 @@ import * as DataEthAddPaymentAddress from '../../../utils/payment-network/ethere
 import * as DataEthCreate from '../../../utils/payment-network/ethereum/create-data-generator';
 import * as TestData from '../../../utils/test-data-generator';
 
-const ethereumInputDataPaymentNetwork = new EthereumInputDataPaymentNetwork();
+const ethereumInputDataPaymentNetwork = new EthereumInputDataPaymentNetwork(
+  CurrencyManager.getDefault(),
+);
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 describe('extensions/payment-network/ethereum/input-data', () => {

--- a/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/native-token.test.ts
@@ -12,9 +12,11 @@ import {
 import { AdvancedLogic } from '../../../src';
 import { arbitraryTimestamp, payeeRaw } from '../../utils/test-data-generator';
 import { CurrencyTypes, ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
+import { CurrencyManager } from '@requestnetwork/currency';
 import NearTestnetNativeNativePaymentNetwork from '../../../src/extensions/payment-network/near/near-testnet-native';
 
 const salt = arbitrarySalt;
+const currencyManager = CurrencyManager.getDefault();
 
 describe('extensions/payment-network/native-token', () => {
   const nearCurrency = {
@@ -35,7 +37,7 @@ describe('extensions/payment-network/native-token', () => {
   const nativeTokenTestCases = [
     {
       name: 'Near',
-      paymentNetwork: new NearNativePaymentNetwork() as NativeTokenPaymentNetwork,
+      paymentNetwork: new NearNativePaymentNetwork(currencyManager) as NativeTokenPaymentNetwork,
       networkName: 'aurora',
       suffix: 'near',
       wrongSuffix: 'testnet',
@@ -44,7 +46,9 @@ describe('extensions/payment-network/native-token', () => {
     },
     {
       name: 'Aurora testnet',
-      paymentNetwork: new NearTestnetNativeNativePaymentNetwork() as NativeTokenPaymentNetwork,
+      paymentNetwork: new NearTestnetNativeNativePaymentNetwork(
+        currencyManager,
+      ) as NativeTokenPaymentNetwork,
       networkName: 'aurora-testnet',
       suffix: 'testnet',
       wrongSuffix: 'near',
@@ -53,7 +57,9 @@ describe('extensions/payment-network/native-token', () => {
     },
     {
       name: 'Near testnet',
-      paymentNetwork: new NearTestnetNativeNativePaymentNetwork() as NativeTokenPaymentNetwork,
+      paymentNetwork: new NearTestnetNativeNativePaymentNetwork(
+        currencyManager,
+      ) as NativeTokenPaymentNetwork,
       networkName: 'near-testnet',
       suffix: 'testnet',
       wrongSuffix: 'near',
@@ -139,14 +145,14 @@ describe('extensions/payment-network/native-token', () => {
     };
     it('createCreationAction() works with no payment or refund address nor network name', () => {
       expect(
-        new NearNativePaymentNetwork().createCreationAction({
+        new NearNativePaymentNetwork(currencyManager).createCreationAction({
           salt,
         }),
       ).toBeTruthy();
     });
     it('createCreationAction() throws with unsupported payment network', () => {
       expect(() => {
-        new NearNativePaymentNetwork().createCreationAction({
+        new NearNativePaymentNetwork(currencyManager).createCreationAction({
           ...partialCreationParams,
           paymentNetworkName: 'another-chain' as CurrencyTypes.NearChainName,
         });
@@ -156,7 +162,7 @@ describe('extensions/payment-network/native-token', () => {
     });
     it('createCreationAction() throws without payment network', () => {
       expect(() => {
-        new NearNativePaymentNetwork().createCreationAction(partialCreationParams);
+        new NearNativePaymentNetwork(currencyManager).createCreationAction(partialCreationParams);
       }).toThrowError(
         `The network name is mandatory for the creation of the extension pn-native-token.`,
       );
@@ -219,7 +225,7 @@ describe('extensions/payment-network/native-token', () => {
     });
     it('works when adding a payment address to a created state', () => {
       const advancedLogic = new AdvancedLogic();
-      const nearPn = new NearNativePaymentNetwork();
+      const nearPn = new NearNativePaymentNetwork(currencyManager);
 
       const requestState: typeof requestStateNoExtensions = {
         ...requestStateNoExtensions,
@@ -252,7 +258,7 @@ describe('extensions/payment-network/native-token', () => {
     });
     it('throws when creating the extension on a different network from the request network', () => {
       const advancedLogic = new AdvancedLogic();
-      const nearPn = new NearTestnetNativeNativePaymentNetwork();
+      const nearPn = new NearTestnetNativeNativePaymentNetwork(currencyManager);
 
       const requestState: typeof requestStateNoExtensions = {
         ...requestStateNoExtensions,
@@ -273,7 +279,7 @@ describe('extensions/payment-network/native-token', () => {
     });
     it('throws when adding a payment address a different network', () => {
       const advancedLogic = new AdvancedLogic();
-      const nearPn = new NearNativePaymentNetwork();
+      const nearPn = new NearNativePaymentNetwork(currencyManager);
 
       const requestState: typeof requestStateNoExtensions = {
         ...requestStateNoExtensions,
@@ -424,6 +430,7 @@ describe('extensions/payment-network/native-token', () => {
     }
     expect(() => {
       const testNativePaymentNetwork = new TestNativePaymentNetwork(
+        currencyManager,
         ExtensionTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN,
         'test',
         [],


### PR DESCRIPTION
## Description of the changes

### Context
Initiating a `CurrencyManager` is expensive. I was debugging the `computeRequestId` function. I'm sharing the logs of my test.

<img width="1198" alt="Screenshot 2023-11-28 at 12 09 16" src="https://github.com/RequestNetwork/requestNetwork/assets/28204154/ed0672a8-05bf-4ab7-b816-ac53128d2cd2">

Based on my test, `computeRequestId` is executed for 130ms. I'm using a M1 Macbook Pro. External network calls (API/DB calls) only take around 20ms _(from verifying signature input until signed)_. So, we still have 110ms of processing time, and it's all local execution. I suspected two things: for loops or a computing-intensive operation such as signing/hashing/encrypting, etc. But apparently, the process that takes much time is `CurrencyManager.getDefault()`. You can see on the logs there are several `.getDefault()` calls, and it takes approximately 15ms. A total of 6 calls contribute 90ms from the 110ms local execution 🥲

### Change
Inject instantiated `currencyManager`. I think we should re-use the `currencyManager` that has been instantiated in the `AdvancedLogic` class and pass it down to the payment networks unless there are specific reasons why certain payment networks can't use the `currencyManager` from the `AdvancedLogic` class.
