### PR TITLE
fix: include merged tags when determining the previous release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -510,6 +510,7 @@ jobs:
               --preid next \
               --no-verify-access \
               --dist-tag next \
+              --include-merged-tags \
               --yes \
               --force-publish=${FORCE_PUBLISH}
 


### PR DESCRIPTION
# Problem

The `next-release` workflow in CircleCI releases a `-next` package in NPM. It determines the version number based on the previous annotated, tagged commit *originating from the `master` branch*. It doesn't consider tags that were merged from other branches.

In https://github.com/RequestNetwork/requestNetwork/issues/1381#issuecomment-2241347444, I force-pushed several annotated tags in an attempt to fix the auto-generated CHANGELOG.md files. Before this, *there were zero annotated, tagged commits originating from the `master` branch* so the `next-release` workflow would fallback to counting commits from the beginning fo time. This is why the `-next` releases end with a number instead of a commit hash.

The reason there was zero annotated, tagged commits originating from the `master` branch is that we've always used squash merge to merge PRs into `master`. squash merge changes the commit hash, thus orphaning the tags produced by `lerna publish`.

# Proposed Solution

1. We could use `--include-merged-commits` option in the `next-release` workflow. We could adopt the release process in https://github.com/RequestNetwork/release-tools/pull/8 which uses `lerna publish` on a `release` branch and then `merges` (not `squash merge`) the tagged commits to master. The `-next` releases going forward would have `shortSHA` postfixes instead of `refCount` postfixes. This requires us to enable `merge` on the `master` branch which I don't love - because it runs the risk that non-conventional commits are merged to the `master` branch.

# Alternative Solution

2. We could delete the annotated tags on the `master` branch. We could still adopt the new release process in https://github.com/RequestNetwork/release-tools/pull/8 except continue using squash merge for the `release` branch. The `-next` releases going forward would still have the `refCount` postfixes, and we wouldn't have to enable `merge` on the `master` branch. I don't love this option either because it eliminates the possibility of bumping the version on only changed packages instead of force-publishing all packages every time.