### PR TITLE
chore: `Single Request Proxy` deployment to mainnets

### DIFF
--- a/packages/smart-contracts/deploy/deploy-zk-single-request-proxy.ts
+++ b/packages/smart-contracts/deploy/deploy-zk-single-request-proxy.ts
@@ -13,8 +13,8 @@ export default async function () {
     throw new Error('ADMIN_WALLET_ADDRESS is not set');
   }
 
-  const ethereumFeeProxy = erc20FeeProxyArtifact.getAddress('zksyncera');
-  const erc20FeeProxy = ethereumFeeProxyArtifact.getAddress('zksyncera');
+  const ethereumFeeProxy = ethereumFeeProxyArtifact.getAddress('zksyncera');
+  const erc20FeeProxy = erc20FeeProxyArtifact.getAddress('zksyncera');
 
   await deployContract('SingleRequestProxyFactory', [
     ethereumFeeProxy,

--- a/packages/smart-contracts/deploy/deploy-zk-single-request-proxy.ts
+++ b/packages/smart-contracts/deploy/deploy-zk-single-request-proxy.ts
@@ -1,0 +1,24 @@
+import { deployContract } from './utils-zk';
+import { erc20FeeProxyArtifact, ethereumFeeProxyArtifact } from '../src/lib';
+/**
+ * Deploys SingleRequestProxyFactory to zkSync network.
+ * This script is supposed to be run with the deploy-zksync plugin
+ */
+export default async function () {
+  console.log('Deploying SingleRequestProxyFactory to zkSync ...');
+
+  const ownerAdddress = process.env.ADMIN_WALLET_ADDRESS;
+
+  if (!ownerAdddress) {
+    throw new Error('ADMIN_WALLET_ADDRESS is not set');
+  }
+
+  const ethereumFeeProxy = erc20FeeProxyArtifact.getAddress('zksyncera');
+  const erc20FeeProxy = ethereumFeeProxyArtifact.getAddress('zksyncera');
+
+  await deployContract('SingleRequestProxyFactory', [
+    ethereumFeeProxy,
+    erc20FeeProxy,
+    ownerAdddress,
+  ]);
+}

--- a/packages/smart-contracts/deploy/deploy-zk-single-request-proxy.ts
+++ b/packages/smart-contracts/deploy/deploy-zk-single-request-proxy.ts
@@ -7,9 +7,9 @@ import { erc20FeeProxyArtifact, ethereumFeeProxyArtifact } from '../src/lib';
 export default async function () {
   console.log('Deploying SingleRequestProxyFactory to zkSync ...');
 
-  const ownerAdddress = process.env.ADMIN_WALLET_ADDRESS;
+  const ownerAddress = process.env.ADMIN_WALLET_ADDRESS;
 
-  if (!ownerAdddress) {
+  if (!ownerAddress) {
     throw new Error('ADMIN_WALLET_ADDRESS is not set');
   }
 
@@ -19,6 +19,6 @@ export default async function () {
   await deployContract('SingleRequestProxyFactory', [
     ethereumFeeProxy,
     erc20FeeProxy,
-    ownerAdddress,
+    ownerAddress,
   ]);
 }

--- a/packages/smart-contracts/hardhat.config.ts
+++ b/packages/smart-contracts/hardhat.config.ts
@@ -242,6 +242,7 @@ export default {
       auroraTestnet: 'api-key',
       mantle: 'api-key',
       'mantle-testnet': 'api-key',
+      celo: process.env.CELOSCAN_API_KEY,
     },
     customChains: [
       {
@@ -274,6 +275,14 @@ export default {
         urls: {
           apiURL: 'https://openapi.coredao.org/api',
           browserURL: 'https://scan.coredao.org/',
+        },
+      },
+      {
+        network: 'celo',
+        chainId: 42220,
+        urls: {
+          apiURL: 'https://api.celoscan.io/api',
+          browserURL: 'https://celoscan.io/',
         },
       },
     ],

--- a/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/index.ts
@@ -17,6 +17,10 @@ export const singleRequestProxyFactoryArtifact = new ContractArtifact<SingleRequ
           address: '0xf8cACE7EE4c03Eb4f225434B0709527938D365b4',
           creationBlockNumber: 7038199,
         },
+        zksyncera: {
+          address: '0xC52F0f36b4f0Cdf55D4349640C32929c5E85Ab1a',
+          creationBlockNumber: 48467338,
+        },
       },
     },
   },

--- a/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/index.ts
@@ -18,8 +18,8 @@ export const singleRequestProxyFactoryArtifact = new ContractArtifact<SingleRequ
           creationBlockNumber: 7038199,
         },
         zksyncera: {
-          address: '0xC52F0f36b4f0Cdf55D4349640C32929c5E85Ab1a',
-          creationBlockNumber: 48467338,
+          address: '0x9Fd503e723e5EfcCde3183632b443fFF49E68715',
+          creationBlockNumber: 48690095,
         },
         base: {
           address: '0xAdc0001eA67Ab36D5321612c6b500572704fFF20',

--- a/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/index.ts
@@ -21,6 +21,46 @@ export const singleRequestProxyFactoryArtifact = new ContractArtifact<SingleRequ
           address: '0xC52F0f36b4f0Cdf55D4349640C32929c5E85Ab1a',
           creationBlockNumber: 48467338,
         },
+        base: {
+          address: '0xAdc0001eA67Ab36D5321612c6b500572704fFF20',
+          creationBlockNumber: 22154500,
+        },
+        matic: {
+          address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
+          creationBlockNumber: 64048143,
+        },
+        avalanche: {
+          address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
+          creationBlockNumber: 52824404,
+        },
+        optimism: {
+          address: '0xf8cACE7EE4c03Eb4f225434B0709527938D365b4',
+          creationBlockNumber: 127750366,
+        },
+        'arbitrum-one': {
+          address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
+          creationBlockNumber: 272440350,
+        },
+        xdai: {
+          address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
+          creationBlockNumber: 36924272,
+        },
+        bsc: {
+          address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
+          creationBlockNumber: 43839939,
+        },
+        celo: {
+          address: '0x8d996a0591a0F9eB65301592C88303e07Ec481db',
+          creationBlockNumber: 28685655,
+        },
+        mantle: {
+          address: '0xf8cACE7EE4c03Eb4f225434B0709527938D365b4',
+          creationBlockNumber: 71485828,
+        },
+        mainnet: {
+          address: '0xD5933C74414ce80D9d7082cc89FBAdcfF4751fAF',
+          creationBlockNumber: 21145968,
+        },
       },
     },
   },


### PR DESCRIPTION
Resolves #1485 

## Description of the changes
Deploy Single Request Proxy to the following:

- Sepolia
- Ethereum
- Optimism
- Arbitrum One
- Base
- ZkSync Era
- Gnosis
- Polygon
- BNB
- Avalanche
- Celo
- Manle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a deployment script for the `SingleRequestProxyFactory` on the zkSync network.
  - Added support for multiple blockchain networks, including Celo, with updated API configurations.

- **Enhancements**
  - Improved deployment address management for various networks in the configuration settings.

- **Deployment Configurations**
  - Added new deployment details for `SingleRequestProxyFactory` across several blockchain networks, including zksyncera, base, matic, avalanche, optimism, arbitrum-one, xdai, bsc, celo, mantle, and mainnet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->