### PR TITLE
Replicate incident where request node stopped submitting transactions

### DIFF
--- a/packages/request-node/test/persistTransaction.test.ts
+++ b/packages/request-node/test/persistTransaction.test.ts
@@ -94,7 +94,7 @@ describe('persistTransaction', () => {
     await Promise.all(assertions);
   });
 
-  it('should work twice in a row even after a transaction is rejected by the RPC', async () => {
+  it('should return 200 on the second call, even after a transaction is rejected by the RPC', async () => {
     axiosMock.reset();
     axiosMock.onAny().reply((req) => {
       if (req.data.body?.includes('eth_sendTransaction')) {


### PR DESCRIPTION
Investigation for https://github.com/RequestNetwork/private-issues/issues/57

## Description of the changes

* Add test that replicates the error:
`[14:47:35] ERROR: persistTransaction error: Error: processing response error (body="{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32010,\"message\":\"FeeTooLow, EffectivePriorityFeePerGas too low 513061393 < 1000000000, BaseFee: 20101010505\"},\"id\":3939}", error={"code":-32010}, requestBody="{\"method\":\"eth_sendRawTransaction\",\"params\":[\"0x02f9015b6483014c3a84773594008504ccb1c65a82d08f94268c146afb4790902ee26a6d2d3aff968623ec80880162ea854d0fc000b8e451a58abb000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000002e516d516231515a4e336b6756373573766579516d79684850344552416d3873747a6a4c685232433273506b64655300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000626c080a054094bc2faac3a8a216de4f4a34b2936d5f4027f93f08f10546847dd8166a644a00dd6feae39e6beb144c4ed212a7b56da9bf40724968c029adf2679fc559b43f3\"],\"id\":3939,\"jsonrpc\":\"2.0\"}", requestMethod="POST", url="<omitted>", code=SERVER_ERROR, version=web/5.5.0) `