### PR TITLE
fix: isSolvent

### DIFF
--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -195,14 +195,20 @@ export async function swapToPayRequest(
  * @param providerOptions.provider the Web3 provider. Defaults to getDefaultProvider.
  * @param providerOptions.nearWalletConnection the Near WalletConnection
  */
-export async function hasSufficientFunds(
-  request: ClientTypes.IRequestData,
-  address: string,
+export async function hasSufficientFunds({
+  request,
+  address,
+  providerOptions,
+  needsGas = true,
+}: {
+  request: ClientTypes.IRequestData;
+  address: string;
   providerOptions?: {
     provider?: providers.Provider;
     nearWalletConnection?: WalletConnection;
-  },
-): Promise<boolean> {
+  };
+  needsGas?: boolean;
+}): Promise<boolean> {
   const paymentNetwork = getPaymentNetwork(request);
   if (!paymentNetwork || !noConversionNetworks.includes(paymentNetwork)) {
     throw new UnsupportedNetworkError(paymentNetwork);
@@ -219,12 +225,13 @@ export async function hasSufficientFunds(
   ) {
     feeAmount = request.extensions[paymentNetwork].values.feeAmount || 0;
   }
-  return isSolvent(
-    address,
-    request.currencyInfo,
-    BigNumber.from(request.expectedAmount).add(feeAmount),
+  return isSolvent({
+    fromAddress: address,
+    currency: request.currencyInfo,
+    amount: BigNumber.from(request.expectedAmount).add(feeAmount),
     providerOptions,
-  );
+    needsGas,
+  });
 }
 
 /**
@@ -236,15 +243,22 @@ export async function hasSufficientFunds(
  * @param providerOptions.nearWalletConnection the Near WalletConnection
  * @throws UnsupportedNetworkError if network isn't supported
  */
-export async function isSolvent(
-  fromAddress: string,
-  currency: RequestLogicTypes.ICurrency,
-  amount: BigNumberish,
+export async function isSolvent({
+  fromAddress,
+  currency,
+  amount,
+  providerOptions,
+  needsGas = true,
+}: {
+  fromAddress: string;
+  currency: RequestLogicTypes.ICurrency;
+  amount: BigNumberish;
   providerOptions?: {
     provider?: providers.Provider;
     nearWalletConnection?: WalletConnection;
-  },
-): Promise<boolean> {
+  };
+  needsGas?: boolean;
+}): Promise<boolean> {
   // Near case
   if (NearChains.isChainSupported(currency.network) && providerOptions?.nearWalletConnection) {
     return isNearAccountSolvent(amount, providerOptions.nearWalletConnection, currency);
@@ -255,11 +269,6 @@ export async function isSolvent(
   }
   const provider = providerOptions.provider;
   const ethBalance = await provider.getBalance(fromAddress);
-  const needsGas =
-    !(provider as any)?.provider?.safe?.safeAddress &&
-    !['Safe Multisig WalletConnect', 'Gnosis Safe Multisig'].includes(
-      (provider as any)?.provider?.wc?._peerMeta?.name,
-    );
 
   if (currency.type === 'ETH') {
     return ethBalance.gt(amount);

--- a/packages/usage-examples/src/pay-erc20-request.ts
+++ b/packages/usage-examples/src/pay-erc20-request.ts
@@ -20,7 +20,7 @@ const requestNetwork = new RequestNetwork();
 
   const request = await requestNetwork.fromRequestId('REQUEST_ID');
   const requestData = request.getData();
-  if (!(await hasSufficientFunds(requestData, account))) {
+  if (!(await hasSufficientFunds({ request: requestData, address: account }))) {
     throw new Error('You do not have enough funds to pay this request');
   }
   if (!(await hasErc20Approval(requestData, account))) {

--- a/packages/usage-examples/src/pay-eth-request.ts
+++ b/packages/usage-examples/src/pay-eth-request.ts
@@ -14,7 +14,7 @@ const requestNetwork = new RequestNetwork();
 
   const request = await requestNetwork.fromRequestId('REQUEST_ID');
   const requestData = request.getData();
-  if (!(await hasSufficientFunds(requestData, account))) {
+  if (!(await hasSufficientFunds({ request: requestData, address: account }))) {
     throw new Error('You do not have enough funds to pay this request');
   }
   const tx = await payRequest(requestData, wallet);


### PR DESCRIPTION
## Description of the changes

The method `isSolvent` was broken.
```ts
const needsGas =
    !(provider as any)?.provider?.safe?.safeAddress &&
    !['Safe Multisig WalletConnect', 'Gnosis Safe Multisig'].includes(
      (provider as any)?.provider?.wc?._peerMeta?.name,
    );
```
This is not working as intended anymore, and these info are no longer on the `provider` object.

I propose instead to pass a `needsGas` value - which is true by default. It should be to the client to decide whether he wants to check for gas fees or not, the protocol can't handle the situation for every wallet.
