### PR TITLE
fix: lerna publish error

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,5 @@
   "lerna": "3.2.1",
   "packages": ["packages/*"],
   "version": "independent",
-  "npmClient": "yarn",
-  "useWorkspaces": true
+  "npmClient": "yarn"
 }


### PR DESCRIPTION
## Description of the changes

* Remove `useWorkspaces: true` from `lerna.json`

# Error

```
lerna ERR! ECONFIGWORKSPACES The "useWorkspaces" option has been removed. By default lerna will resolve your packages using your package manager's workspaces configuration. Alternatively, you can manually provide a list of package globs to be used instead via the "packages" option in lerna.json.
```