### PR TITLE
fix: payments-subgraph URL on Base

### DIFF
--- a/packages/payment-detection/src/thegraph/client.ts
+++ b/packages/payment-detection/src/thegraph/client.ts
@@ -9,6 +9,9 @@ import { RequestConfig } from 'graphql-request/src/types';
 const THE_GRAPH_STUDIO_URL =
   'https://api.studio.thegraph.com/query/67444/request-payments-$NETWORK/version/latest';
 
+const THE_GRAPH_STUDIO_URL_BASE =
+  'https://api.studio.thegraph.com/query/67444/request-payments-base-2/version/latest';
+
 const THE_GRAPH_URL_MANTLE_TESTNET =
   'https://graph.testnet.mantle.xyz/subgraphs/name/requestnetwork/request-payments-mantle-testnet';
 
@@ -98,6 +101,8 @@ export const defaultGetTheGraphClient = (
         `${THE_GRAPH_STUDIO_URL.replace('$NETWORK', network.replace('aurora', 'near'))}`,
         options,
       )
+    : network === 'base'
+    ? getTheGraphEvmClient(THE_GRAPH_STUDIO_URL_BASE, options)
     : network === 'mantle'
     ? getTheGraphEvmClient(THE_GRAPH_URL_MANTLE, options)
     : network === 'mantle-testnet'


### PR DESCRIPTION
Fixes #1413 

## Description of the changes

* Add `THE_GRAPH_STUDIO_URL_BASE`