### PR TITLE
chore: payments subgraph Alchemy URLs: ZkSync Era, Avalanche, and Fantom

### DIFF
--- a/packages/payment-detection/src/thegraph/client.ts
+++ b/packages/payment-detection/src/thegraph/client.ts
@@ -113,7 +113,10 @@ export const defaultGetTheGraphClient = (
       network === 'bsc' ||
       network === 'optimism' ||
       network === 'arbitrum-one' ||
-      network === 'base'
+      network === 'base' ||
+      network === 'zksyncera' ||
+      network === 'avalanche' ||
+      network === 'fantom'
     ? getTheGraphEvmClient(`${THE_GRAPH_ALCHEMY_URL.replace('$NETWORK', network)}`, options)
     : getTheGraphEvmClient(`${THE_GRAPH_STUDIO_URL.replace('$NETWORK', network)}`, options);
 };


### PR DESCRIPTION
## Description of the changes

* chore: payments subgraph Alchemy URLs: ZkSync Era, Avalanche, and Fantom
  * Previously used Subgraph Studio URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Expanded blockchain network support in the payment detection functionality, now including 'zksyncera', 'avalanche', and 'fantom' alongside existing networks. This enhancement increases the versatility of the application for users interacting with various blockchain environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->