### PR TITLE
fix: invalid decimal places for fUSDT and fUSDC on sepolia

### DIFF
--- a/packages/currency/src/erc20/chains/sepolia.ts
+++ b/packages/currency/src/erc20/chains/sepolia.ts
@@ -1,20 +1,20 @@
 import { CurrencyTypes } from '@requestnetwork/types';
 
-// List of the supported goerli ERC20 tokens
+// List of the supported sepolia  ERC20 tokens
 export const supportedSepoliaERC20: CurrencyTypes.TokenMap = {
-  // Faucet Token on goerli network.
+  // Faucet Token on sepolia  network.
   '0x370DE27fdb7D1Ff1e1BaA7D11c5820a324Cf623C': {
     decimals: 18,
     name: 'FaucetToken',
     symbol: 'FAU',
   },
   '0xF046b3CA5ae2879c6bAcC4D42fAF363eE8379F78': {
-    decimals: 18,
+    decimals: 6,
     name: 'FakeUSDT',
     symbol: 'fUSDT',
   },
   '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238': {
-    decimals: 18,
+    decimals: 6,
     name: 'FakeUSDC',
     symbol: 'fUSDC',
   },


### PR DESCRIPTION
## Description of the changes

Fixed Invalid Decimal Places on `fUSDC` and `fUSDT` on sepolia. Initially it was `18` by according to smart contracts on sepolia it is `6` which can cause invalid `expectedAmount` if one parses units with these Decimals.

https://sepolia.etherscan.io/address/0xF046b3CA5ae2879c6bAcC4D42fAF363eE8379F78#readContract

https://sepolia.etherscan.io/address/0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238#readProxyContract