### PR TITLE
chore(security): remove ipfs-unixfs

### DIFF
--- a/packages/ethereum-storage/package.json
+++ b/packages/ethereum-storage/package.json
@@ -46,7 +46,6 @@
     "@requestnetwork/utils": "0.40.0",
     "ethers": "5.5.1",
     "form-data": "3.0.0",
-    "ipfs-unixfs": "6.0.7",
     "qs": "6.11.2",
     "shelljs": "0.8.5",
     "tslib": "2.5.0",

--- a/packages/ethereum-storage/src/ipfs-manager.ts
+++ b/packages/ethereum-storage/src/ipfs-manager.ts
@@ -1,4 +1,3 @@
-import { UnixFS } from 'ipfs-unixfs';
 import * as qs from 'qs';
 import { LogTypes, StorageTypes } from '@requestnetwork/types';
 
@@ -144,30 +143,6 @@ export default class IpfsManager {
   }
 
   /**
-   * Retrieve content from ipfs from its hash
-   * @param hash Hash of the content
-   * @returns Promise resolving retrieved ipfs object
-   */
-  public async read(hash: string): Promise<StorageTypes.IIpfsObject> {
-    try {
-      const response = await this.ipfs('object/get', {
-        params: { arg: hash, 'data-encoding': 'base64' },
-      });
-      if (response.Type === 'error') {
-        throw new Error(response.Message);
-      }
-      const ipfsDataBuffer = Buffer.from(response.Data, 'base64');
-      const content = IpfsManager.getContentFromMarshaledData(ipfsDataBuffer);
-      const ipfsSize = ipfsDataBuffer.length;
-      const ipfsLinks = response.Links;
-      return { content, ipfsSize, ipfsLinks };
-    } catch (e) {
-      this.logger.error(`Failed to read IPFS file: ${e.message}`, ['ipfs']);
-      throw e;
-    }
-  }
-
-  /**
    * Pin content on ipfs node from its hash
    * @param hashes Array of hashes of the content
    * @param [timeout] An optional timeout for the IPFS pin request
@@ -240,16 +215,5 @@ export default class IpfsManager {
       id: await this.getIpfsNodeId(),
       maxRetries: this.ipfsErrorHandling.maxRetries,
     };
-  }
-
-  /**
-   * Removes the Unicode special characters from an IPFS content
-   * @param marshaledData marshaled data
-   * @returns the content without the padding
-   */
-  private static getContentFromMarshaledData(marshaledData: Buffer): string {
-    const { data } = UnixFS.unmarshal(marshaledData);
-    if (!data) throw new Error('Cannot unmarshal data');
-    return data.toString();
   }
 }

--- a/packages/ethereum-storage/test/ipfs-manager.test.ts
+++ b/packages/ethereum-storage/test/ipfs-manager.test.ts
@@ -72,16 +72,6 @@ describe('Ipfs manager', () => {
     expect(pinnedHashes).toMatchObject([hash, hash2]);
   });
 
-  it('allows to read files from ipfs', async () => {
-    await ipfsManager.add(content);
-    let contentReturned = await ipfsManager.read(hash);
-    expect(contentReturned.content).toBe(content);
-
-    await ipfsManager.add(content2);
-    contentReturned = await ipfsManager.read(hash2);
-    expect(contentReturned.content).toBe(content2);
-  });
-
   it('allows to get file size from ipfs', async () => {
     await ipfsManager.add(content);
     let sizeReturned = await ipfsManager.getContentLength(hash);
@@ -101,14 +91,8 @@ describe('Ipfs manager', () => {
     await expect(ipfsManager.getIpfsNodeId()).rejects.toThrowError('getaddrinfo ENOTFOUND');
     await expect(ipfsManager.getBootstrapList()).rejects.toThrowError('getaddrinfo ENOTFOUND');
     await expect(ipfsManager.add(content)).rejects.toThrowError('getaddrinfo ENOTFOUND');
-    await expect(ipfsManager.read(hash)).rejects.toThrowError('getaddrinfo ENOTFOUND');
     await expect(ipfsManager.getContentLength(hash)).rejects.toThrowError('getaddrinfo ENOTFOUND');
   }, 10000);
-
-  it('reading a non-existent hash should throw a timeout error', async () => {
-    await expect(ipfsManager.read(notAddedHash)).rejects.toThrowError('timeout of 1000ms exceeded');
-  });
-
   it('getContentLength on a non-existent hash should throw a timeout error', async () => {
     await expect(ipfsManager.getContentLength(notAddedHash)).rejects.toThrowError(
       'timeout of 1000ms exceeded',
@@ -128,7 +112,7 @@ describe('Ipfs manager', () => {
     );
     mockServer.listen();
 
-    await expect(ipfsManager.read(hash)).rejects.toThrowError('Failed to fetch');
+    await expect(ipfsManager.getContentLength(hash)).rejects.toThrowError('Failed to fetch');
     expect(mock).toHaveBeenCalledTimes(retryTestErrorHandling.maxRetries + 1);
     mockServer.close();
   });
@@ -140,23 +124,5 @@ describe('Ipfs manager', () => {
     });
 
     await expect(ipfsManager.add('test')).rejects.toThrowError('timeout of 1ms exceeded');
-  });
-
-  it('added and read files should have the same size and content', async () => {
-    let content = `{
-  test;
-\ttest again tab
-  spéci@l çhàractêrs
-}`;
-    const lengthyString = '='.repeat(10000);
-    content += lengthyString;
-    const contentSize = Buffer.from(content, 'utf-8').length;
-    const hash = await ipfsManager.add(content);
-    const contentSizeOnIPFS = await ipfsManager.getContentLength(hash);
-    const contentRead = await ipfsManager.read(hash);
-    expect(contentRead.ipfsSize).toEqual(contentSizeOnIPFS);
-    const contentReadSize = Buffer.from(contentRead.content, 'utf-8').length;
-    expect(contentReadSize).toBe(contentSize);
-    expect(contentRead.content).toBe(content);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4520,59 +4520,6 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz"
-  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
-
-"@protobufjs/base64@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz"
-  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
-
-"@protobufjs/codegen@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz"
-  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
-
-"@protobufjs/eventemitter@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz"
-  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
-
-"@protobufjs/fetch@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz"
-  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.1"
-    "@protobufjs/inquire" "^1.1.0"
-
-"@protobufjs/float@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz"
-  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
-
-"@protobufjs/inquire@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz"
-  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
-
-"@protobufjs/path@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz"
-  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
-
-"@protobufjs/pool@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz"
-  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
-
-"@protobufjs/utf8@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
-  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
-
 "@rainbow-me/fee-suggestions@2.1.0":
   version "2.1.0"
   resolved "https://registry.npmjs.org/@rainbow-me/fee-suggestions/-/fee-suggestions-2.1.0.tgz"
@@ -5345,11 +5292,6 @@
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz"
   integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
 
-"@types/long@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz"
-  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
-
 "@types/lru-cache@^5.1.0":
   version "5.1.1"
   resolved "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz"
@@ -5409,11 +5351,6 @@
   version "18.11.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
-
-"@types/node@>=13.7.0":
-  version "17.0.31"
-  resolved "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz"
-  integrity sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==
 
 "@types/node@^12.12.6":
   version "12.20.6"
@@ -10284,11 +10221,6 @@ err-code@^2.0.2:
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
   integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
 
-err-code@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz"
-  integrity sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==
-
 errno@^0.1.3, errno@~0.1.1:
   version "0.1.8"
   resolved "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz"
@@ -13994,14 +13926,6 @@ ipaddr.js@1.9.1:
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
-ipfs-unixfs@6.0.7:
-  version "6.0.7"
-  resolved "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.7.tgz"
-  integrity sha512-5mKbQgvux6n5lQ+upGWWPKcoswXahdOcyGQ2SbIIRV6eBJMzxLprzKsyb0GMsg80tHX2wnNOxBKSCiSGjb+54A==
-  dependencies:
-    err-code "^3.0.1"
-    protobufjs "^6.10.2"
-
 irregular-plurals@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.2.0.tgz"
@@ -16006,11 +15930,6 @@ loglevel@^1.6.4:
   version "1.7.1"
   resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
-
-long@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/long/-/long-4.0.0.tgz"
-  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
 looper@^2.0.0:
   version "2.0.0"
@@ -18862,25 +18781,6 @@ proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
-
-protobufjs@^6.10.2:
-  version "6.11.4"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.4.tgz#29a412c38bf70d89e537b6d02d904a6f448173aa"
-  integrity sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/long" "^4.0.1"
-    "@types/node" ">=13.7.0"
-    long "^4.0.0"
 
 protocols@^2.0.0, protocols@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Resolves https://github.com/advisories/GHSA-mxhp-79qh-mcx6 (not spotted by Github Security vulnerabilities, but visible in GCP docker registry scanner)

`ipfs-unixfs@6.0.7` > `protobufjs@6.11.4` > `taffydb@2.6.2`

We cannot upgrade ipfs-unixfs easily due to a breaking change to drop CJS support. 

`ipfs-unixfs` was only used to read IPFS content, which we don't need anymore, since the indexing is done by the Subgraph