### PR TITLE
feat: xdai eth conversion

### DIFF
--- a/packages/smart-contracts/src/lib/artifacts/ChainlinkConversionPath/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/ChainlinkConversionPath/index.ts
@@ -89,10 +89,9 @@ export const chainlinkConversionPath = new ContractArtifact<ChainlinkConversionP
           address: '0x0818Ad7016138f0A40DFAe30F64a923c2A8F61bA',
           creationBlockNumber: 28548259,
         },
-        // v0.1.0 contract - v0.2.0 required if/when we support EthConversionProxy on this chain
         xdai: {
-          address: '0xEEc4790306C43DC00cebbE4D0c36Fadf8634B533',
-          creationBlockNumber: 18326897,
+          address: '0x05D782aD6D6556179A6387Ff1D2fA104FD5c515a',
+          creationBlockNumber: 35928984,
         },
         'arbitrum-one': {
           address: '0x0818Ad7016138f0A40DFAe30F64a923c2A8F61bA',

--- a/packages/smart-contracts/src/lib/artifacts/EthConversionProxy/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/EthConversionProxy/index.ts
@@ -104,6 +104,10 @@ export const ethConversionArtifact = new ContractArtifact<EthConversionProxy>(
           address: '0xEdfD8386d5DE52072B4Ad8dC69BBD0bB89f9A1fb',
           creationBlockNumber: 10827267,
         },
+        xdai: {
+          address: '0x3E3B04e1bF170522a5c5DDE628C4d365c0342239',
+          creationBlockNumber: 35929105,
+        },
       },
     },
     '0.2.1': {
@@ -117,6 +121,10 @@ export const ethConversionArtifact = new ContractArtifact<EthConversionProxy>(
         base: {
           address: '0xEdfD8386d5DE52072B4Ad8dC69BBD0bB89f9A1fb',
           creationBlockNumber: 10827267,
+        },
+        xdai: {
+          address: '0x3E3B04e1bF170522a5c5DDE628C4d365c0342239',
+          creationBlockNumber: 35929105,
         },
       },
     },


### PR DESCRIPTION
## Description of the changes

Additional deployment on `xDai` (GnosisChain):
 - Deployment of the latest version of `ChainlinkConversionPath`. The previous version deployed wasn't able to support `EthConversionProxy`
 - Deployment of the `EthConversionProxy` contract.

 ✅ Contracts verified
 ✅ The new `ChainlinkConversionPath` has been fed the list of aggregators set in the previous version. 
 ✅ Ownership transferred to the RN Admin contract

## Next steps:
 - Subgraph update
 - Update the values of `chainlinkConversionPath` and `ethConversionProxy` in the Batch contract on `xDai`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated `xdai` network configuration for the Chainlink conversion path, ensuring accurate contract details.
	- Added support for the `xdai` network in the EthConversionProxy, enhancing multi-network functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->