### PR TITLE
refactor: prepare `SingleRequestFactory` for deployment with Request Deployer

### DIFF
--- a/packages/smart-contracts/scripts-create2/constructor-args.ts
+++ b/packages/smart-contracts/scripts-create2/constructor-args.ts
@@ -76,7 +76,7 @@ export const getConstructorArgs = (
       const ethereumFeeProxy = artifacts.ethereumFeeProxyArtifact;
       const ethereumFeeProxyAddress = ethereumFeeProxy.getAddress(network);
 
-      return [ethereumFeeProxyAddress, erc20FeeProxyAddress];
+      return [ethereumFeeProxyAddress, erc20FeeProxyAddress, getAdminWalletAddress(contract)];
     }
     default:
       return [];

--- a/packages/smart-contracts/scripts-create2/verify.ts
+++ b/packages/smart-contracts/scripts-create2/verify.ts
@@ -53,7 +53,6 @@ export async function VerifyCreate2FromList(hre: HardhatRuntimeEnvironmentExtend
             EvmChains.assertChainSupported(network);
             const constructorArgs = getConstructorArgs(contract, network);
             address = await computeCreate2DeploymentAddress({ contract, constructorArgs }, hre);
-            console.log(`Contract at ${network} : ${address}`);
             await verifyOne(address, { contract, constructorArgs }, hre);
             break;
           }

--- a/packages/smart-contracts/scripts-create2/verify.ts
+++ b/packages/smart-contracts/scripts-create2/verify.ts
@@ -47,11 +47,13 @@ export async function VerifyCreate2FromList(hre: HardhatRuntimeEnvironmentExtend
           case 'Erc20ConversionProxy':
           case 'ERC20EscrowToPay':
           case 'BatchConversionPayments':
-          case 'ERC20TransferableReceivable': {
+          case 'ERC20TransferableReceivable':
+          case 'SingleRequestProxyFactory': {
             const network = hre.config.xdeploy.networks[0];
             EvmChains.assertChainSupported(network);
             const constructorArgs = getConstructorArgs(contract, network);
             address = await computeCreate2DeploymentAddress({ contract, constructorArgs }, hre);
+            console.log(`Contract at ${network} : ${address}`);
             await verifyOne(address, { contract, constructorArgs }, hre);
             break;
           }

--- a/packages/smart-contracts/src/contracts/SingleRequestProxyFactory.sol
+++ b/packages/smart-contracts/src/contracts/SingleRequestProxyFactory.sol
@@ -34,11 +34,13 @@ contract SingleRequestProxyFactory is Ownable {
   event ERC20FeeProxyUpdated(address indexed newERC20FeeProxy);
   event EthereumFeeProxyUpdated(address indexed newEthereumFeeProxy);
 
-  constructor(address _ethereumFeeProxy, address _erc20FeeProxy) {
+  constructor(address _ethereumFeeProxy, address _erc20FeeProxy, address _owner) {
     require(_ethereumFeeProxy != address(0), 'EthereumFeeProxy address cannot be zero');
     require(_erc20FeeProxy != address(0), 'ERC20FeeProxy address cannot be zero');
+    require(_owner != address(0), 'Owner address cannot be zero');
     ethereumFeeProxy = _ethereumFeeProxy;
     erc20FeeProxy = _erc20FeeProxy;
+    transferOwnership(_owner);
   }
 
   /**

--- a/packages/smart-contracts/test/contracts/SingleRequestProxyFactory.test.ts
+++ b/packages/smart-contracts/test/contracts/SingleRequestProxyFactory.test.ts
@@ -48,6 +48,7 @@ describe('contract: SingleRequestProxyFactory', () => {
     singleRequestProxyFactory = await SingleRequestProxyFactoryFactory.deploy(
       ethereumFeeProxy.address,
       erc20FeeProxy.address,
+      ownerAddress,
     );
     await singleRequestProxyFactory.deployed();
 


### PR DESCRIPTION
Refactor the `SingleRequestProxyFactory` to be deployed by using the Request Deployer.

- Add `transferOwnership` to construct to have the correct owner of smart contract instead of Request Deployer.
- Add `SingleRequestProxyFactory` to verify method
- Update tests to reflect the changes in constructor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `SingleRequestProxyFactory` contract now includes an owner parameter for improved ownership management.
	- Updated functionality to return admin wallet address alongside fee proxy addresses for the `SingleRequestProxyFactory`.

- **Bug Fixes**
	- Improved validation in the constructor to prevent zero address for the owner.

- **Tests**
	- Updated test cases to validate the new owner parameter during contract deployment and ensure ownership functionalities are correctly enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->