### PR TITLE
fix(payment-detection): default block filter on decentralized network

### DIFF
--- a/packages/payment-detection/src/thegraph/client.ts
+++ b/packages/payment-detection/src/thegraph/client.ts
@@ -56,8 +56,8 @@ const extractClientOptions = (
   if (minIndexedBlock) {
     queryOptions.blockFilter = { number_gte: minIndexedBlock };
   } else if (url.match(/^https:\/\/gateway-\w+\.network\.thegraph\.com\//)) {
-    // the decentralized network expects an empty object, and doesn't support "undefined"
-    queryOptions.blockFilter = {};
+    // the decentralized network doesn't support "undefined"
+    queryOptions.blockFilter = { number_gte: 0 };
   }
 
   // build client options


### PR DESCRIPTION
## Description of the changes

This is a follow-up on https://github.com/RequestNetwork/requestNetwork/pull/1267, the decentralized gateway of TheGraph has changed its validation regarding accepted values on block filters. We need to change the default when no block filter is used.

| Block Filter                      | TheGraph Node                                             | TheGraph Gateway (decentralized)                                            |
|-----------------------------------|-----------------------------------------------------------|-----------------------------------------------------------------------------|
| `undefined`                         | ✅                                                         | ❌ `Invalid query: Failed to determine block constraints.`                     |
| `null`                         | ✅                                                         | ❌ `Invalid query: Failed to determine block constraints.`                     |
| empty object: `{}`                   | ❌ `Invalid value provided for argument block: Object({})` | ❌ `Invalid value provided for argument block: Object({})`                                                                           |
| default to zero: `{ number_gte: 0 }` | ✅                                                         | ✅ |