### PR TITLE
chore(ethereum-storage): add getter for eip-1559 support

### DIFF
--- a/packages/ethereum-storage/src/ethereum-tx-submitter.ts
+++ b/packages/ethereum-storage/src/ethereum-tx-submitter.ts
@@ -75,11 +75,12 @@ export class EthereumTransactionSubmitter implements StorageTypes.ITransactionSu
     this.enableEip1559 = await isEip1559Supported(this.provider, this.logger);
   }
 
+  /** Returns whether EIP-1559 is supported by the underlying provider. */
   supportsEip1559() {
     return this.enableEip1559;
   }
 
-  /** Submits an IPFS hash, with fees according to `ipfsSize`  */
+  /** Submits an IPFS hash, with fees according to `ipfsSize` */
   async submit(ipfsHash: string, ipfsSize: number): Promise<ContractTransaction> {
     const preparedTransaction = await this.prepareSubmit(ipfsHash, ipfsSize);
     return await this.hashSubmitter.signer.sendTransaction(preparedTransaction);

--- a/packages/ethereum-storage/src/ethereum-tx-submitter.ts
+++ b/packages/ethereum-storage/src/ethereum-tx-submitter.ts
@@ -75,6 +75,10 @@ export class EthereumTransactionSubmitter implements StorageTypes.ITransactionSu
     this.enableEip1559 = await isEip1559Supported(this.provider, this.logger);
   }
 
+  supportsEip1559() {
+    return this.enableEip1559;
+  }
+
   /** Submits an IPFS hash, with fees according to `ipfsSize`  */
   async submit(ipfsHash: string, ipfsSize: number): Promise<ContractTransaction> {
     const preparedTransaction = await this.prepareSubmit(ipfsHash, ipfsSize);

--- a/packages/ethereum-storage/test/ethereum-tx-submitter.test.ts
+++ b/packages/ethereum-storage/test/ethereum-tx-submitter.test.ts
@@ -13,6 +13,10 @@ describe(EthereumTransactionSubmitter, () => {
     await txSubmitter.initialize();
   });
 
+  it('can retrieve whether the provider supports eip-1559', () => {
+    expect(txSubmitter.supportsEip1559()).toBe(true);
+  });
+
   it('can prepareSubmit', async () => {
     expect(await txSubmitter.prepareSubmit('hash', 1)).toMatchObject({
       to: '0xf25186b5081ff5ce73482ad761db0eb0d25abfbf',
@@ -20,10 +24,12 @@ describe(EthereumTransactionSubmitter, () => {
       value: BigNumber.from(0),
     });
   });
+
   it('can submit', async () => {
     const tx = await txSubmitter.submit('hash', 1);
     expect(tx.hash).toMatch(/^0x.+/);
   });
+
   it('can debug transactions', async () => {
     const debugMock = jest.fn();
     const logger = {


### PR DESCRIPTION
## Description of the changes

When using the `EthereumTransactionSubmitter` as a standalone class, it is helpful to know whether it supports EIP-1559, for instance, during a service startup's health checks to ensure the underlying RPC provides the feature.

## Current solutions

Currently, the only two options are the following:

### Current solution 1
```ts
const supportEip1559 = await isEip1559Supported(this.provider, this.logger)
```
This does not test the actual support of EIP-1559 for the `EthereumTransactionSubmitter` class:
- `isEip1559Supported()` can return `false` during the initialization phase with `EthereumTransactionSubmitter.initialize()` because the RPC times out, for instance ;
- and then return `true` when we test it by calling again `isEip1559Supported()`.

In this case we're stuck with a `EthereumTransactionSubmitter` that doesn't support EIP-1559 even thought the RPC supports it.

### Current solution 2
```ts
// check if the submitter supports Eip1559 - we only prepare the transaction, we do not send it
const testTransaction = await this.transactionSubmitter.prepareSubmit(
  'test',
  0,
);
const supportEip1559 = Boolean(testTransaction.maxFeePerGas);
```
This works but it wastes some RPC calls:
- One call to get the Request fee against the `StorageFeeCollector`.
- One call to get the current gas fee.

## Proposed change 
Since we already have that information in the class, I propose to expose it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to check if EIP-1559 support is enabled, enhancing user access to transaction submission features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->