### PR TITLE
chore(currency): search by ID from Map

### DIFF
--- a/packages/currency/src/currencyManager.ts
+++ b/packages/currency/src/currencyManager.ts
@@ -20,8 +20,7 @@ export class CurrencyManager<TMeta = unknown> implements CurrencyTypes.ICurrency
   private readonly legacyTokens: CurrencyTypes.LegacyTokenMap;
   private readonly conversionPairs: CurrencyTypes.AggregatorsMap;
 
-  private readonly knownCurrenciesById: Map<string, CurrencyTypes.CurrencyDefinition<TMeta>> =
-    new Map();
+  private readonly knownCurrenciesById: Map<string, CurrencyTypes.CurrencyDefinition<TMeta>>;
 
   private static defaultInstance: CurrencyManager;
 
@@ -44,6 +43,10 @@ export class CurrencyManager<TMeta = unknown> implements CurrencyTypes.ICurrency
       }
       this.knownCurrencies.push(currency);
     }
+
+    this.knownCurrenciesById = new Map(
+      this.knownCurrencies.map((knownCurrency) => [knownCurrency.id, knownCurrency]),
+    );
     this.legacyTokens = legacyTokens || CurrencyManager.getDefaultLegacyTokens();
     this.conversionPairs = conversionPairs || CurrencyManager.getDefaultConversionPairs();
   }
@@ -87,18 +90,7 @@ export class CurrencyManager<TMeta = unknown> implements CurrencyTypes.ICurrency
    * Gets a supported currency from its CurrencyTypes.CurrencyDefinition id
    */
   fromId(id: string): CurrencyTypes.CurrencyDefinition<TMeta> | undefined {
-    const cachedCurrency = this.knownCurrenciesById.get(id);
-    if (cachedCurrency) {
-      return cachedCurrency;
-    }
-
-    const currency = this.knownCurrencies.find((knownCurrency) => knownCurrency.id === id);
-    if (!currency) {
-      return undefined;
-    }
-
-    this.knownCurrenciesById.set(id, currency);
-    return currency;
+    return this.knownCurrenciesById.get(id);
   }
 
   /**

--- a/packages/currency/src/currencyManager.ts
+++ b/packages/currency/src/currencyManager.ts
@@ -20,6 +20,9 @@ export class CurrencyManager<TMeta = unknown> implements CurrencyTypes.ICurrency
   private readonly legacyTokens: CurrencyTypes.LegacyTokenMap;
   private readonly conversionPairs: CurrencyTypes.AggregatorsMap;
 
+  private readonly knownCurrenciesById: Map<string, CurrencyTypes.CurrencyDefinition<TMeta>> =
+    new Map();
+
   private static defaultInstance: CurrencyManager;
 
   /**
@@ -84,7 +87,18 @@ export class CurrencyManager<TMeta = unknown> implements CurrencyTypes.ICurrency
    * Gets a supported currency from its CurrencyTypes.CurrencyDefinition id
    */
   fromId(id: string): CurrencyTypes.CurrencyDefinition<TMeta> | undefined {
-    return this.knownCurrencies.find((knownCurrency) => knownCurrency.id === id);
+    const cachedCurrency = this.knownCurrenciesById.get(id);
+    if (cachedCurrency) {
+      return cachedCurrency;
+    }
+
+    const currency = this.knownCurrencies.find((knownCurrency) => knownCurrency.id === id);
+    if (!currency) {
+      return undefined;
+    }
+
+    this.knownCurrenciesById.set(id, currency);
+    return currency;
   }
 
   /**

--- a/packages/currency/test/currencyManager.test.ts
+++ b/packages/currency/test/currencyManager.test.ts
@@ -153,6 +153,19 @@ describe('CurrencyManager', () => {
   });
 
   describe('Accessing currencies', () => {
+    it('access a common token by its id', () => {
+      expect(currencyManager.fromId('USDC-multichain-moonbeam')).toMatchObject({
+        symbol: 'USDC-multichain',
+        decimals: 6,
+      });
+
+      // Run the test twice to ensure caching result don't break things.
+      expect(currencyManager.fromId('USDC-multichain-moonbeam')).toMatchObject({
+        symbol: 'USDC-multichain',
+        decimals: 6,
+      });
+    });
+
     it('access a common token by its symbol', () => {
       expect(currencyManager.from('DAI')).toMatchObject({
         symbol: 'DAI',

--- a/packages/currency/test/currencyManager.test.ts
+++ b/packages/currency/test/currencyManager.test.ts
@@ -158,12 +158,6 @@ describe('CurrencyManager', () => {
         symbol: 'USDC-multichain',
         decimals: 6,
       });
-
-      // Run the test twice to ensure caching result don't break things.
-      expect(currencyManager.fromId('USDC-multichain-moonbeam')).toMatchObject({
-        symbol: 'USDC-multichain',
-        decimals: 6,
-      });
     });
 
     it('access a common token by its symbol', () => {


### PR DESCRIPTION
## Description of the changes

Search currency with `.fromId` results from a `Map`.
Since Node.js is a single thread, we couldn't loop through an array in parallel.

```typescript
const data: { currency: string } = [...]; // Consist of 200 items

await Promise.all(data.map(item) => {
   // do some async task // takes 10ms

  const currency = currencyManager.fromId(item.currency) // takes 20ms
  
  return result;
});
```

In the above example, even though we use `Promise.all`, the whole operation will take (200* 20ms) + 10ms = 4010ms. The async task could be executed concurrently, but the array iteration runs serially. If we cache the result in a `Map`, we could get the data with `O(1)` time complexity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved currency retrieval efficiency through caching in the CurrencyManager.
- **Tests**
	- Added tests to ensure correct retrieval of currencies by ID, confirming caching functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->