### PR TITLE
feat: add support for Fraxtal by deploying on fraxtal and fraxtal testnet

### DIFF
--- a/packages/currency/src/chains/evm/data/frax.ts
+++ b/packages/currency/src/chains/evm/data/frax.ts
@@ -1,0 +1,8 @@
+import { CurrencyTypes } from '@requestnetwork/types';
+import { supportedFrax } from 'currency/src/erc20/chains/frax';
+
+
+export const chainId = 252;
+export const currencies: CurrencyTypes.TokenMap = {
+  ...supportedFrax,
+};

--- a/packages/currency/src/chains/evm/data/fraxtestnet.ts
+++ b/packages/currency/src/chains/evm/data/fraxtestnet.ts
@@ -1,0 +1,7 @@
+import { CurrencyTypes } from '@requestnetwork/types';
+import { supportedFraxtestneterc20 } from 'currency/src/erc20/chains/fraxtestnet';
+
+export const chainId = 2522;
+export const currencies: CurrencyTypes.TokenMap = {
+  ...supportedFraxtestneterc20,
+};

--- a/packages/currency/src/chains/evm/index.ts
+++ b/packages/currency/src/chains/evm/index.ts
@@ -28,6 +28,8 @@ import * as SepoliaDefinition from './data/sepolia';
 import * as ZkSyncEraTestnetDefinition from './data/zksync-era-testnet';
 import * as ZkSyncEraDefinition from './data/zksync-era';
 import * as BaseDefinition from './data/base';
+import * as FraxDefinition from './data/frax';
+import * as FraxTestnetDefinition from './data/fraxtestnet';
 
 export type EvmChain = CurrencyTypes.Chain & {
   chainId: number;
@@ -62,4 +64,6 @@ export const chains: Record<CurrencyTypes.EvmChainName, EvmChain> = {
   zksynceratestnet: ZkSyncEraTestnetDefinition,
   zksyncera: ZkSyncEraDefinition,
   base: BaseDefinition,
+  frax: FraxDefinition,
+  fraxtestnet: FraxTestnetDefinition,
 };

--- a/packages/currency/src/erc20/chains/frax.ts
+++ b/packages/currency/src/erc20/chains/frax.ts
@@ -1,0 +1,15 @@
+import { CurrencyTypes } from '@requestnetwork/types';
+
+// List of the supported  network tokens
+export const supportedFrax: CurrencyTypes.TokenMap = {
+  '0x4d15EA9C2573ADDAeD814e48C148b5262694646A': {
+    name: 'FRAX USDT Token',
+    symbol: 'USDT',
+    decimals: 6,
+  },
+  '0xfc00000000000000000000000000000000000001': {
+    name: 'FRAX Token',
+    symbol: 'FRAX',
+    decimals: 18,
+  },
+};

--- a/packages/currency/src/erc20/chains/frax.ts
+++ b/packages/currency/src/erc20/chains/frax.ts
@@ -1,7 +1,7 @@
 import { CurrencyTypes } from '@requestnetwork/types';
 
 // List of the supported  network tokens
-export const supportedFrax: CurrencyTypes.TokenMap = {
+export const supportedFraxerc20: CurrencyTypes.TokenMap = {
   '0x4d15EA9C2573ADDAeD814e48C148b5262694646A': {
     name: 'FRAX USDT Token',
     symbol: 'USDT',

--- a/packages/currency/src/erc20/chains/fraxtestnet.ts
+++ b/packages/currency/src/erc20/chains/fraxtestnet.ts
@@ -1,0 +1,15 @@
+import { CurrencyTypes } from '@requestnetwork/types';
+
+// List of the supported bsc network tokens
+export const supportedFraxtestneterc20: CurrencyTypes.TokenMap = {
+  '0x4d15EA9C2573ADDAeD814e48C148b5262694646A': {
+    name: 'FRAX USDT Token',
+    symbol: 'USDT',
+    decimals: 6,
+  },
+  '0xfc00000000000000000000000000000000000001': {
+    name: 'FRAX Token',
+    symbol: 'FRAX',
+    decimals: 18,
+  },
+};

--- a/packages/currency/src/erc20/chains/index.ts
+++ b/packages/currency/src/erc20/chains/index.ts
@@ -13,6 +13,8 @@ import { supportedOptimismERC20 } from './optimism';
 import { supportedRinkebyERC20 } from './rinkeby';
 import { supportedXDAIERC20 } from './xdai';
 import { supportedSepoliaERC20 } from './sepolia';
+import { supportedFraxerc20 } from './frax';
+import { supportedFraxtestneterc20 } from './fraxtestnet';
 
 export const supportedNetworks: Partial<
   Record<CurrencyTypes.EvmChainName, CurrencyTypes.TokenMap>
@@ -31,4 +33,6 @@ export const supportedNetworks: Partial<
   optimism: supportedOptimismERC20,
   moonbeam: supportedMoonbeamERC20,
   sepolia: supportedSepoliaERC20,
+  frax: supportedFraxerc20,
+  fraxtestnet: supportedFraxtestneterc20,
 };

--- a/packages/currency/src/native.ts
+++ b/packages/currency/src/native.ts
@@ -172,6 +172,11 @@ export const nativeCurrencies: Record<RequestLogicTypes.CURRENCY.ETH, NativeEthC
       name: 'Base Ether',
       network: 'base',
     },
+    {
+      symbol: 'FRAX-ETH',
+      decimals: 18,
+      name: 'Frax',
+    }
   ],
   [RequestLogicTypes.CURRENCY.BTC]: [
     {

--- a/packages/smart-contracts/hardhat.config.ts
+++ b/packages/smart-contracts/hardhat.config.ts
@@ -115,6 +115,16 @@ export default {
       chainId: 42220,
       accounts,
     },
+    frax: {
+      url: url('frax'),
+      chainId: 252,
+      accounts,
+    },
+    fraxtestnet: {
+      url: url('fraxtestnet'),
+      chainId: 2522,
+      accounts,
+    },
     bsctest: {
       url: url('bsctest'),
       chainId: 97,

--- a/packages/types/src/currency-types.ts
+++ b/packages/types/src/currency-types.ts
@@ -31,7 +31,9 @@ export type EvmChainName =
   | 'tombchain'
   | 'xdai'
   | 'zksynceratestnet'
-  | 'zksyncera';
+  | 'zksyncera'
+  | 'frax'
+  | 'fraxtestnet';
 
 /**
  * List of supported BTC chains

--- a/packages/utils/src/providers.ts
+++ b/packages/utils/src/providers.ts
@@ -53,6 +53,8 @@ const networkRpcs: Record<string, string> = {
   zksyncera: 'https://mainnet.era.zksync.io',
   sepolia: 'https://rpc.sepolia.org/',
   base: 'https://mainnet.base.org/',
+  frax : 'https://rpc.frax.com',
+  fraxtestnet: 'https://rpc.testnet.frax.com',
 };
 
 /**


### PR DESCRIPTION
## Description of the changes

Deploy the following contracts on Fraxtal Testnet 

[RequestDeployer]() - verified
[EthereumProxy](https://holesky.fraxscan.com/address/0x920cdb18a183ba4bda521c302e56e3a5347ac8d1) - verified
[EthereumFeeProxy](https://holesky.fraxscan.com/address/0xee3288eeb0a60a3d9b63d735ed5b12974e425838) - verified
[ERC20Proxy]() - verified
[ERC20FeeProxy]() - verified


Deploy the following contracts on Fraxtal Mainnet

[RequestDeployer]() - verified
[EthereumProxy]() - verified
[EthereumFeeProxy]() - verified
[ERC20Proxy]() - verified
[ERC20FeeProxy]() - verified