### PR TITLE
fix: Remove NonceManager

### DIFF
--- a/packages/request-node/src/dataAccess.ts
+++ b/packages/request-node/src/dataAccess.ts
@@ -1,5 +1,4 @@
 import { providers, Wallet } from 'ethers';
-import { NonceManager } from '@ethersproject/experimental';
 import { CurrencyTypes, DataAccessTypes, LogTypes, StorageTypes } from '@requestnetwork/types';
 
 import * as config from './config';
@@ -18,7 +17,7 @@ export function getDataAccess(
     new providers.StaticJsonRpcProvider(config.getStorageWeb3ProviderUrl()),
   );
 
-  const signer = new NonceManager(wallet);
+  const signer = wallet;
 
   const gasPriceMin = config.getGasPriceMin();
   const blockConfirmations = config.getBlockConfirmations();


### PR DESCRIPTION
## Description of the changes

* Remove the `NonceManager` from the Request Node

## Motivation
(Copied from https://github.com/RequestNetwork/marble/pull/105 written by @alexandre-abrioux)

The `NonceManager` does not handle catching errors from the RPC.

When the RPC refuses a transaction, because for instance:

* the transaction gas fees are too low for the RPC to accept it
* or the RPC times out

; then an error is thrown and not handled by the `NonceManager`. In that case, the `NonceManager` still increases its internal counter.

Since the initial transaction was never persisted on-chain, the following transactions are never picked up by the network because their nonce is too high.

More sources:
In ethers.js documentation https://docs.ethers.org/v5/api/experimental/#experimental-noncemanager

> Currently the NonceManager does not handle re-broadcast. If you attempt to send a lot of transactions to the network on a node that does not control that account, the transaction pool may drop your transactions.

> In the future, it'd be nice if the NonceManager remembered transactions and watched for them on the network, rebroadcasting transactions that appear to have been dropped.

In ethers.js code (latest version, v6, not the version we use): https://github.com/ethers-io/ethers.js/blob/v6.9.0/src.ts/providers/signer-noncemanager.ts#L82
there is this comment:

```ts
// @todo: Maybe handle interesting/recoverable errors?
// Like don't increment if the tx was certainly not sent
```

This is the code for the currently used version of ethers.js (v5): https://github.com/ethers-io/ethers.js/blob/v5.5.1/packages/experimental/src.ts/nonce-manager.ts

Additionally, I suspect that the "OldNonce" error was also caused by the `NonceManager`.
Fixes #1292 