### PR TITLE
chore: add safe admins

### DIFF
--- a/packages/smart-contracts/scripts-create2/contract-setup/execute-contract-method.ts
+++ b/packages/smart-contracts/scripts-create2/contract-setup/execute-contract-method.ts
@@ -11,7 +11,7 @@ const txServiceUrls: Record<string, string> = {
   sepolia: 'https://safe-transaction-sepolia.safe.global/',
   matic: 'https://safe-transaction-polygon.safe.global/',
   celo: 'https://safe-transaction-celo.safe.global/',
-  xsai: 'https://safe-transaction-gnosis-chain.safe.global/',
+  xdai: 'https://safe-transaction-gnosis-chain.safe.global/',
   bsc: 'https://safe-transaction-bsc.safe.global/',
   'arbitrum-one': 'https://safe-transaction-arbitrum.safe.global/',
   avalanche: 'https://safe-transaction-avalanche.safe.global/',
@@ -36,13 +36,9 @@ export const executeContractMethod = async ({
   signer: Wallet;
   signWithEoa?: boolean;
 }): Promise<void> => {
-  if (!signWithEoa) {
-    const safeAddress = safeAdminArtifact.getAddress(network as CurrencyTypes.VMChainName);
-    const txServiceUrl = txServiceUrls[network];
-    if (!safeAddress || !txServiceUrl) {
-      throw new Error(`Can't administrate using Safe on ${network}`);
-    }
-
+  const safeAddress = safeAdminArtifact.getAddress(network as CurrencyTypes.VMChainName);
+  const txServiceUrl = txServiceUrls[network];
+  if (!signWithEoa && !!safeAddress && !!txServiceUrl) {
     const ethAdapter = new EthersAdapter({
       ethers,
       signerOrProvider: signer,

--- a/packages/smart-contracts/src/lib/artifacts/Admin/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/Admin/index.ts
@@ -32,19 +32,19 @@ export const safeAdminArtifact = new ContractArtifact<any>(
           creationBlockNumber: 1,
         },
         optimism: {
-          address: 'oeth:0xDF593767a0b42C641845e026F898f9C465d1E714',
+          address: '0xDF593767a0b42C641845e026F898f9C465d1E714',
           creationBlockNumber: 1,
         },
         zksyncera: {
-          address: 'zksync:0xC93edf2722d17d423bCd630CBB9384Cd629890f3',
+          address: '0xC93edf2722d17d423bCd630CBB9384Cd629890f3',
           creationBlockNumber: 1,
         },
         celo: {
-          address: 'celo:0x7eF1DC5317Dd6Fd258766A1B620930c2DD8A54A8',
+          address: '0x7eF1DC5317Dd6Fd258766A1B620930c2DD8A54A8',
           creationBlockNumber: 1,
         },
         avalanche: {
-          address: 'avax:0xAb05E8277c2c605D2762F6e3B6175Cab954fC8e8',
+          address: '0xAb05E8277c2c605D2762F6e3B6175Cab954fC8e8',
           creationBlockNumber: 1,
         },
       },

--- a/packages/smart-contracts/src/lib/artifacts/Admin/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/Admin/index.ts
@@ -12,11 +12,39 @@ export const safeAdminArtifact = new ContractArtifact<any>(
       abi: ABI_0_1_0,
       deployment: {
         mainnet: {
-          address: '0x8b138Eb490aBbbB11B8AD6Ae127E7ceBff7E848D',
+          address: '0xBB428798fD43431b224aF319013A8740B47f962b',
           creationBlockNumber: 1,
         },
         matic: {
-          address: '0xC8cBFf73a29a2c7D9280955B266ffe2BA77d77Ba',
+          address: '0x8d188533F7eD39fe355458A5d4766A9cE9C8071B',
+          creationBlockNumber: 1,
+        },
+        xdai: {
+          address: '0x8a4D2659f6d24312804BFA2f1F174A5498948037',
+          creationBlockNumber: 1,
+        },
+        bsc: {
+          address: '0x67817a094599cD73D64495509F1c3C24d0f2C4DB',
+          creationBlockNumber: 1,
+        },
+        'arbitrum-one': {
+          address: '0xC806e694FDB31Ce879B08c29b3Ba4127122A3524',
+          creationBlockNumber: 1,
+        },
+        optimism: {
+          address: 'oeth:0xDF593767a0b42C641845e026F898f9C465d1E714',
+          creationBlockNumber: 1,
+        },
+        zksyncera: {
+          address: 'zksync:0xC93edf2722d17d423bCd630CBB9384Cd629890f3',
+          creationBlockNumber: 1,
+        },
+        celo: {
+          address: 'celo:0x7eF1DC5317Dd6Fd258766A1B620930c2DD8A54A8',
+          creationBlockNumber: 1,
+        },
+        avalanche: {
+          address: 'avax:0xAb05E8277c2c605D2762F6e3B6175Cab954fC8e8',
           creationBlockNumber: 1,
         },
       },


### PR DESCRIPTION
## Description of the changes

Add Safes for RN administration on supported chains.

TBD:
- Finalize the list of admins 
- Update the signature threshol to 3
- Transfer the ownership of the contracts to the Safes

#### Additional update

By default, if an update on a specific network is not possible via Safe, fallback to EOA.
