### PR TITLE
fix: assert promise is rejected and error is thrown after last retry

### DIFF
--- a/packages/utils/test/retry.test.ts
+++ b/packages/utils/test/retry.test.ts
@@ -207,11 +207,12 @@ describe('Retry', () => {
     expect(throwFn).toHaveBeenCalledTimes(8);
     expect(Date.now()).toBe(127000);
 
+    // Reject and throw after the last retry
+    await expect(retryPromise).rejects.toThrow('threw');
+
     // No further retries
     jest.advanceTimersByTime(1000000000);
     await Promise.resolve();
-    await expect(retryPromise).rejects.toThrow('threw');
-
     expect(throwFn).toHaveBeenCalledTimes(8);
     expect(Date.now()).toBe(1000127000);
 


### PR DESCRIPTION
Follow-up #1316 

## Description of the changes

* fix: assert promise is rejected and error is thrown after last retry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced test suite for the retry mechanism with new assertions for error handling after retries.
	- Improved validation of the retry logic, ensuring correct behavior with exponential backoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->