### PR TITLE
chore(prettier): ignore yarn release

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,13 @@
 {
   "singleQuote": true,
   "trailingComma": "all",
-  "printWidth": 100
+  "printWidth": 100,
+  "overrides": [
+    {
+      "files": ".yarn/releases/yarn-1.22.19.cjs",
+      "options": {
+        "rangeEnd": 0
+      }
+    }
+  ]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
   "printWidth": 100,
   "overrides": [
     {
-      "files": ".yarn/releases/yarn-1.22.19.cjs",
+      "files": ".yarn/releases/*.cjs",
       "options": {
         "rangeEnd": 0
       }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint-staged": "10.5.4",
     "npm-package-json-lint": "5.1.0",
     "nyc": "15.1.0",
-    "prettier": "2.8.6",
+    "prettier": "3.0.3",
     "prettier-plugin-solidity": "1.0.0-beta.19",
     "remap-istanbul": "0.13.0",
     "typescript": "5.1.3"

--- a/packages/advanced-logic/src/extensions/content-data.ts
+++ b/packages/advanced-logic/src/extensions/content-data.ts
@@ -7,7 +7,8 @@ const CURRENT_VERSION = '0.1.0';
  * Implementation of the content data extension
  */
 export default class ContentDataExtension<
-  TCreationParameters extends ExtensionTypes.ContentData.ICreationParameters = ExtensionTypes.ContentData.ICreationParameters,
+  TCreationParameters extends
+    ExtensionTypes.ContentData.ICreationParameters = ExtensionTypes.ContentData.ICreationParameters,
 > extends AbstractExtension<TCreationParameters> {
   public constructor() {
     super(ExtensionTypes.TYPE.CONTENT_DATA, ExtensionTypes.ID.CONTENT_DATA, CURRENT_VERSION);

--- a/packages/advanced-logic/src/extensions/payment-network/address-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/address-based.ts
@@ -13,7 +13,8 @@ import DeclarativePaymentNetwork from './declarative';
  * This module is called by the address based payment networks to avoid code redundancy
  */
 export default abstract class AddressBasedPaymentNetwork<
-  TCreationParameters extends ExtensionTypes.PnAddressBased.ICreationParameters = ExtensionTypes.PnAddressBased.ICreationParameters,
+  TCreationParameters extends
+    ExtensionTypes.PnAddressBased.ICreationParameters = ExtensionTypes.PnAddressBased.ICreationParameters,
 > extends DeclarativePaymentNetwork<TCreationParameters> {
   protected constructor(
     protected currencyManager: ICurrencyManager,

--- a/packages/advanced-logic/src/extensions/payment-network/declarative.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/declarative.ts
@@ -8,7 +8,8 @@ const CURRENT_VERSION = '0.1.0';
  * Core of the declarative payment network
  */
 export default class DeclarativePaymentNetwork<
-  TCreationParameters extends ExtensionTypes.PnAnyDeclarative.ICreationParameters = ExtensionTypes.PnAnyDeclarative.ICreationParameters,
+  TCreationParameters extends
+    ExtensionTypes.PnAnyDeclarative.ICreationParameters = ExtensionTypes.PnAnyDeclarative.ICreationParameters,
 > extends AbstractExtension<TCreationParameters> {
   public constructor(
     public readonly extensionId: ExtensionTypes.PAYMENT_NETWORK_ID = ExtensionTypes

--- a/packages/advanced-logic/src/extensions/payment-network/erc20/fee-proxy-contract.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/fee-proxy-contract.ts
@@ -10,7 +10,8 @@ const NEAR_CURRENT_VERSION = 'NEAR-0.1.0';
  * Implementation of the payment network to pay in ERC20, including third-party fees payment, based on a reference provided to a proxy contract.
  */
 export default class Erc20FeeProxyPaymentNetwork<
-  TCreationParameters extends ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
+  TCreationParameters extends
+    ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
 > extends FeeReferenceBasedPaymentNetwork<TCreationParameters> {
   /**
    * @param network is only relevant for non-EVM chains (Near and Near testnet)

--- a/packages/advanced-logic/src/extensions/payment-network/erc20/proxy-contract.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/proxy-contract.ts
@@ -8,7 +8,8 @@ const CURRENT_VERSION = '0.1.0';
  * Implementation of the payment network to pay in ERC20 based on a reference provided to a proxy contract.
  */
 export default class Erc20ProxyPaymentNetwork<
-  TCreationParameters extends ExtensionTypes.PnReferenceBased.ICreationParameters = ExtensionTypes.PnReferenceBased.ICreationParameters,
+  TCreationParameters extends
+    ExtensionTypes.PnReferenceBased.ICreationParameters = ExtensionTypes.PnReferenceBased.ICreationParameters,
 > extends ReferenceBasedPaymentNetwork<TCreationParameters> {
   public constructor(currencyManager: ICurrencyManager) {
     super(

--- a/packages/advanced-logic/src/extensions/payment-network/erc20/transferable-receivable.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc20/transferable-receivable.ts
@@ -8,7 +8,8 @@ const CURRENT_VERSION = '0.2.0';
  * Implementation of the payment network to pay in ERC20 based on a transferable receivable contract.
  */
 export default class Erc20TransferableReceivablePaymentNetwork<
-  TCreationParameters extends ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
+  TCreationParameters extends
+    ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
 > extends FeeReferenceBasedPaymentNetwork<TCreationParameters> {
   public constructor(
     currencyManager: ICurrencyManager,

--- a/packages/advanced-logic/src/extensions/payment-network/erc777/stream.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/erc777/stream.ts
@@ -8,7 +8,8 @@ const CURRENT_VERSION = '0.1.0';
  * Implementation of the payment network to pay in ERC777, including third-party fees payment, based on a reference provided to a proxy contract.
  */
 export default class Erc777StreamPaymentNetwork<
-  TCreationParameters extends ExtensionTypes.PnStreamReferenceBased.ICreationParameters = ExtensionTypes.PnStreamReferenceBased.ICreationParameters,
+  TCreationParameters extends
+    ExtensionTypes.PnStreamReferenceBased.ICreationParameters = ExtensionTypes.PnStreamReferenceBased.ICreationParameters,
 > extends ReferenceBasedPaymentNetwork<TCreationParameters> {
   public constructor(currencyManager: ICurrencyManager) {
     super(

--- a/packages/advanced-logic/src/extensions/payment-network/ethereum/fee-proxy-contract.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/ethereum/fee-proxy-contract.ts
@@ -8,7 +8,8 @@ const CURRENT_VERSION = '0.2.0';
  * Implementation of the payment network to pay in Ethereum, including third-party fees payment, based on a reference provided to a proxy contract.
  */
 export default class EthereumFeeProxyPaymentNetwork<
-  TCreationParameters extends ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
+  TCreationParameters extends
+    ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
 > extends FeeReferenceBasedPaymentNetwork<TCreationParameters> {
   public constructor(
     currencyManager: ICurrencyManager,

--- a/packages/advanced-logic/src/extensions/payment-network/fee-reference-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/fee-reference-based.ts
@@ -8,7 +8,8 @@ import { ICurrencyManager } from '@requestnetwork/currency';
  * This module is called by the fee reference based (ethereum & erc20) payment networks to avoid code redundancy
  */
 export abstract class FeeReferenceBasedPaymentNetwork<
-  TCreationParameters extends ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
+  TCreationParameters extends
+    ExtensionTypes.PnFeeReferenceBased.ICreationParameters = ExtensionTypes.PnFeeReferenceBased.ICreationParameters,
 > extends ReferenceBasedPaymentNetwork<TCreationParameters> {
   protected constructor(
     currencyManager: ICurrencyManager,

--- a/packages/advanced-logic/src/extensions/payment-network/reference-based.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/reference-based.ts
@@ -9,7 +9,8 @@ const eightHexRegex = /[0-9a-f]{16,}/;
  * This module is called by the reference based payment networks to avoid code redundancy
  */
 export default abstract class ReferenceBasedPaymentNetwork<
-  TCreationParameters extends ExtensionTypes.PnReferenceBased.ICreationParameters = ExtensionTypes.PnReferenceBased.ICreationParameters,
+  TCreationParameters extends
+    ExtensionTypes.PnReferenceBased.ICreationParameters = ExtensionTypes.PnReferenceBased.ICreationParameters,
 > extends AddressBasedPaymentNetwork<TCreationParameters> {
   /**
    * Creates the extensionsData to create the payment detection extension

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -56,7 +56,6 @@
     "ethers": "5.5.1",
     "jest": "29.5.0",
     "jest-junit": "16.0.0",
-    "prettier": "2.1.1",
     "shx": "0.3.2",
     "source-map-support": "0.5.19",
     "ts-jest": "29.1.0",

--- a/packages/data-access/src/data-read.ts
+++ b/packages/data-access/src/data-read.ts
@@ -89,17 +89,23 @@ export class DataAccessRead implements DataAccessTypes.IDataRead {
     const filteredTxs = transactions.filter((tx) => channels.includes(tx.channelId));
     return {
       meta: {
-        storageMeta: filteredTxs.reduce((acc, tx) => {
-          acc[tx.channelId] = [this.toStorageMeta(tx, result.blockNumber, this.network)];
-          return acc;
-        }, {} as Record<string, StorageTypes.IEntryMetadata[]>),
-        transactionsStorageLocation: filteredTxs.reduce((prev, curr) => {
-          if (!prev[curr.channelId]) {
-            prev[curr.channelId] = [];
-          }
-          prev[curr.channelId].push(curr.hash);
-          return prev;
-        }, {} as Record<string, string[]>),
+        storageMeta: filteredTxs.reduce(
+          (acc, tx) => {
+            acc[tx.channelId] = [this.toStorageMeta(tx, result.blockNumber, this.network)];
+            return acc;
+          },
+          {} as Record<string, StorageTypes.IEntryMetadata[]>,
+        ),
+        transactionsStorageLocation: filteredTxs.reduce(
+          (prev, curr) => {
+            if (!prev[curr.channelId]) {
+              prev[curr.channelId] = [];
+            }
+            prev[curr.channelId].push(curr.hash);
+            return prev;
+          },
+          {} as Record<string, string[]>,
+        ),
       },
       result: {
         transactions: filteredTxs.reduce((prev, curr) => {

--- a/packages/payment-detection/src/balance-error.ts
+++ b/packages/payment-detection/src/balance-error.ts
@@ -1,7 +1,10 @@
 import { PaymentTypes, ExtensionTypes } from '@requestnetwork/types';
 
 export class BalanceError extends Error {
-  constructor(message: string, public readonly code: PaymentTypes.BALANCE_ERROR_CODE) {
+  constructor(
+    message: string,
+    public readonly code: PaymentTypes.BALANCE_ERROR_CODE,
+  ) {
     super(message);
   }
 }

--- a/packages/payment-detection/src/types.ts
+++ b/packages/payment-detection/src/types.ts
@@ -67,27 +67,29 @@ export interface IEventRetriever<
 
 /** Object interface to list the payment network module by id */
 export type IPaymentNetworkModuleByType<
-  TPaymentEventParameters extends PaymentTypes.GenericEventParameters = PaymentTypes.GenericEventParameters,
+  TPaymentEventParameters extends
+    PaymentTypes.GenericEventParameters = PaymentTypes.GenericEventParameters,
 > = Partial<
   Record<
     ExtensionTypes.PAYMENT_NETWORK_ID,
-    new (...pnParams: any) => PaymentDetectorBase<
-      ExtensionTypes.IExtension,
-      TPaymentEventParameters
-    >
+    new (
+      ...pnParams: any
+    ) => PaymentDetectorBase<ExtensionTypes.IExtension, TPaymentEventParameters>
   >
 >;
 
 /** Object interface to list the payment network module by network */
 export interface ISupportedPaymentNetworkByNetwork<
-  TPaymentEventParameters extends PaymentTypes.GenericEventParameters = PaymentTypes.GenericEventParameters,
+  TPaymentEventParameters extends
+    PaymentTypes.GenericEventParameters = PaymentTypes.GenericEventParameters,
 > {
   [network: string]: IPaymentNetworkModuleByType<TPaymentEventParameters>;
 }
 
 /** Object interface to list the payment network id and its module by currency */
 export interface ISupportedPaymentNetworkByCurrency<
-  TPaymentEventParameters extends PaymentTypes.GenericEventParameters = PaymentTypes.GenericEventParameters,
+  TPaymentEventParameters extends
+    PaymentTypes.GenericEventParameters = PaymentTypes.GenericEventParameters,
 > {
   [currency: string]: ISupportedPaymentNetworkByNetwork<TPaymentEventParameters>;
 }

--- a/packages/payment-processor/test/payment/shared.ts
+++ b/packages/payment-processor/test/payment/shared.ts
@@ -16,6 +16,6 @@ export const currencyManager = new CurrencyManager([
         decimals: 18,
         symbol: 'ERC20_' + i,
         type: RequestLogicTypes.CURRENCY.ERC20,
-      } as CurrencyDefinition),
+      }) as CurrencyDefinition,
   ),
 ]);

--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -79,9 +79,8 @@ export default class RequestNetwork {
     parameters: Types.ICreateRequestParameters,
     options?: Types.ICreateRequestOptions,
   ): Promise<Request> {
-    const { requestParameters, topics, paymentNetwork } = await this.prepareRequestParameters(
-      parameters,
-    );
+    const { requestParameters, topics, paymentNetwork } =
+      await this.prepareRequestParameters(parameters);
 
     const requestLogicCreateResult = await this.requestLogic.createRequest(
       requestParameters,
@@ -123,9 +122,8 @@ export default class RequestNetwork {
     encryptionParams: EncryptionTypes.IEncryptionParameters[],
     options?: Types.ICreateRequestOptions,
   ): Promise<Request> {
-    const { requestParameters, topics, paymentNetwork } = await this.prepareRequestParameters(
-      parameters,
-    );
+    const { requestParameters, topics, paymentNetwork } =
+      await this.prepareRequestParameters(parameters);
 
     const requestLogicCreateResult = await this.requestLogic.createEncryptedRequest(
       requestParameters,

--- a/packages/request-client.js/test/index-encryption.html
+++ b/packages/request-client.js/test/index-encryption.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <title>@requestnetwork/request-client.js Test Page</title>

--- a/packages/request-client.js/test/index-metamask.html
+++ b/packages/request-client.js/test/index-metamask.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <title>@requestnetwork/request-client.js Test Page</title>

--- a/packages/request-client.js/test/index-persist-from-metamask.html
+++ b/packages/request-client.js/test/index-persist-from-metamask.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <title>@requestnetwork/request-client.js Test Page</title>

--- a/packages/request-client.js/test/index.html
+++ b/packages/request-client.js/test/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <title>@requestnetwork/request-client.js Test Page</title>

--- a/packages/request-logic/specs/example/example.ts
+++ b/packages/request-logic/specs/example/example.ts
@@ -40,7 +40,7 @@ async function foo(): Promise<void> {
       ({
         [aliceRaw.identity.value as string]: sign(data, aliceRaw.signatureParams),
         [bobRaw.identity.value as string]: sign(data, bobRaw.signatureParams),
-      }[identity.value]),
+      })[identity.value],
     supportedIdentityTypes: [IdentityTypes.TYPE.ETHEREUM_ADDRESS],
     supportedMethods: [SignatureTypes.METHOD.ECDSA],
   };

--- a/packages/request-logic/src/request-logic.ts
+++ b/packages/request-logic/src/request-logic.ts
@@ -503,23 +503,26 @@ export default class RequestLogic implements RequestLogicTypes.IRequestLogic {
     // second parameter is null, because the first action must be a creation (no state expected)
     const confirmedRequestState = transactions
       .filter((action) => action.state === TransactionTypes.TransactionState.CONFIRMED)
-      .reduce((requestState, actionConfirmed) => {
-        try {
-          return RequestLogicCore.applyActionToRequest(
-            requestState,
-            actionConfirmed.action,
-            actionConfirmed.timestamp,
-            this.advancedLogic,
-          );
-        } catch (e) {
-          // if an error occurs while applying we ignore the action
-          ignoredTransactionsByApplication.push({
-            reason: e.message,
-            transaction: actionConfirmed,
-          });
-          return requestState;
-        }
-      }, null as RequestLogicTypes.IRequest | null);
+      .reduce(
+        (requestState, actionConfirmed) => {
+          try {
+            return RequestLogicCore.applyActionToRequest(
+              requestState,
+              actionConfirmed.action,
+              actionConfirmed.timestamp,
+              this.advancedLogic,
+            );
+          } catch (e) {
+            // if an error occurs while applying we ignore the action
+            ignoredTransactionsByApplication.push({
+              reason: e.message,
+              transaction: actionConfirmed,
+            });
+            return requestState;
+          }
+        },
+        null as RequestLogicTypes.IRequest | null,
+      );
 
     const pendingRequestState = transactions
       .filter((action) => action.state === TransactionTypes.TransactionState.PENDING)
@@ -666,9 +669,8 @@ export default class RequestLogic implements RequestLogicTypes.IRequestLogic {
     requestId: RequestLogicTypes.RequestId,
     action: RequestLogicTypes.IAction,
   ): Promise<void> {
-    const { confirmedRequestState, pendingRequestState } = await this.computeRequestFromRequestId(
-      requestId,
-    );
+    const { confirmedRequestState, pendingRequestState } =
+      await this.computeRequestFromRequestId(requestId);
 
     try {
       // Check if the action doesn't fail with the request state

--- a/packages/request-logic/test/unit/utils/test-data-generator.ts
+++ b/packages/request-logic/test/unit/utils/test-data-generator.ts
@@ -283,7 +283,7 @@ export const fakeSignatureProvider: SignatureProviderTypes.ISignatureProvider = 
       [payeeRaw.address as string]: sign(data, payeeRaw.signatureParams),
       [payerRaw.address as string]: sign(data, payerRaw.signatureParams),
       [otherIdRaw.address as string]: sign(data, otherIdRaw.signatureParams),
-    }[identity.value]),
+    })[identity.value],
   supportedIdentityTypes: [IdentityTypes.TYPE.ETHEREUM_ADDRESS],
   supportedMethods: [SignatureTypes.METHOD.ECDSA],
 };

--- a/packages/request-node/src/request/getChannelsByTopic.ts
+++ b/packages/request-node/src/request/getChannelsByTopic.ts
@@ -3,7 +3,10 @@ import { Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
 export default class GetChannelHandler {
-  constructor(private logger: LogTypes.ILogger, private dataAccess: DataAccessTypes.IDataRead) {
+  constructor(
+    private logger: LogTypes.ILogger,
+    private dataAccess: DataAccessTypes.IDataRead,
+  ) {
     this.handler = this.handler.bind(this);
   }
 

--- a/packages/request-node/src/request/getConfirmedTransactionHandler.ts
+++ b/packages/request-node/src/request/getConfirmedTransactionHandler.ts
@@ -4,7 +4,10 @@ import { StatusCodes } from 'http-status-codes';
 import ConfirmedTransactionStore from './confirmedTransactionStore';
 
 export default class getConfirmedTransactionHandler {
-  constructor(private logger: LogTypes.ILogger, private store: ConfirmedTransactionStore) {
+  constructor(
+    private logger: LogTypes.ILogger,
+    private store: ConfirmedTransactionStore,
+  ) {
     this.handler = this.handler.bind(this);
   }
 

--- a/packages/request-node/src/request/getStatus.ts
+++ b/packages/request-node/src/request/getStatus.ts
@@ -14,7 +14,10 @@ const packageJson = require('../../package.json');
  * @param dataAccess data access layer
  */
 export default class GetStatusHandler {
-  constructor(private logger: LogTypes.ILogger, private dataAccess: DataAccessTypes.IDataAccess) {
+  constructor(
+    private logger: LogTypes.ILogger,
+    private dataAccess: DataAccessTypes.IDataAccess,
+  ) {
     this.handler = this.handler.bind(this);
   }
   async handler(clientRequest: Request, serverResponse: Response): Promise<void> {

--- a/packages/request-node/src/request/getTransactionsByChannelId.ts
+++ b/packages/request-node/src/request/getTransactionsByChannelId.ts
@@ -3,7 +3,10 @@ import { Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
 export default class GetTransactionsByChannelIdHandler {
-  constructor(private logger: LogTypes.ILogger, private dataAccess: DataAccessTypes.IDataRead) {
+  constructor(
+    private logger: LogTypes.ILogger,
+    private dataAccess: DataAccessTypes.IDataRead,
+  ) {
     this.handler = this.handler.bind(this);
   }
 

--- a/packages/request-node/src/request/ipfsAdd.ts
+++ b/packages/request-node/src/request/ipfsAdd.ts
@@ -13,7 +13,10 @@ import { getPersistTransactionTimeout } from '../config';
  * @param dataAccess data access layer
  */
 export default class IpfsAddHandler {
-  constructor(private logger: LogTypes.ILogger, private ipfsStorage: StorageTypes.IIpfsStorage) {
+  constructor(
+    private logger: LogTypes.ILogger,
+    private ipfsStorage: StorageTypes.IIpfsStorage,
+  ) {
     this.handler = this.handler.bind(this);
   }
 

--- a/packages/request-node/src/request/persistTransaction.ts
+++ b/packages/request-node/src/request/persistTransaction.ts
@@ -88,10 +88,10 @@ export default class PersistTransactionHandler {
         );
         this.logger.error(`persistTransaction error: ${e}\n
           transactionHash: ${transactionHash.value}, channelId: ${
-          clientRequest.body.channelId
-        }, topics: ${clientRequest.body.topics}, transactionData: ${JSON.stringify(
-          clientRequest.body.transactionData,
-        )}`);
+            clientRequest.body.channelId
+          }, topics: ${clientRequest.body.topics}, transactionData: ${JSON.stringify(
+            clientRequest.body.transactionData,
+          )}`);
       });
 
       this.logger.debug(`persistTransaction successfully completed`, ['metric', 'successRate']);

--- a/packages/smart-contracts/scripts/deploy-payments.ts
+++ b/packages/smart-contracts/scripts/deploy-payments.ts
@@ -315,9 +315,8 @@ export async function deployAllPaymentContracts(
     );
 
     // Batch 4
-    const { chainlinkInstance, ethConversionResult } = await runDeploymentBatch_4(
-      ethFeeProxyAddress,
-    );
+    const { chainlinkInstance, ethConversionResult } =
+      await runDeploymentBatch_4(ethFeeProxyAddress);
 
     // Batch 5
     await runDeploymentBatch_5(

--- a/packages/smart-contracts/src/lib/ContractArtifact.ts
+++ b/packages/smart-contracts/src/lib/ContractArtifact.ts
@@ -34,7 +34,10 @@ export type DeploymentInformation = {
  * and utilities to connect to it
  **/
 export class ContractArtifact<TContract extends Contract> {
-  constructor(private info: ArtifactInfo, private lastVersion: string) {
+  constructor(
+    private info: ArtifactInfo,
+    private lastVersion: string,
+  ) {
     this.connect = this.connect.bind(this);
     this.getInterface = this.getInterface.bind(this);
     this.getContractAbi = this.getContractAbi.bind(this);

--- a/yarn.lock
+++ b/yarn.lock
@@ -17811,15 +17811,10 @@ prettier-plugin-solidity@1.0.0-beta.19:
     solidity-comments-extractor "^0.0.7"
     string-width "^4.2.3"
 
-prettier@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz"
-  integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
-
-prettier@2.8.6:
-  version "2.8.6"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-2.8.6.tgz"
-  integrity sha512-mtuzdiBbHwPEgl7NxWlqOkithPyp4VN93V7VeHVWBF+ad3I5avc0RVDT4oImXQy9H/AqxA2NSQH8pSxHW6FYbQ==
+prettier@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
 
 prettier@^1.14.3:
   version "1.19.1"


### PR DESCRIPTION
## Description of the changes

The file `.yarn/releases/yarn-1.22.19.cjs` is slow to format, we should just ignore it.
To do so, and without unlinking `.prettierignore` from `.gitignore`, we can use prettier's new configuration override feature.

## Description of the changes

- updated `prettier` (+ removed prettier from `packages/currency/package.json`, it should only be at the top level `package.json`)
- modified `.prettierrc` to ignore the yarn release file
- ran `yarn format`