### PR TITLE
chore: add test - create and declare received payment in a single transaction

### DIFF
--- a/packages/request-client.js/test/declarative-payments.test.ts
+++ b/packages/request-client.js/test/declarative-payments.test.ts
@@ -190,7 +190,7 @@ describe('request-client.js: declarative payments', () => {
       expect(requestData.balance!.balance).toEqual('10');
     });
 
-    it('allows to create a request and declare a received payment at the same time', async () => {
+    it('allows to create a request and declare a received payment in the same transaction', async () => {
       const requestNetwork = new RequestNetwork({
         useMockStorage: true,
         signatureProvider: TestData.fakeSignatureProvider,

--- a/packages/request-client.js/test/declarative-payments.test.ts
+++ b/packages/request-client.js/test/declarative-payments.test.ts
@@ -190,6 +190,33 @@ describe('request-client.js: declarative payments', () => {
       expect(requestData.balance!.balance).toEqual('10');
     });
 
+    it('allows to create a request and declare a received payment at the same time', async () => {
+      const requestNetwork = new RequestNetwork({
+        useMockStorage: true,
+        signatureProvider: TestData.fakeSignatureProvider,
+      });
+      const request = await requestNetwork.createRequest({
+        ...requestCreationParams,
+        requestInfo: {
+          ...TestData.parametersWithoutExtensionsData,
+          extensionsData: [
+            {
+              action: ExtensionTypes.PnAnyDeclarative.ACTION.DECLARE_RECEIVED_PAYMENT,
+              id: ExtensionTypes.PAYMENT_NETWORK_ID.ANY_DECLARATIVE,
+              parameters: {
+                amount: '10',
+                note: 'received payment',
+                txhash: '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+                network: 'mainnet',
+              },
+            },
+          ],
+        },
+      });
+      const requestData = await request.waitForConfirmation();
+      expect(requestData.balance!.balance).toEqual('10');
+    });
+
     it('allows to declare a sent refund', async () => {
       const requestNetwork = new RequestNetwork({
         httpConfig,


### PR DESCRIPTION
## Description of the changes

* Add a test that creates and declares the received payment in a single transaction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the declarative payments functionality by allowing users to create a payment request and declare a received payment in a single transaction.
  
- **Tests**
	- Introduced a new test case to validate the simultaneous creation of a request and declaration of a received payment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->