### PR TITLE
chore(thegraph): migrate to TheGraph Studio

### DIFF
--- a/packages/payment-detection/codegen-near.yml
+++ b/packages/payment-detection/codegen-near.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'https://api.thegraph.com/subgraphs/name/requestnetwork/request-payments-near-testnet'
+schema: 'https://api.studio.thegraph.com/query/35843/request-payments-near-testnet/version/latest'
 documents: src/thegraph/queries/near/*.graphql
 generates:
   src/thegraph/generated/graphql-near.ts:

--- a/packages/payment-detection/codegen.yml
+++ b/packages/payment-detection/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'https://api.thegraph.com/subgraphs/name/requestnetwork/request-payments-goerli'
+schema: 'https://api.studio.thegraph.com/query/35843/request-payments-sepolia/version/latest'
 documents: src/thegraph/queries/*.graphql
 generates:
   src/thegraph/generated/graphql.ts:

--- a/packages/payment-detection/src/thegraph/client.ts
+++ b/packages/payment-detection/src/thegraph/client.ts
@@ -6,10 +6,8 @@ import { Block_Height, Maybe, getSdk } from './generated/graphql';
 import { getSdk as getNearSdk } from './generated/graphql-near';
 import { RequestConfig } from 'graphql-request/src/types';
 
-const HOSTED_THE_GRAPH_URL =
-  'https://api.thegraph.com/subgraphs/name/requestnetwork/request-payments-';
-
-const STUDIO_THE_GRAPH_URL = 'https://api.studio.thegraph.com/query/35843/request-payments-';
+const THE_GRAPH_URL =
+  'https://api.studio.thegraph.com/query/35843/request-payments-$NETWORK/version/latest';
 
 const THE_GRAPH_URL_MANTLE_TESTNET =
   'https://graph.testnet.mantle.xyz/subgraphs/name/requestnetwork/request-payments-mantle-testnet';
@@ -96,14 +94,15 @@ export const defaultGetTheGraphClient = (
   return network === 'private'
     ? undefined
     : NearChains.isChainSupported(network)
-    ? getTheGraphNearClient(`${HOSTED_THE_GRAPH_URL}${network.replace('aurora', 'near')}`, options)
+    ? getTheGraphNearClient(
+        `${THE_GRAPH_URL.replace('$NETWORK', network.replace('aurora', 'near'))}`,
+        options,
+      )
     : network === 'mantle'
     ? getTheGraphEvmClient(THE_GRAPH_URL_MANTLE, options)
     : network === 'mantle-testnet'
     ? getTheGraphEvmClient(THE_GRAPH_URL_MANTLE_TESTNET, options)
     : network === 'core'
     ? getTheGraphEvmClient(THE_GRAPH_URL_CORE, options)
-    : network === 'zksyncera' || network === 'base'
-    ? getTheGraphEvmClient(`${STUDIO_THE_GRAPH_URL}${network}/version/latest`, options)
-    : getTheGraphEvmClient(`${HOSTED_THE_GRAPH_URL}${network}`, options);
+    : getTheGraphEvmClient(`${THE_GRAPH_URL.replace('$NETWORK', network)}`, options);
 };

--- a/packages/payment-detection/src/thegraph/queries/graphql.config.yml
+++ b/packages/payment-detection/src/thegraph/queries/graphql.config.yml
@@ -1,1 +1,1 @@
-schema: https://api.thegraph.com/subgraphs/name/requestnetwork/request-payments-goerli
+schema: https://api.studio.thegraph.com/query/35843/request-payments-sepolia/version/latest

--- a/packages/payment-detection/src/thegraph/queries/near/graphql.config.yml
+++ b/packages/payment-detection/src/thegraph/queries/near/graphql.config.yml
@@ -1,1 +1,1 @@
-schema: https://api.thegraph.com/subgraphs/name/requestnetwork/request-payments-near-testnet
+schema: https://api.studio.thegraph.com/query/35843/request-payments-near-testnet/version/latest


### PR DESCRIPTION
## Description of the changes

Remove the legacy references to TheGraph Hosted Service, and use TheGraph Studio URLs instead