### PR TITLE
chore(toolbox): sepolia and fix double transaction

### DIFF
--- a/packages/currency/src/erc20/chains/index.ts
+++ b/packages/currency/src/erc20/chains/index.ts
@@ -13,6 +13,7 @@ import { supportedMoonbeamERC20 } from './moonbeam';
 import { supportedOptimismERC20 } from './optimism';
 import { supportedRinkebyERC20 } from './rinkeby';
 import { supportedXDAIERC20 } from './xdai';
+import { supportedSepoliaERC20 } from './sepolia';
 
 export const supportedNetworks: Partial<Record<CurrencyTypes.EvmChainName, TokenMap>> = {
   celo: supportedCeloERC20,
@@ -28,4 +29,5 @@ export const supportedNetworks: Partial<Record<CurrencyTypes.EvmChainName, Token
   avalanche: supportedAvalancheERC20,
   optimism: supportedOptimismERC20,
   moonbeam: supportedMoonbeamERC20,
+  sepolia: supportedSepoliaERC20,
 };

--- a/packages/toolbox/src/commands/chainlink/contractUtils.ts
+++ b/packages/toolbox/src/commands/chainlink/contractUtils.ts
@@ -16,11 +16,11 @@ export const runUpdate = async <T extends 'updateAggregator' | 'updateAggregator
 
   for (const { version, contract } of contractsWithVersion) {
     console.log(
-      `${dryRunText} will call ${method} on chainlinkConversionPath version ${version} at ${contract.address} (${args.network}))`,
+      `${dryRunText}will call ${method} on chainlinkConversionPath version ${version} at ${contract.address} (${args.network}))`,
     );
     console.log(JSON.stringify(params));
     if (args.dryRun) {
-      process.exit();
+      continue;
     }
     // TS hack to fix params type
     const neverParams = params as [never, never, never];
@@ -94,7 +94,8 @@ const connectChainlinkContracts = ({
   }
   const versions = chainlinkConversionPath
     .getAllAddresses(network)
-    .filter((x) => !!x.address)
+    // keep only versions with index, and remove duplicates (different versions can have same address for retro compatiblity)
+    .filter((x, i, self) => !!x.address && self.findIndex((y) => y.address === x.address) === i)
     .map((x) => x.version);
 
   return versions.map((version) => {

--- a/packages/utils/src/providers.ts
+++ b/packages/utils/src/providers.ts
@@ -51,6 +51,7 @@ const networkRpcs: Record<string, string> = {
   core: 'https://rpc.coredao.org/',
   zksynceratestnet: 'https://testnet.era.zksync.dev',
   zksyncera: 'https://mainnet.era.zksync.io',
+  sepolia: 'https://rpc.sepolia.org/',
 };
 
 /**


### PR DESCRIPTION
- adding a default RPC for sepolia
- fixing double transactions, when contract versions have the same address (this is a hack so that requests can have PN version 2.0 or 2.1)
- add sepolia to default currency list