### PR TITLE
fix: add `gasPriceMax` and `gasPriceMultiplier` to the Request Node config

### DIFF
--- a/packages/request-node/src/config.ts
+++ b/packages/request-node/src/config.ts
@@ -112,7 +112,7 @@ export function getGasPriceMax(): BigNumber | undefined {
   return gasPriceMax ? BigNumber.from(gasPriceMax) : undefined;
 }
 
-export const getGasPriceMultiplier = getOption(
+export const getGasPriceMultiplier = makeOption(
   'gasPriceMultiplier',
   'GAS_PRICE_MULTIPLIER',
   defaultValues.storage.ethereum.gasPriceMultiplier,

--- a/packages/request-node/src/config.ts
+++ b/packages/request-node/src/config.ts
@@ -20,7 +20,10 @@ const defaultValues = {
     ethereum: {
       networkId: 0,
       web3ProviderUrl: 'http://localhost:8545',
-      gasPriceMin: '1000000000', // one gwei
+      gasPriceMin: '1000000000', // 1 gwei per gas
+      gasPriceMax: '1000000000000', // 1000 gwei per gas
+      // multiply by 2 the estimated max fee per gas to accomadate for volatility
+      gasPriceMultiplier: '200',
       blockConfirmations: 2,
     },
     ipfs: {
@@ -98,6 +101,24 @@ export function getGasPriceMin(): BigNumber | undefined {
     defaultValues.storage.ethereum.gasPriceMin,
   );
   return gasPriceMin ? BigNumber.from(gasPriceMin) : undefined;
+}
+
+export function getGasPriceMax(): BigNumber | undefined {
+  const gasPriceMax = getOption(
+    'gasPriceMax',
+    'GAS_PRICE_MAX',
+    defaultValues.storage.ethereum.gasPriceMax,
+  );
+  return gasPriceMax ? BigNumber.from(gasPriceMax) : undefined;
+}
+
+export function getGasPriceMultiplier(): BigNumber | undefined {
+  const gasPriceMultiplier = getOption(
+    'gasPriceMultiplier',
+    'GAS_PRICE_MULTIPLIER',
+    defaultValues.storage.ethereum.gasPriceMultiplier,
+  );
+  return gasPriceMultiplier ? BigNumber.from(gasPriceMultiplier) : undefined;
 }
 
 /**
@@ -186,7 +207,7 @@ export function getHelpMessage(): string {
         })\t\t\t\tCustom headers to send with the API responses
 
       THE GRAPH OPTIONS
-        graphNodeUrl (${defaultValues.storage.thegraph.nodeUrl})\t\t\t\t
+        graphNodeUrl (${defaultValues.storage.thegraph.nodeUrl})\t\t\t\tURL of the Graph node
 
       ETHEREUM OPTIONS
         networkId (${
@@ -195,6 +216,18 @@ export function getHelpMessage(): string {
         providerUrl (${
           defaultValues.storage.ethereum.web3ProviderUrl
         })\tUrl of the web3 provider for Ethereum
+        gasPriceMin (${
+          defaultValues.storage.ethereum.gasPriceMin
+        })\t\t\t\tMinimum value for maxPriorityFeePerGas and maxFeePerGas
+        gasPriceMax (${
+          defaultValues.storage.ethereum.gasPriceMax
+        })\t\t\t\tMaximum value for maxFeePerGas
+        gasPriceMultiplier (${
+          defaultValues.storage.ethereum.gasPriceMultiplier
+        })\t\t\t\tMultiplier for the computed maxFeePerGas
+        blockConfirmations (${
+          defaultValues.storage.ethereum.blockConfirmations
+        })\t\t\t\tNumber of block confirmations to wait before considering a transaction successful
 
       IPFS OPTIONS
         ipfsUrl (${defaultValues.storage.ipfs.url})\t\t\tURL of the IPFS gateway

--- a/packages/request-node/src/config.ts
+++ b/packages/request-node/src/config.ts
@@ -21,7 +21,7 @@ const defaultValues = {
       networkId: 0,
       web3ProviderUrl: 'http://localhost:8545',
       gasPriceMin: '1000000000', // 1 gwei per gas
-      gasPriceMax: '1000000000000', // 1000 gwei per gas
+      gasPriceMax: '10000000000000', // 10,000 gwei per gas
       // multiply by 2 the estimated max fee per gas to accomadate for volatility
       gasPriceMultiplier: '200',
       blockConfirmations: 2,

--- a/packages/request-node/src/config.ts
+++ b/packages/request-node/src/config.ts
@@ -23,7 +23,7 @@ const defaultValues = {
       gasPriceMin: '1000000000', // 1 gwei per gas
       gasPriceMax: '10000000000000', // 10,000 gwei per gas
       // multiply by 2 the estimated max fee per gas to accomadate for volatility
-      gasPriceMultiplier: '200',
+      gasPriceMultiplier: 200,
       blockConfirmations: 2,
     },
     ipfs: {
@@ -112,14 +112,11 @@ export function getGasPriceMax(): BigNumber | undefined {
   return gasPriceMax ? BigNumber.from(gasPriceMax) : undefined;
 }
 
-export function getGasPriceMultiplier(): BigNumber | undefined {
-  const gasPriceMultiplier = getOption(
-    'gasPriceMultiplier',
-    'GAS_PRICE_MULTIPLIER',
-    defaultValues.storage.ethereum.gasPriceMultiplier,
-  );
-  return gasPriceMultiplier ? BigNumber.from(gasPriceMultiplier) : undefined;
-}
+export const getGasPriceMultiplier = getOption(
+  'gasPriceMultiplier',
+  'GAS_PRICE_MULTIPLIER',
+  defaultValues.storage.ethereum.gasPriceMultiplier,
+);
 
 /**
  * Get the number of block confirmations to wait before considering a transaction successful

--- a/packages/request-node/src/dataAccess.ts
+++ b/packages/request-node/src/dataAccess.ts
@@ -21,8 +21,17 @@ export function getDataAccess(
   const signer = new NonceManager(wallet);
 
   const gasPriceMin = config.getGasPriceMin();
+  const gasPriceMax = config.getGasPriceMax();
+  const gasPriceMultiplier = config.getGasPriceMultiplier();
   const blockConfirmations = config.getBlockConfirmations();
-  const txSubmitter = new EthereumTransactionSubmitter({ network, logger, gasPriceMin, signer });
+  const txSubmitter = new EthereumTransactionSubmitter({
+    network,
+    logger,
+    gasPriceMin,
+    gasPriceMax,
+    gasPriceMultiplier,
+    signer,
+  });
   const pendingStore = new PendingStore();
   const storage = new EthereumStorage({
     ipfsStorage,


### PR DESCRIPTION
## Description of the changes

* fix: add `gasPriceMax` and `gasPriceMultiplier` to the Request Node config

## Motivation
(Copied with minor edits from https://github.com/RequestNetwork/marble/pull/141, written by @alexandre-abrioux)

This PR was made possible thanks to https://github.com/RequestNetwork/requestNetwork/pull/1318, and should fix the following issue that we get from time to time while persisting transactions on-chain:

> FeeTooLow, EffectivePriorityFeePerGas too low 806006831 < 1000000000, BaseFee: 23667261698

## Origin of the issue
There is also more info on why the `gasPriceMultiplier` was introduced in the protocol https://github.com/RequestNetwork/requestNetwork/pull/1318#discussion_r1447581135.

## Practical example
When submitting a transaction with the following EIP-1559 parameters:

```
 2,000,000,000 wei (= 2 Gwei)  for the maxPriorityFeePerGas (given to validators)
24,473,268,529 wei (= 24 Gwei) for the maxFeePerGas (total max per gas)
```
; we are assuming that the `baseFeePerGas` of the next block (when the transaction will be included) will be `24 - 2 = 22 Gwei`.

But, if our estimation is wrong, and the actual `baseFeePerGas` of the next block is `23.5 Gwei` for instance, then the remaining priority fee for validators will be `24 - 23.5 = 0.5 Gwei`. Or, [in the code of Neithermind](https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Consensus/Transactions/MinGasPriceTxFilter.cs#L51) (execution client), there is a hardcoded minimum limit of `1 Gwei` for the priority fee. Quicknode uses that execution client. In this case, the transaction will not be accepted by the client.

## Solution
Let's always multiply by two the `maxFeePerGas`. In this case, the transaction would be submitted with the following parameters:
```
 2,000,000,000 wei (= 2 Gwei)  for the maxPriorityFeePerGas (given to validators)
48,...,...,... wei (= 48 Gwei) for the maxFeePerGas (total max per gas)
```
; and we would not encounter that issue. We will not pay more gas, as the `maxPriorityFee` is still defined in the same way, and the `baseFeePerGas` is defined by the network and cannot be cheated when including a block.

To do so, we introduce a new environment variable `GAS_PRICE_MULTIPLIER`.

## Bonus
To protect ourselves against gas price spikes, we also introduce `GAS_PRICE_MAX`. This will limit the `maxFeePerGas` value to a certain amount. In case this ever happens, our transactions might get delayed for a bit until the frenzy of "insert new NFT protocol" slows down and the network goes back to normal. The current default is `10,000 Gwei` per gas or about $0.53345 per transaction on Gnosis