### PR TITLE
chore: update graphql-request

### DIFF
--- a/packages/payment-detection/package.json
+++ b/packages/payment-detection/package.json
@@ -47,7 +47,7 @@
     "@requestnetwork/utils": "0.40.0",
     "ethers": "5.5.1",
     "graphql": "16.8.1",
-    "graphql-request": "6.1.0",
+    "graphql-request": "7.0.0-next.17",
     "graphql-tag": "2.12.6",
     "satoshi-bitcoin": "1.0.4",
     "tslib": "2.5.0"

--- a/packages/payment-detection/package.json
+++ b/packages/payment-detection/package.json
@@ -57,7 +57,7 @@
     "@graphql-codegen/cli": "4.0.1",
     "@graphql-codegen/typescript": "4.0.1",
     "@graphql-codegen/typescript-document-nodes": "4.0.1",
-    "@graphql-codegen/typescript-graphql-request": "6.0.1",
+    "@graphql-codegen/typescript-graphql-request": "6.2.0",
     "@graphql-codegen/typescript-operations": "4.0.1",
     "@graphql-codegen/typescript-resolvers": "4.0.1",
     "@jridgewell/gen-mapping": "0.3.2",

--- a/packages/request-node/package.json
+++ b/packages/request-node/package.json
@@ -55,7 +55,7 @@
     "ethers": "5.5.1",
     "express": "4.18.0",
     "graphql": "16.8.1",
-    "graphql-request": "6.1.0",
+    "graphql-request": "7.0.0-next.17",
     "http-shutdown": "1.2.2",
     "http-status-codes": "2.1.4",
     "shelljs": "0.8.5",

--- a/packages/thegraph-data-access/package.json
+++ b/packages/thegraph-data-access/package.json
@@ -45,7 +45,7 @@
     "@requestnetwork/types": "0.40.0",
     "@requestnetwork/utils": "0.40.0",
     "ethers": "5.5.1",
-    "graphql-request": "6.1.0",
+    "graphql-request": "7.0.0-next.17",
     "tslib": "2.5.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12965,13 +12965,12 @@ graphql-config@^5.0.2:
     string-env-interpolation "^1.0.1"
     tslib "^2.4.0"
 
-graphql-request@6.1.0, graphql-request@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-6.1.0.tgz#f4eb2107967af3c7a5907eb3131c671eac89be4f"
-  integrity sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==
+graphql-request@7.0.0-next.17:
+  version "7.0.0-next.17"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-7.0.0-next.17.tgz#e7098d4a00a9d336b5202bbbff3d7a34939663c6"
+  integrity sha512-GoCG5GgxZ8NtGFRaisOFHznNTwGYvqZ95EiD4QH/gLfu8Q2DtLNTtvW/W1L7CrqHlv6WyVtfHfjywnB9zcuw1Q==
   dependencies:
     "@graphql-typed-document-node/core" "^3.2.0"
-    cross-fetch "^3.1.5"
 
 graphql-request@^4.3.0:
   version "4.3.0"
@@ -12981,6 +12980,14 @@ graphql-request@^4.3.0:
     cross-fetch "^3.1.5"
     extract-files "^9.0.0"
     form-data "^3.0.0"
+
+graphql-request@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-6.1.0.tgz#f4eb2107967af3c7a5907eb3131c671eac89be4f"
+  integrity sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.2.0"
+    cross-fetch "^3.1.5"
 
 graphql-tag@2.12.6:
   version "2.12.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2672,10 +2672,10 @@
     auto-bind "~4.0.0"
     tslib "~2.5.0"
 
-"@graphql-codegen/typescript-graphql-request@6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-graphql-request/-/typescript-graphql-request-6.0.1.tgz#cc21f94bb21ca98298a28065770f62fb2a1c053f"
-  integrity sha512-aScw7ICyscW7bYLh2HyjQU3geCAjvFy6sRIlzgdkeFvcKBdjCil69upkyZAyntnSno2C4ZoUv7sHOpyQ9hQmFQ==
+"@graphql-codegen/typescript-graphql-request@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-graphql-request/-/typescript-graphql-request-6.2.0.tgz#db3bd90cd9070d446b8039384476cc1029929617"
+  integrity sha512-nkp5tr4PrC/+2QkQqi+IB+bc7AavUnUvXPW8MC93HZRvwfMGy6m2Oo7b9JCPZ3vhNpqT2VDWOn/zIZXKz6zJAw==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^3.0.0"
     "@graphql-codegen/visitor-plugin-common" "2.13.1"


### PR DESCRIPTION
## Description of the changes

The current version of `graphql-request` causes issues with Node19+, see https://github.com/jasonkuhrt/graphql-request/issues/628

A fix was merged in https://github.com/jasonkuhrt/graphql-request/pull/597 but has yet to be officially released. We can use the pre-release build for now.