### PR TITLE
feat(request-node): use subgraph for confirmation

### DIFF
--- a/packages/data-access/README.md
+++ b/packages/data-access/README.md
@@ -139,10 +139,6 @@ Transactions are indexed with `topics`. When persisting a transaction on data-ac
 
 To save on costs, transactions are batched together. This is the responsibility of Data Access layer. This package creates `blocks` that are collections of `transactions`
 
-### Cache
-
-In order to speed up recovery of transactions, data-access has a local cache of topics=>transaction. This is the reason why this package should be initialized with `dataAccess.initialize()` before being operational. This cache can be persisted in a file using a [Keyv store](https://github.com/lukechilds/keyv#official-storage-adapters).
-
 ### Synchronization
 
 Blocks can be added into the storage by other peers running their own data-access instance. Therefore, to remain consistent with the global state of the network, this package need to synchronize with these new blocks.`dataAccess.synchronizeNewDataIds()` allows to synchronize manually with all unsynchronized blocks. The synchronization can also be done automatically, `dataAccess.startAutoSynchronization()` allows to automatically synchronize with new blocks, the interval time between each synchronization can be defined in data-access constructor. `dataAccess.stopAutoSynchronization()` allows to stop automatic synchronization.

--- a/packages/integration-test/test/scheduled/native-token.test.ts
+++ b/packages/integration-test/test/scheduled/native-token.test.ts
@@ -1,13 +1,12 @@
 import { PaymentNetworkFactory } from '@requestnetwork/payment-detection';
 import { ExtensionTypes, RequestLogicTypes } from '@requestnetwork/types';
-import { PnReferenceBased } from '@requestnetwork/types/dist/extension-types';
 import { AdvancedLogic } from '@requestnetwork/advanced-logic';
 import { CurrencyManager } from '@requestnetwork/currency';
 import { omit } from 'lodash';
 
 const advancedLogic = new AdvancedLogic(new CurrencyManager(CurrencyManager.getDefaultList()));
 
-const createCreationActionParams: PnReferenceBased.ICreationParameters = {
+const createCreationActionParams: ExtensionTypes.PnReferenceBased.ICreationParameters = {
   paymentAddress: 'payment.testnet',
   salt: 'a1a2a3a4a5a6a7a8',
   paymentNetworkName: 'aurora-testnet',

--- a/packages/payment-processor/src/payment/batch-conversion-proxy.ts
+++ b/packages/payment-processor/src/payment/batch-conversion-proxy.ts
@@ -29,7 +29,6 @@ import { IPreparedTransaction } from './prepared-transaction';
 import { IConversionPaymentSettings } from './index';
 import { getConversionPathForErc20Request } from './any-to-erc20-proxy';
 import { checkErc20Allowance, encodeApproveAnyErc20 } from './erc20';
-import { IState } from 'types/dist/extension-types';
 import { CurrencyDefinition, CurrencyManager, ICurrencyManager } from '@requestnetwork/currency';
 import {
   BatchPaymentNetworks,
@@ -128,7 +127,7 @@ const computeRequestDetails = ({
   extension,
 }: {
   enrichedRequest: EnrichedRequest;
-  extension: IState<any> | undefined;
+  extension: ExtensionTypes.IState<any> | undefined;
 }) => {
   const paymentNetworkId = enrichedRequest.paymentNetworkId;
   const allowedCurrencies = mapPnToAllowedCurrencies[paymentNetworkId];
@@ -177,7 +176,7 @@ function encodePayBatchConversionRequest(
     'pn-eth-fee-proxy-contract': [],
   };
 
-  const requestExtensions: Record<BatchPaymentNetworks, IState<any> | undefined> = {
+  const requestExtensions: Record<BatchPaymentNetworks, ExtensionTypes.IState<any> | undefined> = {
     'pn-any-to-erc20-proxy': undefined,
     'pn-any-to-eth-proxy': undefined,
     'pn-erc20-fee-proxy-contract': undefined,

--- a/packages/request-node/README.md
+++ b/packages/request-node/README.md
@@ -242,8 +242,6 @@ Default values correspond to the basic configuration used to run a server in a t
 - `--storageConcurrency` Maximum number of concurrent calls to Ethereum or IPFS
   - Default value: `'200'`
   - Environment variable name: `$STORAGE_MAX_CONCURRENCY`
-- `--initializationStorageFilePath` Path to a file to persist the ethereum metadata and transaction index for faster initialization
-  - Environment variable name: `$INITIALIZATION_STORAGE_FILE_PATH`
 - `--logLevel` The maximum level of messages we will log
   - Environment variable name: `$LOG_LEVEL`
   - Available levels: ERROR, WARN, INFO and DEBUG

--- a/packages/request-node/package.json
+++ b/packages/request-node/package.json
@@ -58,8 +58,6 @@
     "graphql-request": "6.1.0",
     "http-shutdown": "1.2.2",
     "http-status-codes": "2.1.4",
-    "keyv": "4.0.3",
-    "keyv-file": "0.2.0",
     "shelljs": "0.8.5",
     "tslib": "2.5.0",
     "yargs": "17.6.2"
@@ -68,7 +66,6 @@
     "@types/cors": "2.8.9",
     "@types/express": "4.17.17",
     "@types/jest": "29.5.6",
-    "@types/keyv": "3.1.1",
     "@types/node": "18.11.9",
     "@types/supertest": "2.0.10",
     "@types/yargs": "17.0.14",

--- a/packages/request-node/src/config.ts
+++ b/packages/request-node/src/config.ts
@@ -154,16 +154,6 @@ export const getLogLevel = (): LogTypes.LogLevel => {
 export const getLogMode = makeOption('logMode', 'LOG_MODE', defaultValues.log.mode);
 
 /**
- * Get the initialization storage (a json-like file) path.
- * @returns the path to the json-like file that stores the initialization data (ethereum metadata and transaction index).
- */
-export const getInitializationStorageFilePath = makeOption(
-  'initializationStorageFilePath',
-  'INITIALIZATION_STORAGE_FILE_PATH',
-  '',
-);
-
-/**
  * Get the delay to wait before sending a timeout when performing a persistTransaction request
  * persistTransaction is called when a request is created or updated and need to wait for Ethereum to commit the transaction
  * PROT-300: This configuration value can be removed once batching is implenented
@@ -240,7 +230,6 @@ export const getConfigDisplay = (): string => {
   TheGraph url: ${getGraphNodeUrl()}
   IPFS url: ${getIpfsUrl()}
   IPFS timeout: ${getIpfsTimeout()}
-  Initialization storage path: ${getInitializationStorageFilePath()}
   Storage block confirmations: ${getBlockConfirmations()}
 `;
 };

--- a/packages/request-node/src/dataAccess.ts
+++ b/packages/request-node/src/dataAccess.ts
@@ -1,28 +1,18 @@
 import { providers, Wallet } from 'ethers';
 import { NonceManager } from '@ethersproject/experimental';
-import { DataAccessTypes, LogTypes, StorageTypes } from '@requestnetwork/types';
-import { EvmChains } from '@requestnetwork/currency';
+import { CurrencyTypes, DataAccessTypes, LogTypes, StorageTypes } from '@requestnetwork/types';
 
 import * as config from './config';
 import { TheGraphDataAccess } from '@requestnetwork/thegraph-data-access';
 import { PendingStore } from '@requestnetwork/data-access';
-import {
-  EthereumStorage,
-  EthereumTransactionSubmitter,
-  getEthereumStorageNetworkNameFromId,
-} from '@requestnetwork/ethereum-storage';
+import { EthereumStorage, EthereumTransactionSubmitter } from '@requestnetwork/ethereum-storage';
 
 export function getDataAccess(
+  network: CurrencyTypes.EvmChainName,
   ipfsStorage: StorageTypes.IIpfsStorage,
   logger: LogTypes.ILogger,
 ): DataAccessTypes.IDataAccess {
   const graphNodeUrl = config.getGraphNodeUrl();
-
-  const network = getEthereumStorageNetworkNameFromId(config.getStorageNetworkId()) as any;
-  if (!network) {
-    throw new Error(`Storage network not supported: ${config.getStorageNetworkId()}`);
-  }
-  EvmChains.assertChainSupported(network);
 
   const wallet = Wallet.fromMnemonic(config.getMnemonic()).connect(
     new providers.StaticJsonRpcProvider(config.getStorageWeb3ProviderUrl()),

--- a/packages/request-node/src/dataStorage.ts
+++ b/packages/request-node/src/dataStorage.ts
@@ -1,7 +1,7 @@
 import * as config from './config';
 
 import { IpfsStorage } from '@requestnetwork/ethereum-storage';
-import { LogTypes, StorageTypes } from 'types/dist';
+import { LogTypes, StorageTypes } from '@requestnetwork/types';
 
 export function getDataStorage(logger: LogTypes.ILogger): StorageTypes.IIpfsStorage {
   return new IpfsStorage({

--- a/packages/request-node/src/request/confirmedTransactionStore.ts
+++ b/packages/request-node/src/request/confirmedTransactionStore.ts
@@ -2,9 +2,10 @@ import { DataAccessTypes, StorageTypes } from '@requestnetwork/types';
 import { SubgraphClient } from '@requestnetwork/thegraph-data-access';
 
 /**
- * Class for storing confirmed transactions information
- * When 'confirmed' event is received from a 'persistTransaction', the event data are stored.
- * The client can call the getConfirmed entry point, to get the confirmed event.
+ * Class for storing confirmed transaction information
+ * When 'confirmed' event is received from a 'persistTransaction', the event data is
+ * stored and indexed by the storage subgraph. The client can call the 
+ * getConfirmedTransaction endpoint, to get the confirmed event.
  */
 export default class ConfirmedTransactionStore {
   /**

--- a/packages/request-node/src/request/confirmedTransactionStore.ts
+++ b/packages/request-node/src/request/confirmedTransactionStore.ts
@@ -4,7 +4,7 @@ import { SubgraphClient } from '@requestnetwork/thegraph-data-access';
 /**
  * Class for storing confirmed transaction information
  * When 'confirmed' event is received from a 'persistTransaction', the event data is
- * stored and indexed by the storage subgraph. The client can call the 
+ * stored and indexed by the storage subgraph. The client can call the
  * getConfirmedTransaction endpoint, to get the confirmed event.
  */
 export default class ConfirmedTransactionStore {
@@ -19,9 +19,8 @@ export default class ConfirmedTransactionStore {
   public async getConfirmedTransaction(
     transactionHash: string,
   ): Promise<DataAccessTypes.IReturnPersistTransactionRaw | undefined> {
-    const { transactions, blockNumber } = await this.subgraphClient.getTransactionsByDataHash(
-      transactionHash,
-    );
+    const { transactions, blockNumber } =
+      await this.subgraphClient.getTransactionsByDataHash(transactionHash);
     if (transactions.length === 0) {
       return;
     }

--- a/packages/request-node/src/request/confirmedTransactionStore.ts
+++ b/packages/request-node/src/request/confirmedTransactionStore.ts
@@ -1,5 +1,5 @@
-import { DataAccessTypes } from '@requestnetwork/types';
-import Keyv, { Store } from 'keyv';
+import { DataAccessTypes, StorageTypes } from '@requestnetwork/types';
+import { SubgraphClient } from '@requestnetwork/thegraph-data-access';
 
 /**
  * Class for storing confirmed transactions information
@@ -7,44 +7,46 @@ import Keyv, { Store } from 'keyv';
  * The client can call the getConfirmed entry point, to get the confirmed event.
  */
 export default class ConfirmedTransactionStore {
-  private store: Keyv<DataAccessTypes.IReturnPersistTransactionRaw | Error>;
-
   /**
    * Confirmed transactions store constructor
    */
-  constructor(store?: Store<DataAccessTypes.IReturnPersistTransaction | Error>) {
-    this.store = new Keyv<DataAccessTypes.IReturnPersistTransaction | Error>({
-      namespace: 'ConfirmedTransactions',
-      store,
-    });
-  }
+  constructor(
+    private readonly subgraphClient: SubgraphClient,
+    private readonly networkName: string,
+  ) {}
 
   public async getConfirmedTransaction(
     transactionHash: string,
-  ): Promise<DataAccessTypes.IReturnPersistTransactionRaw | Error | undefined> {
-    return this.store.get(transactionHash);
-  }
-
-  /**
-   * Stores the result of a transaction confirmation
-   *
-   * @param transactionHash hash of the transaction
-   * @param result result of the event "confirmed"
-   */
-  public async addConfirmedTransaction(
-    transactionHash: string,
-    result: DataAccessTypes.IReturnPersistTransactionRaw,
-  ): Promise<void> {
-    await this.store.set(transactionHash, result);
-  }
-
-  /**
-   * Stores the error
-   *
-   * @param transactionHash hash of the transaction
-   * @param error error of the event "error"
-   */
-  public async addFailedTransaction(transactionHash: string, error: Error): Promise<void> {
-    await this.store.set(transactionHash, error);
+  ): Promise<DataAccessTypes.IReturnPersistTransactionRaw | undefined> {
+    const { transactions, blockNumber } = await this.subgraphClient.getTransactionsByDataHash(
+      transactionHash,
+    );
+    if (transactions.length === 0) {
+      return;
+    }
+    const transaction = transactions[0];
+    return {
+      meta: {
+        transactionStorageLocation: transaction.hash,
+        topics: transaction.topics,
+        storageMeta: {
+          state: StorageTypes.ContentState.CONFIRMED,
+          storageType: StorageTypes.StorageSystemType.ETHEREUM_IPFS,
+          timestamp: transaction.blockTimestamp,
+          ethereum: {
+            blockConfirmation: blockNumber - transaction.blockNumber,
+            blockTimestamp: transaction.blockTimestamp,
+            blockNumber: transaction.blockNumber,
+            networkName: this.networkName,
+            smartContractAddress: transaction.smartContractAddress,
+            transactionHash: transaction.transactionHash,
+          },
+          ipfs: {
+            size: Number(transaction.size),
+          },
+        },
+      },
+      result: {},
+    };
   }
 }

--- a/packages/request-node/src/request/getConfirmedTransactionHandler.ts
+++ b/packages/request-node/src/request/getConfirmedTransactionHandler.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import ConfirmedTransactionStore from './confirmedTransactionStore';
 
-export default class getConfirmedTransactionHandler {
+export default class GetConfirmedTransactionHandler {
   constructor(
     private logger: LogTypes.ILogger,
     private store: ConfirmedTransactionStore,

--- a/packages/request-node/src/request/persistTransaction.ts
+++ b/packages/request-node/src/request/persistTransaction.ts
@@ -12,7 +12,10 @@ export default class PersistTransactionHandler {
   /**
    * Persist transaction constructor
    */
-  constructor(private dataAccess: DataAccessTypes.IDataWrite, private logger: LogTypes.ILogger) {
+  constructor(
+    private dataAccess: DataAccessTypes.IDataWrite,
+    private logger: LogTypes.ILogger,
+  ) {
     this.handler = this.handler.bind(this);
   }
 

--- a/packages/request-node/src/server.ts
+++ b/packages/request-node/src/server.ts
@@ -26,7 +26,9 @@ export const getRequestNode = (): RequestNode => {
   const storage = getDataStorage(logger);
   const dataAccess = getDataAccess(network, storage, logger);
 
- // we access the subgraph client directly, not through the data access, because this feature is specific to RN use with Request Node. Without a node, the confirmation process would be different, so this doesn't fit in the data access layer
+  // we access the subgraph client directly, not through the data access,
+  // because this feature is specific to RN use with Request Node. Without a node,
+  // the confirmation process would be different, so this doesn't fit in the data access layer
   const confirmedTransactionStore = new ConfirmedTransactionStore(
     new SubgraphClient(config.getGraphNodeUrl()),
     network,

--- a/packages/request-node/src/server.ts
+++ b/packages/request-node/src/server.ts
@@ -3,22 +3,36 @@ import { Logger } from './logger';
 import withShutdown from 'http-shutdown';
 import { RequestNode } from './requestNode';
 import { getDataAccess } from './dataAccess';
-import KeyvFile from 'keyv-file';
 import { getDataStorage } from './dataStorage';
+import ConfirmedTransactionStore from './request/confirmedTransactionStore';
+import { EvmChains } from '@requestnetwork/currency';
+import { getEthereumStorageNetworkNameFromId } from '@requestnetwork/ethereum-storage';
+import { SubgraphClient } from '@requestnetwork/thegraph-data-access';
 
 // Initialize the node logger
 const logger = new Logger(config.getLogLevel(), config.getLogMode());
 
+const getNetwork = () => {
+  const network = getEthereumStorageNetworkNameFromId(config.getStorageNetworkId()) as any;
+  if (!network) {
+    throw new Error(`Storage network not supported: ${config.getStorageNetworkId()}`);
+  }
+  EvmChains.assertChainSupported(network);
+  return network;
+};
+
 export const getRequestNode = (): RequestNode => {
-  const initializationStoragePath = config.getInitializationStorageFilePath();
-  const store = initializationStoragePath
-    ? new KeyvFile({
-        filename: initializationStoragePath,
-      })
-    : undefined;
+  const network = getNetwork();
   const storage = getDataStorage(logger);
-  const dataAccess = getDataAccess(storage, logger);
-  return new RequestNode(dataAccess, storage, store, logger);
+  const dataAccess = getDataAccess(network, storage, logger);
+
+  // the confirmed transaction feature is specific to usage with a Request Node, so isn't exposed by dataAccess.
+  const confirmedTransactionStore = new ConfirmedTransactionStore(
+    new SubgraphClient(config.getGraphNodeUrl()),
+    network,
+  );
+
+  return new RequestNode(dataAccess, storage, confirmedTransactionStore, logger);
 };
 
 export const startNode = async (): Promise<void> => {

--- a/packages/request-node/src/server.ts
+++ b/packages/request-node/src/server.ts
@@ -26,7 +26,7 @@ export const getRequestNode = (): RequestNode => {
   const storage = getDataStorage(logger);
   const dataAccess = getDataAccess(network, storage, logger);
 
-  // the confirmed transaction feature is specific to usage with a Request Node, so isn't exposed by dataAccess.
+ // we access the subgraph client directly, not through the data access, because this feature is specific to RN use with Request Node. Without a node, the confirmation process would be different, so this doesn't fit in the data access layer
   const confirmedTransactionStore = new ConfirmedTransactionStore(
     new SubgraphClient(config.getGraphNodeUrl()),
     network,

--- a/packages/request-node/test/getChannelsByTopic.test.ts
+++ b/packages/request-node/test/getChannelsByTopic.test.ts
@@ -17,7 +17,7 @@ const otherTopics = [`01eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee${tim
 );
 const nonExistentTopic = '010000000000000000000000000000000000000000000000000000000000000000';
 const transactionData = {
-  data: 'this is sample data for a transaction to test getChannelsByTopic',
+  data: `this is sample data for a transaction to test getChannelsByTopic ${Date.now()}`,
 };
 const otherTransactionData = {
   data: 'this is other sample data for a transaction to test getChannelsByTopic',

--- a/packages/request-node/test/getConfirmedTransaction.test.ts
+++ b/packages/request-node/test/getConfirmedTransaction.test.ts
@@ -7,7 +7,7 @@ import { providers } from 'ethers';
 
 const channelId = '010aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
-const transactionData = { data: 'this is sample data for a transaction' };
+const transactionData = { data: `this is sample data for a transaction ${Date.now()}` };
 const transactionHash = normalizeKeccak256Hash(transactionData).value;
 const provider = new providers.JsonRpcProvider('http://localhost:8545');
 

--- a/packages/request-node/test/getTransactionsByChannelId.test.ts
+++ b/packages/request-node/test/getTransactionsByChannelId.test.ts
@@ -7,7 +7,7 @@ const channelId = '01aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 const anotherChannelId = '01bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbc';
 const nonExistentChannelId = '01cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccd';
 const transactionData = {
-  data: 'this is sample data for a transaction to test getTransactionsByChannelId',
+  data: `this is sample data for a transaction to test getTransactionsByChannelId ${Date.now()}`,
 };
 const otherTransactionData = {
   data: 'this is other sample data for a transaction to test getTransactionsByChannelId',

--- a/packages/request-node/test/persistTransaction.test.ts
+++ b/packages/request-node/test/persistTransaction.test.ts
@@ -12,7 +12,7 @@ const topics = [
   '010ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
   '010ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
 ];
-const transactionData = { data: 'this is sample data for a transaction' };
+const transactionData = { data: `this is sample data for a transaction ${Date.now()}` };
 const anotherTransactionData = { data: 'you can put any data' };
 const badlyFormattedTransactionData = { not: 'a transaction' };
 

--- a/packages/smart-contracts/deploy/utils-zk.ts
+++ b/packages/smart-contracts/deploy/utils-zk.ts
@@ -5,7 +5,7 @@ import { formatEther } from 'ethers/lib/utils';
 import { BigNumberish } from 'ethers';
 
 import { config } from 'dotenv';
-import { networkRpcs } from '@requestnetwork/utils/dist/providers';
+import { networkRpcs } from '@requestnetwork/utils';
 
 config();
 

--- a/packages/smart-contracts/test/contracts/BatchNoConversionErc20Payments.test.ts
+++ b/packages/smart-contracts/test/contracts/BatchNoConversionErc20Payments.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../../src/types';
 import { chainlinkConversionPath } from '../../src/lib';
 import { CurrencyManager, EvmChains } from '@requestnetwork/currency';
-import { RequestDetail } from 'types/dist/payment-types';
+import { PaymentTypes } from '@requestnetwork/types';
 
 const logGasInfos = false;
 
@@ -544,7 +544,7 @@ describe('contract: batchNoConversionPayments: ERC20', () => {
   });
 
   describe('Batch revert, issues with: args, or funds, or approval', () => {
-    let requestDetails: RequestDetail[] = [];
+    let requestDetails: PaymentTypes.RequestDetail[] = [];
     beforeEach(async () => {
       requestDetails = [
         {

--- a/packages/smart-contracts/test/contracts/BatchNoConversionEthPayments.test.ts
+++ b/packages/smart-contracts/test/contracts/BatchNoConversionEthPayments.test.ts
@@ -11,7 +11,7 @@ import {
 import { EthereumFeeProxy, BatchNoConversionPayments } from '../../src/types';
 import { chainlinkConversionPath } from '../../src/lib';
 import { HttpNetworkConfig } from 'hardhat/types';
-import { PaymentTypes } from 'types/dist';
+import { PaymentTypes } from '@requestnetwork/types';
 import { CurrencyManager, EvmChains } from '@requestnetwork/currency';
 
 const logGasInfos = false;

--- a/packages/thegraph-data-access/src/queries.ts
+++ b/packages/thegraph-data-access/src/queries.ts
@@ -4,6 +4,14 @@ export type Meta = {
   _meta: { block: { number: number } };
 };
 
+const metaQueryBody = `
+  _meta {
+    block {
+      number
+    }
+  }
+`;
+
 export type Transaction = {
   hash: string;
   channelId: string;
@@ -45,11 +53,7 @@ const TransactionsBodyFragment = gql`
 export const GetTransactionsByChannelIdQuery = gql`
   ${TransactionsBodyFragment}
   query GetTransactionsByChannelId($channelId: String!, $from: Int, $to: Int) {
-    _meta {
-      block {
-        number
-      }
-    }
+    ${metaQueryBody}
     transactions(
       where: { channelId: $channelId, blockTimestamp_gte: $from, blockTimestamp_lt: $to }
       orderBy: blockTimestamp
@@ -63,11 +67,7 @@ export const GetTransactionsByChannelIdQuery = gql`
 export const GetTransactionsByHashQuery = gql`
   ${TransactionsBodyFragment}
   query GetTransactionsByHash($hash: String!) {
-    _meta {
-      block {
-        number
-      }
-    }
+    ${metaQueryBody}
     transactions(where: { hash: $hash }, orderBy: blockTimestamp, orderDirection: asc) {
       ...TransactionsBody
     }
@@ -77,11 +77,7 @@ export const GetTransactionsByHashQuery = gql`
 export const GetChannelsByTopicsQuery = gql`
   ${TransactionsBodyFragment}
   query GetChannelsByTopics($topics: [String!]!) {
-    _meta {
-      block {
-        number
-      }
-    }
+    ${metaQueryBody}
     transactions(
       where: { topics_contains: $topics }
       orderBy: blockTimestamp
@@ -92,12 +88,18 @@ export const GetChannelsByTopicsQuery = gql`
   }
 `;
 
-export const GetBlock = gql`
+export const GetBlockQuery = gql`
   query GetBlock {
-    _meta {
-      block {
-        number
-      }
+    ${metaQueryBody}
+  }
+`;
+
+export const GetTransactionByDataHashQuery = gql`
+  ${TransactionsBodyFragment}
+  query GetTransactionsByDataHash($dataHash: String!) {
+    ${metaQueryBody}
+    transactions(where: { dataHash: $dataHash }) {
+      ...TransactionsBody
     }
   }
 `;

--- a/packages/thegraph-data-access/src/subgraph-client.ts
+++ b/packages/thegraph-data-access/src/subgraph-client.ts
@@ -1,8 +1,9 @@
 import { DataAccessTypes, StorageTypes } from '@requestnetwork/types';
 import { GraphQLClient } from 'graphql-request';
 import {
-  GetBlock,
+  GetBlockQuery,
   GetChannelsByTopicsQuery,
+  GetTransactionByDataHashQuery,
   GetTransactionsByChannelIdQuery,
   GetTransactionsByHashQuery,
   Meta,
@@ -27,7 +28,7 @@ export class SubgraphClient implements StorageTypes.IIndexer {
   }
 
   public async getBlockNumber(): Promise<number> {
-    const { _meta } = await this.graphql.request<Meta>(GetBlock);
+    const { _meta } = await this.graphql.request<Meta>(GetBlockQuery);
     return _meta.block.number;
   }
 
@@ -75,6 +76,12 @@ export class SubgraphClient implements StorageTypes.IIndexer {
       transactions: transactionsByChannel.map(this.toIndexedTransaction),
       blockNumber: _meta.block.number,
     };
+  }
+
+  public async getTransactionsByDataHash(
+    dataHash: string,
+  ): Promise<StorageTypes.IGetTransactionsResponse> {
+    return await this.fetchAndFormat(GetTransactionByDataHashQuery, { dataHash });
   }
 
   private async fetchAndFormat(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5316,13 +5316,6 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/keyv@3.1.1":
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz"
-  integrity sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/lodash@4.14.161":
   version "4.14.161"
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz"
@@ -12146,7 +12139,7 @@ fs-extra@^11.1.1:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^4.0.1, fs-extra@^4.0.2, fs-extra@^4.0.3:
+fs-extra@^4.0.2, fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz"
   integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
@@ -14764,11 +14757,6 @@ json-buffer@3.0.0:
   resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
-json-buffer@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz"
-  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
-
 json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz"
@@ -14934,22 +14922,6 @@ keccak@^3.0.2:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
     readable-stream "^3.6.0"
-
-keyv-file@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/keyv-file/-/keyv-file-0.2.0.tgz"
-  integrity sha512-zUQ11eZRmilEUpV1gJSj8mBAHjyXpleQo1iCS0khb+GFRhiPfwavWgn4eDUKNlOyMZzmExnISl8HE1hNbim0gw==
-  dependencies:
-    debug "^4.1.1"
-    fs-extra "^4.0.1"
-    tslib "^1.9.3"
-
-keyv@4.0.3:
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz"
-  integrity sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==
-  dependencies:
-    json-buffer "3.0.1"
 
 keyv@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Resolves #1287
Requires https://github.com/RequestNetwork/storage-subgraph/pull/13

This changes removes the handling of failed transactions. I think this is acceptable, since there is a relatively short timeout on confirmation, and failures aren't very common. Please feel free to challenge this.