### PR TITLE
feat: Pay before Persist experiment

### DIFF
--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -31,8 +31,8 @@ export default class RequestNetwork {
   public paymentNetworkFactory: PaymentNetworkFactory;
   public supportedIdentities: IdentityTypes.TYPE[] = supportedIdentities;
 
-  private requestLogic: RequestLogicTypes.IRequestLogic;
-  private transaction: TransactionTypes.ITransactionManager;
+  public requestLogic: RequestLogicTypes.IRequestLogic;
+  public transaction: TransactionTypes.ITransactionManager;
   private advancedLogic: AdvancedLogicTypes.IAdvancedLogic;
 
   private contentData: ContentDataExtension;
@@ -374,7 +374,7 @@ export default class RequestNetwork {
    * @param parameters Parameters to create a request
    * @returns the parameters, ready for request creation, the topics, and the paymentNetwork
    */
-  private async prepareRequestParameters(parameters: Types.ICreateRequestParameters): Promise<{
+  public async prepareRequestParameters(parameters: Types.ICreateRequestParameters): Promise<{
     requestParameters: RequestLogicTypes.ICreateParameters;
     topics: any[];
     paymentNetwork: PaymentTypes.IPaymentNetwork | null;

--- a/packages/request-logic/src/request-logic.ts
+++ b/packages/request-logic/src/request-logic.ts
@@ -386,7 +386,7 @@ export default class RequestLogic implements RequestLogicTypes.IRequestLogic {
    *
    * @returns the request id, the action and the hashed topics
    */
-  private async createCreationActionRequestIdAndTopics(
+  public async createCreationActionRequestIdAndTopics(
     requestParameters: RequestLogicTypes.ICreateParameters,
     signerIdentity: IdentityTypes.IIdentity,
     topics: any[],
@@ -665,7 +665,7 @@ export default class RequestLogic implements RequestLogicTypes.IRequestLogic {
    *
    * @returns void, throws if the action is invalid
    */
-  private async validateAction(
+  public async validateAction(
     requestId: RequestLogicTypes.RequestId,
     action: RequestLogicTypes.IAction,
   ): Promise<void> {


### PR DESCRIPTION
# Problem

In theory, we can Pay a request before persisting it in the Request Network protocol.

In other words, we create a Request in memory without persisting it. Then, we prompt the end user to send payment against that request. Finally, we persist the request - so that it may serve as a receipt for the payment.

However, the existing SDK functions assume that the request is persisted immediately after being created.

# Motivation

This shortens the critical path for a user making a payment. This is especially desirable for payment apps - in which a payer wants to buy something. The workflow is driven by the _payer_ instead of the payee, so why make them wait for the request to be persisted before allowing them to send a payment?

# Changes

* feat: public funcs for creating a request in memory without persisting

# Why were these variables/functions chosen?

I traced the [RequestNetwork.createRequest()](https://github.com/RequestNetwork/requestNetwork/blob/create-without-publish/packages/request-client.js/src/api/request-network.ts#L78) and the [RequestLogic.acceptRequest()](https://github.com/RequestNetwork/requestNetwork/blob/create-without-publish/packages/request-logic/src/request-logic.ts#L136) functions and changed all the internal variables/functions `private` => `public`.

# Considerations

Rather than implementing this new logic, this PR only changes several `private` functions and variables to be `public`, thus empowering external contributors to experiment with the "Pay before Persist" workflow. The expectation is that once these experiments are complete, we either:

1. **Revert** this PR
or
3. **Implement** the "Pay before Persist" functions in the RN SDK.