### PR TITLE
fix: base deployment

### DIFF
--- a/packages/currency/src/native.ts
+++ b/packages/currency/src/native.ts
@@ -165,6 +165,12 @@ export const nativeCurrencies: Record<RequestLogicTypes.CURRENCY.ETH, NativeEthC
       name: 'Ether',
       network: 'zksynceratestnet',
     },
+    {
+      symbol: 'ETH-base',
+      decimals: 18,
+      name: 'Base Ether',
+      network: 'base',
+    },
   ],
   [RequestLogicTypes.CURRENCY.BTC]: [
     {

--- a/packages/smart-contracts/src/lib/artifacts/Erc20ConversionProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/Erc20ConversionProxy/index.ts
@@ -83,6 +83,10 @@ export const erc20ConversionProxy = new ContractArtifact<Erc20ConversionProxy>(
           address: '0xaD61121DAfAAe495095Cd466022b519Cb7503a4E',
           creationBlockNumber: 4733467,
         },
+        base: {
+          address: '0x8296D56321cf207925a7804E5A8E3F579838e6Ad',
+          creationBlockNumber: 10827277,
+        },
       },
     },
     '0.1.1': {


### PR DESCRIPTION
## Description of the changes

The native currency for base was missing. 

I updated the following contracts who were were not initialized:
 - ChainlinkConversionPath
 - EthConversionProxy
 - Erc20ConversionProxy
 - Batch
 - SwapToPay
 - SwapToConversion
 
 See the latest transactions https://basescan.org/address/0x4e64c2d06d19d13061e62e291b2c4e9fe5679b93