### PR TITLE
feat: improve payment network types

### DIFF
--- a/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-erc20-proxy.ts
@@ -8,7 +8,7 @@ import Erc20FeeProxyPaymentNetwork from './erc20/fee-proxy-contract';
 
 const CURRENT_VERSION = '0.1.0';
 
-export default class AnyToErc20ProxyPaymentNetwork extends Erc20FeeProxyPaymentNetwork {
+export default class AnyToErc20ProxyPaymentNetwork extends Erc20FeeProxyPaymentNetwork<ExtensionTypes.PnAnyToErc20.ICreationParameters> {
   public constructor(
     currencyManager: ICurrencyManager,
     extensionId: ExtensionTypes.PAYMENT_NETWORK_ID = ExtensionTypes.PAYMENT_NETWORK_ID
@@ -28,8 +28,11 @@ export default class AnyToErc20ProxyPaymentNetwork extends Erc20FeeProxyPaymentN
   public createCreationAction(
     creationParameters: ExtensionTypes.PnAnyToErc20.ICreationParameters,
   ): ExtensionTypes.IAction {
-    if (!creationParameters.acceptedTokens || creationParameters.acceptedTokens.length === 0) {
+    if (!creationParameters.acceptedTokens) {
       throw Error('acceptedTokens is required');
+    }
+    if (creationParameters.acceptedTokens.length === 0) {
+      throw Error('acceptedTokens cannot be empty');
     }
     if (creationParameters.acceptedTokens.some((address) => !this.isValidAddress(address))) {
       throw Error('acceptedTokens must contains only valid ethereum addresses');

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-eth-proxy.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-eth-proxy.ts
@@ -4,7 +4,7 @@ import EthereumFeeProxyPaymentNetwork from './ethereum/fee-proxy-contract';
 
 const CURRENT_VERSION = '0.2.0';
 
-export default class AnyToEthProxyPaymentNetwork extends EthereumFeeProxyPaymentNetwork {
+export default class AnyToEthProxyPaymentNetwork extends EthereumFeeProxyPaymentNetwork<ExtensionTypes.PnAnyToAnyConversion.ICreationParameters> {
   public constructor(currencyManager: ICurrencyManager) {
     super(currencyManager, ExtensionTypes.PAYMENT_NETWORK_ID.ANY_TO_ETH_PROXY, CURRENT_VERSION);
   }

--- a/packages/advanced-logic/src/extensions/payment-network/any-to-native.ts
+++ b/packages/advanced-logic/src/extensions/payment-network/any-to-native.ts
@@ -3,7 +3,7 @@ import { CurrencyTypes, ExtensionTypes, RequestLogicTypes } from '@requestnetwor
 import { InvalidPaymentAddressError, UnsupportedNetworkError } from './address-based';
 import { ICurrencyManager } from '@requestnetwork/currency';
 
-export default abstract class AnyToNativeTokenPaymentNetwork extends FeeReferenceBasedPaymentNetwork {
+export default abstract class AnyToNativeTokenPaymentNetwork extends FeeReferenceBasedPaymentNetwork<ExtensionTypes.PnAnyToAnyConversion.ICreationParameters> {
   protected constructor(
     currencyManager: ICurrencyManager,
     extensionId: ExtensionTypes.PAYMENT_NETWORK_ID,

--- a/packages/advanced-logic/test/extensions/payment-network/any-to-erc20-proxy.test.ts
+++ b/packages/advanced-logic/test/extensions/payment-network/any-to-erc20-proxy.test.ts
@@ -123,7 +123,7 @@ describe('extensions/payment-network/erc20/any-to-erc20-fee-proxy-contract', () 
           paymentAddress: '0x0000000000000000000000000000000000000001',
           network: 'rinkeby',
           salt: 'ea3bc7caf64110ca',
-        });
+        } as any);
       }).toThrowError('acceptedTokens is required');
     });
 

--- a/packages/integration-test/test/scheduled/mocks.ts
+++ b/packages/integration-test/test/scheduled/mocks.ts
@@ -68,8 +68,7 @@ export const mockAdvancedLogic: AdvancedLogicTypes.IAdvancedLogic = {
       createAddPaymentInstructionAction,
       createAddRefundInstructionAction,
     } as any as Extension.PnFeeReferenceBased.IFeeReferenceBased<Extension.PnFeeReferenceBased.ICreationParameters>,
-    anyToEthProxy:
-      {} as Extension.PnFeeReferenceBased.IFeeReferenceBased<Extension.PnFeeReferenceBased.ICreationParameters>,
+    anyToEthProxy: {} as Extension.PnAnyToEth.IAnyToEth,
     anyToNativeToken:
       {} as Extension.PnFeeReferenceBased.IFeeReferenceBased<Extension.PnFeeReferenceBased.ICreationParameters>[],
     erc20TransferableReceivable: {

--- a/packages/payment-detection/src/any-to-any-detector.ts
+++ b/packages/payment-detection/src/any-to-any-detector.ts
@@ -7,7 +7,7 @@ import { generate8randomBytes } from '@requestnetwork/utils';
  * Abstract class to extend to get the payment balance of conversion requests
  */
 export abstract class AnyToAnyDetector<
-  TExtension extends ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased,
+  TExtension extends ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased<any>,
   TPaymentEventParameters extends Partial<ExtensionTypes.PnFeeReferenceBased.IAddFeeParameters>,
 > extends FeeReferenceBasedDetector<TExtension, TPaymentEventParameters> {
   /**

--- a/packages/payment-detection/src/any/any-to-erc20-proxy.ts
+++ b/packages/payment-detection/src/any/any-to-erc20-proxy.ts
@@ -52,7 +52,7 @@ export class AnyToERC20PaymentDetector extends ERC20FeeProxyPaymentDetectorBase<
    * @returns The extensionData object
    */
   public async createExtensionsDataForCreation(
-    paymentNetworkCreationParameters: PaymentTypes.IAnyToErc20CreationParameters,
+    paymentNetworkCreationParameters: ExtensionTypes.PnAnyToErc20.ICreationParameters,
   ): Promise<ExtensionTypes.IAction> {
     // If no salt is given, generate one
     const salt = paymentNetworkCreationParameters.salt || (await generate8randomBytes());

--- a/packages/payment-detection/src/declarative.ts
+++ b/packages/payment-detection/src/declarative.ts
@@ -11,7 +11,7 @@ import { notNull } from '@requestnetwork/utils';
  * Handles payment detection for a declarative request, or derived.
  */
 export abstract class DeclarativePaymentDetectorBase<
-  TExtension extends ExtensionTypes.PnAnyDeclarative.IAnyDeclarative,
+  TExtension extends ExtensionTypes.PnAnyDeclarative.IAnyDeclarative<any>,
   TPaymentEventParameters extends PaymentTypes.IDeclarativePaymentEventParameters<unknown>,
 > extends PaymentDetectorBase<TExtension, TPaymentEventParameters> {
   protected constructor(

--- a/packages/payment-detection/src/erc20/fee-proxy-contract.ts
+++ b/packages/payment-detection/src/erc20/fee-proxy-contract.ts
@@ -33,7 +33,7 @@ const PROXY_CONTRACT_ADDRESS_MAP = {
  */
 
 export abstract class ERC20FeeProxyPaymentDetectorBase<
-  TExtension extends ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased,
+  TExtension extends ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased<any>,
   TPaymentEventParameters extends PaymentTypes.IERC20FeePaymentEventParameters,
 > extends FeeReferenceBasedDetector<TExtension, TPaymentEventParameters> {
   /**

--- a/packages/payment-detection/src/fee-reference-based-detector.ts
+++ b/packages/payment-detection/src/fee-reference-based-detector.ts
@@ -8,7 +8,7 @@ import { generate8randomBytes } from '@requestnetwork/utils';
  * Abstract class to extend to get the payment balance of reference based requests
  */
 export abstract class FeeReferenceBasedDetector<
-  TExtension extends ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased,
+  TExtension extends ExtensionTypes.PnFeeReferenceBased.IFeeReferenceBased<any>,
   TPaymentEventParameters extends PaymentTypes.IDeclarativePaymentEventParameters<string> & {
     feeAddress?: string;
     feeAmount?: string;

--- a/packages/payment-detection/src/payment-detector-base.ts
+++ b/packages/payment-detection/src/payment-detector-base.ts
@@ -9,7 +9,11 @@ import {
 export abstract class PaymentDetectorBase<
   TExtension extends ExtensionTypes.IExtension,
   TPaymentEventParameters extends PaymentTypes.GenericEventParameters,
-> implements PaymentTypes.IPaymentNetwork<TPaymentEventParameters>
+> implements
+    PaymentTypes.IPaymentNetwork<
+      TPaymentEventParameters,
+      TExtension extends ExtensionTypes.IExtension<infer U> ? U : never
+    >
 {
   protected constructor(
     public readonly paymentNetworkId: ExtensionTypes.PAYMENT_NETWORK_ID,

--- a/packages/payment-detection/src/payment-network-factory.ts
+++ b/packages/payment-detection/src/payment-network-factory.ts
@@ -120,12 +120,15 @@ export class PaymentNetworkFactory {
    * @param paymentChain Different from request.currency.network for on-chain conversion payment networks (any-to-something)
    * @returns the module to handle the payment network
    */
-  public createPaymentNetwork(
-    paymentNetworkId: ExtensionTypes.PAYMENT_NETWORK_ID,
+  public createPaymentNetwork<PN_ID extends ExtensionTypes.PAYMENT_NETWORK_ID>(
+    paymentNetworkId: PN_ID,
     currencyType: RequestLogicTypes.CURRENCY,
     paymentChain?: CurrencyTypes.ChainName,
     paymentNetworkVersion?: string,
-  ): PaymentTypes.IPaymentNetwork {
+  ): PaymentTypes.IPaymentNetwork<
+    PaymentTypes.GenericEventParameters,
+    Extract<PaymentTypes.PaymentNetworkCreateParameters, { id: PN_ID }>['parameters']
+  > {
     const network = paymentChain ?? 'mainnet';
     const currencyPaymentMap =
       supportedPaymentNetwork[currencyType]?.[network] ||
@@ -171,7 +174,7 @@ export class PaymentNetworkFactory {
    */
   public getPaymentNetworkFromRequest(
     request: RequestLogicTypes.IRequest,
-  ): PaymentTypes.IPaymentNetwork | null {
+  ): PaymentTypes.IPaymentNetwork<PaymentTypes.GenericEventParameters, any> | null {
     const pn = getPaymentNetworkExtension(request);
     if (!pn) {
       return null;
@@ -180,11 +183,6 @@ export class PaymentNetworkFactory {
     const detectionChain = pn.values?.network ?? request.currency.network;
 
     const { id, version } = pn;
-    return this.createPaymentNetwork(
-      id as unknown as ExtensionTypes.PAYMENT_NETWORK_ID,
-      request.currency.type,
-      detectionChain,
-      version,
-    );
+    return this.createPaymentNetwork(id, request.currency.type, detectionChain, version);
   }
 }

--- a/packages/payment-detection/src/reference-based-detector.ts
+++ b/packages/payment-detection/src/reference-based-detector.ts
@@ -15,7 +15,7 @@ import { generate8randomBytes } from '@requestnetwork/utils';
  * Abstract class to extend to get the payment balance of reference based requests
  */
 export abstract class ReferenceBasedDetector<
-  TExtension extends ExtensionTypes.PnReferenceBased.IReferenceBased,
+  TExtension extends ExtensionTypes.PnReferenceBased.IReferenceBased<any>,
   TPaymentEventParameters extends PaymentTypes.IDeclarativePaymentEventParameters<string>,
 > extends DeclarativePaymentDetectorBase<
   TExtension,

--- a/packages/payment-detection/test/any/any-to-erc20-proxy-contract.test.ts
+++ b/packages/payment-detection/test/any/any-to-erc20-proxy-contract.test.ts
@@ -106,6 +106,8 @@ describe('api/any/conversion-fee-proxy-contract', () => {
   it('can createExtensionsDataForCreation without salt', async () => {
     await anyToErc20Proxy.createExtensionsDataForCreation({
       paymentAddress: 'ethereum address',
+      acceptedTokens: [],
+      network: 'mainnet',
     });
 
     // Can't check parameters since salt is generated in createExtensionsDataForCreation

--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -414,7 +414,7 @@ export default class RequestNetwork {
       // create the extensions data for the payment network
       copiedRequestParameters.extensionsData.push(
         await paymentNetwork.createExtensionsDataForCreation(
-          parameters.paymentNetwork?.parameters as any,
+          parameters.paymentNetwork?.parameters || {},
         ),
       );
     }

--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -413,7 +413,9 @@ export default class RequestNetwork {
     if (paymentNetwork) {
       // create the extensions data for the payment network
       copiedRequestParameters.extensionsData.push(
-        await paymentNetwork.createExtensionsDataForCreation(parameters.paymentNetwork?.parameters),
+        await paymentNetwork.createExtensionsDataForCreation(
+          parameters.paymentNetwork?.parameters as any,
+        ),
       );
     }
 

--- a/packages/types/src/advanced-logic-types.ts
+++ b/packages/types/src/advanced-logic-types.ts
@@ -18,7 +18,7 @@ export interface IAdvancedLogicExtensions {
   // FIXME: should be Extension.PnReferenceBased.IReferenceBased<Extension.PnStreamReferenceBased.ICreationParameters>
   erc777Stream: any;
   feeProxyContractEth: Extension.PnFeeReferenceBased.IFeeReferenceBased<Extension.PnFeeReferenceBased.ICreationParameters>;
-  anyToEthProxy: Extension.PnFeeReferenceBased.IFeeReferenceBased<Extension.PnFeeReferenceBased.ICreationParameters>;
+  anyToEthProxy: Extension.PnFeeReferenceBased.IFeeReferenceBased<Extension.PnAnyToEth.ICreationParameters>;
   anyToNativeToken: Extension.PnFeeReferenceBased.IFeeReferenceBased<Extension.PnFeeReferenceBased.ICreationParameters>[];
   erc20TransferableReceivable: Extension.PnFeeReferenceBased.IFeeReferenceBased<Extension.PnFeeReferenceBased.ICreationParameters>;
 }

--- a/packages/types/src/extensions/pn-any-to-erc20-types.ts
+++ b/packages/types/src/extensions/pn-any-to-erc20-types.ts
@@ -6,7 +6,6 @@ export type IAnyToERC20 = PnAnyToAnyConversion.IConversionReferenceBased<ICreati
 
 /** Parameters for the creation action */
 export interface ICreationParameters extends PnAnyToAnyConversion.ICreationParameters {
-  network?: EvmChainName;
-  // FIXME: should be mandatory according to AnyToErc20ProxyPaymentNetwork createCreationAction() logic
-  acceptedTokens?: string[];
+  network: EvmChainName;
+  acceptedTokens: string[];
 }

--- a/packages/types/src/extensions/pn-any-to-eth-types.ts
+++ b/packages/types/src/extensions/pn-any-to-eth-types.ts
@@ -1,7 +1,10 @@
+import { ChainName } from '../currency-types';
 import * as PnAnyToAnyConversion from './pn-any-to-any-conversion-types';
 
 /** Any to ETH reference-based payment network extension interface */
-export type IAnyToEth = PnAnyToAnyConversion.IConversionReferenceBased;
+export type IAnyToEth = PnAnyToAnyConversion.IConversionReferenceBased<ICreationParameters>;
 
 /** Parameters for the creation action */
-export type ICreationParameters = PnAnyToAnyConversion.ICreationParameters;
+export type ICreationParameters = Omit<PnAnyToAnyConversion.ICreationParameters, 'network'> & {
+  network: ChainName;
+};

--- a/packages/types/src/payment-types.ts
+++ b/packages/types/src/payment-types.ts
@@ -2,16 +2,17 @@ import { IIdentity } from './identity-types';
 import * as RequestLogic from './request-logic-types';
 import * as ExtensionTypes from './extension-types';
 import { ICreationParameters } from './extensions/pn-any-declarative-types';
-import { ICreationParameters as ICreationParametersAnyToAny } from './extensions/pn-any-to-any-conversion-types';
-import { EvmChainName } from './currency-types';
 
 /** Interface for payment network extensions state and interpretation */
 export interface IPaymentNetwork<
   TEventParameters extends GenericEventParameters = GenericEventParameters,
+  TCreationParameters = any,
 > {
   paymentNetworkId: ExtensionTypes.PAYMENT_NETWORK_ID;
   extension: ExtensionTypes.IExtension;
-  createExtensionsDataForCreation: (paymentNetworkCreationParameters: any) => Promise<any>;
+  createExtensionsDataForCreation: (
+    paymentNetworkCreationParameters: TCreationParameters,
+  ) => Promise<ExtensionTypes.IAction<any>>;
   createExtensionsDataForAddRefundInformation: (parameters: any) => any;
   createExtensionsDataForAddPaymentInformation: (parameters: any) => any;
   getBalance(request: RequestLogic.IRequest): Promise<IBalanceWithEvents<TEventParameters>>;
@@ -34,12 +35,6 @@ export interface IFeeReferenceBasedCreationParameters extends IReferenceBasedCre
   feeAmount?: string;
 }
 
-/** Parameters to create a request with "any to erc20" payment network */
-export interface IAnyToErc20CreationParameters extends ICreationParametersAnyToAny {
-  acceptedTokens?: string[];
-  network?: EvmChainName;
-}
-
 /**
  * Interface to create a payment network
  * @deprecated Use `PaymentNetworkCreateParameters` type instead
@@ -51,17 +46,27 @@ export interface IPaymentNetworkCreateParameters<T = any> {
 
 export type PaymentNetworkCreateParameters =
   | {
-      id:
-        | ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_PROXY_CONTRACT
-        | ExtensionTypes.PAYMENT_NETWORK_ID.ETH_INPUT_DATA
-        | ExtensionTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN;
+      id: ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_PROXY_CONTRACT;
       parameters: ExtensionTypes.PnReferenceBased.ICreationParameters;
     }
   | {
-      id:
-        | ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT
-        | ExtensionTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT
-        | ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_TRANSFERABLE_RECEIVABLE;
+      id: ExtensionTypes.PAYMENT_NETWORK_ID.ETH_INPUT_DATA;
+      parameters: ExtensionTypes.PnReferenceBased.ICreationParameters;
+    }
+  | {
+      id: ExtensionTypes.PAYMENT_NETWORK_ID.NATIVE_TOKEN;
+      parameters: ExtensionTypes.PnReferenceBased.ICreationParameters;
+    }
+  | {
+      id: ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT;
+      parameters: ExtensionTypes.PnFeeReferenceBased.ICreationParameters;
+    }
+  | {
+      id: ExtensionTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT;
+      parameters: ExtensionTypes.PnFeeReferenceBased.ICreationParameters;
+    }
+  | {
+      id: ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_TRANSFERABLE_RECEIVABLE;
       parameters: ExtensionTypes.PnFeeReferenceBased.ICreationParameters;
     }
   | {
@@ -85,10 +90,15 @@ export type PaymentNetworkCreateParameters =
       parameters: ExtensionTypes.PnStreamReferenceBased.ICreationParameters;
     }
   | {
-      id:
-        | ExtensionTypes.PAYMENT_NETWORK_ID.BITCOIN_ADDRESS_BASED
-        | ExtensionTypes.PAYMENT_NETWORK_ID.TESTNET_BITCOIN_ADDRESS_BASED
-        | ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_ADDRESS_BASED;
+      id: ExtensionTypes.PAYMENT_NETWORK_ID.BITCOIN_ADDRESS_BASED;
+      parameters: ExtensionTypes.PnAddressBased.ICreationParameters;
+    }
+  | {
+      id: ExtensionTypes.PAYMENT_NETWORK_ID.TESTNET_BITCOIN_ADDRESS_BASED;
+      parameters: ExtensionTypes.PnAddressBased.ICreationParameters;
+    }
+  | {
+      id: ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_ADDRESS_BASED;
       parameters: ExtensionTypes.PnAddressBased.ICreationParameters;
     };
 


### PR DESCRIPTION
Make payment network parameters strongly typed, and more precise:


### Example
```ts
 await pnFactory
      .createPaymentNetwork(
        ExtensionTypes.PAYMENT_NETWORK_ID.ANY_TO_ERC20_PROXY,
        RequestLogicTypes.CURRENCY.ERC20,
        'mainnet',
      )
      //  strongly typed to ANY_TO_ERC20_PROXY Payment Network.
      .createExtensionsDataForCreation({
         // TS error because misses `acceptedTokens`

         // TS error because `network` is not valid
         network: "not a valid name"
      }),
```
