### PR TITLE
feat: add all data to deployment events

### DIFF
--- a/packages/payment-processor/src/payment/single-request-proxy.ts
+++ b/packages/payment-processor/src/payment/single-request-proxy.ts
@@ -91,13 +91,17 @@ export async function deploySingleRequestProxy(
 
   const receipt = await tx.wait();
 
-  const event = receipt.events?.[0];
+  const event = receipt.events?.find(
+    (e) =>
+      e.event ===
+      (isERC20 ? 'ERC20SingleRequestProxyCreated' : 'EthereumSingleRequestProxyCreated'),
+  );
 
   if (!event) {
     throw new Error('Single request proxy creation event not found');
   }
 
-  const proxyAddress = ethers.utils.defaultAbiCoder.decode(['address', 'address'], event.data)[0];
+  const proxyAddress = event.args?.proxyAddress || event.args?.[0];
 
   if (!proxyAddress) {
     throw new Error('Proxy address not found in event data');

--- a/packages/payment-processor/test/payment/single-request-proxy.test.ts
+++ b/packages/payment-processor/test/payment/single-request-proxy.test.ts
@@ -195,6 +195,15 @@ describe('deploySingleRequestProxy', () => {
     );
 
     expect(eventData[0]).toBe(proxyAddress);
+    expect(eventData[1]).toBe(ethRequest.payee?.value);
+    expect(eventData[2]).toBe(
+      ethRequest.extensions[ExtensionTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT].values
+        .feeAddress,
+    );
+    expect(eventData[3]).toBe(
+      ethRequest.extensions[ExtensionTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT].values
+        .feeAmount,
+    );
   });
 
   it('should deploy ERC20SingleRequestProxy and emit event', async () => {
@@ -225,6 +234,16 @@ describe('deploySingleRequestProxy', () => {
     );
 
     expect(eventData[0]).toBe(proxyAddress);
+    expect(eventData[1]).toBe(erc20Request.payee?.value);
+    expect(eventData[2]).toBe(erc20Request.currencyInfo.value);
+    expect(eventData[3]).toBe(
+      erc20Request.extensions[ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT].values
+        .feeAddress,
+    );
+    expect(eventData[4]).toBe(
+      erc20Request.extensions[ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT].values
+        .feeAmount,
+    );
   });
 
   it('should throw error when trying to pay with invalid single request proxy', async () => {

--- a/packages/payment-processor/test/payment/single-request-proxy.test.ts
+++ b/packages/payment-processor/test/payment/single-request-proxy.test.ts
@@ -170,9 +170,7 @@ describe('deploySingleRequestProxy', () => {
   it('should deploy EthereumSingleRequestProxy and emit event', async () => {
     const singleRequestProxyFactory = singleRequestProxyFactoryArtifact.connect('private', wallet);
 
-    const initialEventCount = await provider.getBlockNumber();
-
-    const walletAddress = await wallet.getAddress();
+    const initialBlock = await provider.getBlockNumber();
 
     const proxyAddress = await deploySingleRequestProxy(ethRequest, wallet);
 
@@ -183,7 +181,7 @@ describe('deploySingleRequestProxy', () => {
     const latestBlock = await provider.getBlockNumber();
     const events = await singleRequestProxyFactory.queryFilter(
       singleRequestProxyFactory.filters.EthereumSingleRequestProxyCreated(),
-      initialEventCount,
+      initialBlock,
       latestBlock,
     );
 
@@ -211,9 +209,7 @@ describe('deploySingleRequestProxy', () => {
   it('should deploy ERC20SingleRequestProxy and emit event', async () => {
     const singleRequestProxyFactory = singleRequestProxyFactoryArtifact.connect('private', wallet);
 
-    const initialEventCount = await provider.getBlockNumber();
-
-    const walletAddress = await wallet.getAddress();
+    const initialBlock = await provider.getBlockNumber();
 
     const proxyAddress = await deploySingleRequestProxy(erc20Request, wallet);
 
@@ -224,7 +220,7 @@ describe('deploySingleRequestProxy', () => {
     const latestBlock = await provider.getBlockNumber();
     const events = await singleRequestProxyFactory.queryFilter(
       singleRequestProxyFactory.filters.ERC20SingleRequestProxyCreated(),
-      initialEventCount,
+      initialBlock,
       latestBlock,
     );
 

--- a/packages/payment-processor/test/payment/single-request-proxy.test.ts
+++ b/packages/payment-processor/test/payment/single-request-proxy.test.ts
@@ -189,7 +189,10 @@ describe('deploySingleRequestProxy', () => {
 
     expect(events.length).toBeGreaterThan(0);
 
-    const eventData = utils.defaultAbiCoder.decode(['address', 'address'], events[0].data);
+    const eventData = utils.defaultAbiCoder.decode(
+      ['address', 'address', 'address', 'uint256', 'address'],
+      events[0].data,
+    );
 
     expect(eventData[0]).toBe(proxyAddress);
   });
@@ -216,7 +219,10 @@ describe('deploySingleRequestProxy', () => {
 
     expect(events.length).toBeGreaterThan(0);
 
-    const eventData = utils.defaultAbiCoder.decode(['address', 'address'], events[0].data);
+    const eventData = utils.defaultAbiCoder.decode(
+      ['address', 'address', 'address', 'uint256', 'address'],
+      events[0].data,
+    );
 
     expect(eventData[0]).toBe(proxyAddress);
   });

--- a/packages/payment-processor/test/payment/single-request-proxy.test.ts
+++ b/packages/payment-processor/test/payment/single-request-proxy.test.ts
@@ -187,23 +187,19 @@ describe('deploySingleRequestProxy', () => {
 
     expect(events.length).toBeGreaterThan(0);
 
-    const eventData = utils.defaultAbiCoder.decode(
-      ['address', 'address', 'address', 'uint256', 'address'],
-      events[0].data,
-    );
-
-    expect(eventData[0]).toBe(proxyAddress);
-    expect(eventData[1]).toBe(ethRequest.payee?.value);
-    expect(eventData[2]).toBe(
+    const event = events[0];
+    expect(event.args?.proxyAddress).toBe(proxyAddress);
+    expect(event.args?.payee).toBe(ethRequest.payee?.value);
+    expect(event.args?.feeAddress).toBe(
       ethRequest.extensions[ExtensionTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT].values
         .feeAddress,
     );
-    expect(eventData[3]).toBe(
+    expect(event.args?.feeAmount.toString()).toBe(
       ethRequest.extensions[ExtensionTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT].values
         .feeAmount,
     );
     const feeProxyUsed = await singleRequestProxyFactory.ethereumFeeProxy();
-    expect(eventData[4]).toBe(feeProxyUsed);
+    expect(event.args?.feeProxyUsed).toBe(feeProxyUsed);
   });
 
   it('should deploy ERC20SingleRequestProxy and emit event', async () => {
@@ -226,24 +222,20 @@ describe('deploySingleRequestProxy', () => {
 
     expect(events.length).toBeGreaterThan(0);
 
-    const eventData = utils.defaultAbiCoder.decode(
-      ['address', 'address', 'address', 'address', 'uint256', 'address'],
-      events[0].data,
-    );
-
-    expect(eventData[0]).toBe(proxyAddress);
-    expect(eventData[1]).toBe(erc20Request.payee?.value);
-    expect(eventData[2]).toBe(erc20Request.currencyInfo.value);
-    expect(eventData[3]).toBe(
+    const event = events[0];
+    expect(event.args?.proxyAddress).toBe(proxyAddress);
+    expect(event.args?.payee).toBe(erc20Request.payee?.value);
+    expect(event.args?.tokenAddress).toBe(erc20Request.currencyInfo.value);
+    expect(event.args?.feeAddress).toBe(
       erc20Request.extensions[ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT].values
         .feeAddress,
     );
-    expect(eventData[4]).toBe(
+    expect(event.args?.feeAmount.toString()).toBe(
       erc20Request.extensions[ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT].values
         .feeAmount,
     );
     const feeProxyUsed = await singleRequestProxyFactory.erc20FeeProxy();
-    expect(eventData[5]).toBe(feeProxyUsed);
+    expect(event.args?.feeProxyUsed).toBe(feeProxyUsed);
   });
 
   it('should throw error when trying to pay with invalid single request proxy', async () => {

--- a/packages/payment-processor/test/payment/single-request-proxy.test.ts
+++ b/packages/payment-processor/test/payment/single-request-proxy.test.ts
@@ -220,7 +220,7 @@ describe('deploySingleRequestProxy', () => {
     expect(events.length).toBeGreaterThan(0);
 
     const eventData = utils.defaultAbiCoder.decode(
-      ['address', 'address', 'address', 'uint256', 'address'],
+      ['address', 'address', 'address', 'address', 'uint256', 'address'],
       events[0].data,
     );
 

--- a/packages/payment-processor/test/payment/single-request-proxy.test.ts
+++ b/packages/payment-processor/test/payment/single-request-proxy.test.ts
@@ -204,6 +204,8 @@ describe('deploySingleRequestProxy', () => {
       ethRequest.extensions[ExtensionTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT].values
         .feeAmount,
     );
+    const feeProxyUsed = await singleRequestProxyFactory.ethereumFeeProxy();
+    expect(eventData[4]).toBe(feeProxyUsed);
   });
 
   it('should deploy ERC20SingleRequestProxy and emit event', async () => {
@@ -244,6 +246,8 @@ describe('deploySingleRequestProxy', () => {
       erc20Request.extensions[ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_FEE_PROXY_CONTRACT].values
         .feeAmount,
     );
+    const feeProxyUsed = await singleRequestProxyFactory.erc20FeeProxy();
+    expect(eventData[5]).toBe(feeProxyUsed);
   });
 
   it('should throw error when trying to pay with invalid single request proxy', async () => {

--- a/packages/smart-contracts/src/contracts/ERC20SingleRequestProxy.sol
+++ b/packages/smart-contracts/src/contracts/ERC20SingleRequestProxy.sol
@@ -13,24 +13,24 @@ import './lib/SafeERC20.sol';
 contract ERC20SingleRequestProxy {
   address public payee;
   address public tokenAddress;
+  bytes public paymentReference;
   address public feeAddress;
   uint256 public feeAmount;
-  bytes public paymentReference;
   IERC20FeeProxy public erc20FeeProxy;
 
   constructor(
     address _payee,
     address _tokenAddress,
+    bytes memory _paymentReference,
     address _feeAddress,
     uint256 _feeAmount,
-    bytes memory _paymentReference,
     address _erc20FeeProxy
   ) {
     payee = _payee;
     tokenAddress = _tokenAddress;
+    paymentReference = _paymentReference;
     feeAddress = _feeAddress;
     feeAmount = _feeAmount;
-    paymentReference = _paymentReference;
     erc20FeeProxy = IERC20FeeProxy(_erc20FeeProxy);
   }
 

--- a/packages/smart-contracts/src/contracts/EthereumSingleRequestProxy.sol
+++ b/packages/smart-contracts/src/contracts/EthereumSingleRequestProxy.sol
@@ -30,9 +30,9 @@ contract EthereumSingleRequestProxy {
   constructor(
     address _payee,
     bytes memory _paymentReference,
-    address _ethereumFeeProxy,
     address _feeAddress,
     uint256 _feeAmount
+    address _ethereumFeeProxy,
   ) {
     payee = _payee;
     paymentReference = _paymentReference;

--- a/packages/smart-contracts/src/contracts/EthereumSingleRequestProxy.sol
+++ b/packages/smart-contracts/src/contracts/EthereumSingleRequestProxy.sol
@@ -31,8 +31,8 @@ contract EthereumSingleRequestProxy {
     address _payee,
     bytes memory _paymentReference,
     address _feeAddress,
-    uint256 _feeAmount
-    address _ethereumFeeProxy,
+    uint256 _feeAmount,
+    address _ethereumFeeProxy
   ) {
     payee = _payee;
     paymentReference = _paymentReference;

--- a/packages/smart-contracts/src/contracts/SingleRequestProxyFactory.sol
+++ b/packages/smart-contracts/src/contracts/SingleRequestProxyFactory.sol
@@ -66,9 +66,9 @@ contract SingleRequestProxyFactory is Ownable {
     EthereumSingleRequestProxy proxy = new EthereumSingleRequestProxy(
       _payee,
       _paymentReference,
-      ethereumFeeProxy,
       _feeAddress,
-      _feeAmount
+      _feeAmount,
+      ethereumFeeProxy
     );
     emit EthereumSingleRequestProxyCreated(
       address(proxy),
@@ -100,9 +100,9 @@ contract SingleRequestProxyFactory is Ownable {
     ERC20SingleRequestProxy proxy = new ERC20SingleRequestProxy(
       _payee,
       _tokenAddress,
+      _paymentReference,
       _feeAddress,
       _feeAmount,
-      _paymentReference,
       erc20FeeProxy
     );
 

--- a/packages/smart-contracts/src/contracts/SingleRequestProxyFactory.sol
+++ b/packages/smart-contracts/src/contracts/SingleRequestProxyFactory.sol
@@ -21,14 +21,20 @@ contract SingleRequestProxyFactory is Ownable {
   event EthereumSingleRequestProxyCreated(
     address proxyAddress,
     address payee,
-    bytes indexed paymentReference
+    bytes indexed paymentReference,
+    address feeAddress,
+    uint256 feeAmount,
+    address feeProxyUsed
   );
 
   event ERC20SingleRequestProxyCreated(
     address proxyAddress,
     address payee,
     address tokenAddress,
-    bytes indexed paymentReference
+    bytes indexed paymentReference,
+    address feeAddress,
+    uint256 feeAmount,
+    address feeProxyUsed
   );
 
   event ERC20FeeProxyUpdated(address indexed newERC20FeeProxy);
@@ -64,7 +70,14 @@ contract SingleRequestProxyFactory is Ownable {
       _feeAddress,
       _feeAmount
     );
-    emit EthereumSingleRequestProxyCreated(address(proxy), _payee, _paymentReference);
+    emit EthereumSingleRequestProxyCreated(
+      address(proxy),
+      _payee,
+      _paymentReference,
+      _feeAddress,
+      _feeAmount,
+      ethereumFeeProxy
+    );
     return address(proxy);
   }
 
@@ -93,7 +106,15 @@ contract SingleRequestProxyFactory is Ownable {
       erc20FeeProxy
     );
 
-    emit ERC20SingleRequestProxyCreated(address(proxy), _payee, _tokenAddress, _paymentReference);
+    emit ERC20SingleRequestProxyCreated(
+      address(proxy),
+      _payee,
+      _tokenAddress,
+      _paymentReference,
+      _feeAddress,
+      _feeAmount,
+      erc20FeeProxy
+    );
     return address(proxy);
   }
 

--- a/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/0.1.0.json
+++ b/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/0.1.0.json
@@ -60,6 +60,24 @@
           "internalType": "bytes",
           "name": "paymentReference",
           "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "feeAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "feeAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "feeProxyUsed",
+          "type": "address"
         }
       ],
       "name": "ERC20SingleRequestProxyCreated",
@@ -98,6 +116,24 @@
           "internalType": "bytes",
           "name": "paymentReference",
           "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "feeAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "feeAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "feeProxyUsed",
+          "type": "address"
         }
       ],
       "name": "EthereumSingleRequestProxyCreated",

--- a/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/index.ts
@@ -13,10 +13,6 @@ export const singleRequestProxyFactoryArtifact = new ContractArtifact<SingleRequ
           address: '0x9d075ae44D859191C121d7522da0Cc3B104b8837',
           creationBlockNumber: 0,
         },
-        sepolia: {
-          address: '0x435E81E12136414e2c09cAFe05E902E23bD46030',
-          creationBlockNumber: 6965557,
-        },
       },
     },
   },

--- a/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/index.ts
@@ -13,6 +13,10 @@ export const singleRequestProxyFactoryArtifact = new ContractArtifact<SingleRequ
           address: '0x9d075ae44D859191C121d7522da0Cc3B104b8837',
           creationBlockNumber: 0,
         },
+        sepolia: {
+          address: '0xf8cACE7EE4c03Eb4f225434B0709527938D365b4',
+          creationBlockNumber: 7038199,
+        },
       },
     },
   },

--- a/packages/smart-contracts/test/contracts/ERC20SingleRequestProxy.test.ts
+++ b/packages/smart-contracts/test/contracts/ERC20SingleRequestProxy.test.ts
@@ -47,9 +47,9 @@ describe('contract: ERC20SingleRequestProxy', () => {
     erc20SingleRequestProxy = await new ERC20SingleRequestProxy__factory(deployer).deploy(
       user2Addr,
       testToken.address,
+      paymentReference,
       feeRecipientAddr,
       feeAmount,
-      paymentReference,
       erc20FeeProxy.address,
     );
 
@@ -156,9 +156,9 @@ describe('contract: ERC20SingleRequestProxy', () => {
     const usdtProxy = await new ERC20SingleRequestProxy__factory(deployer).deploy(
       user2Addr,
       usdtFake.address,
+      paymentReference,
       feeRecipientAddr,
       usdtFeeAmount,
-      paymentReference,
       erc20FeeProxy.address,
     );
 
@@ -210,9 +210,9 @@ describe('contract: ERC20SingleRequestProxy', () => {
     const zeroFeeProxy = await new ERC20SingleRequestProxy__factory(deployer).deploy(
       user2Addr,
       testToken.address,
+      paymentReference,
       feeRecipientAddr,
       0,
-      paymentReference,
       erc20FeeProxy.address,
     );
 

--- a/packages/smart-contracts/test/contracts/EthereumSingleRequestProxy.test.ts
+++ b/packages/smart-contracts/test/contracts/EthereumSingleRequestProxy.test.ts
@@ -30,9 +30,9 @@ describe('contract : EthereumSingleRequestProxy', () => {
     ethereumSingleRequestProxy = await ethereumSingleRequestProxyFactory.deploy(
       payeeAddress,
       paymentReference,
-      ethereumFeeProxy.address,
       feeRecipientAddress,
       feeAmount,
+      ethereumFeeProxy.address,
     );
     await ethereumSingleRequestProxy.deployed();
   });
@@ -87,9 +87,9 @@ describe('contract : EthereumSingleRequestProxy', () => {
     const newEthereumSingleRequestProxy = await newEthereumSingleRequestProxyFactory.deploy(
       payeeAddress,
       paymentReference,
-      mockEthereumFeeProxy.address,
       feeRecipientAddress,
       feeAmount,
+      mockEthereumFeeProxy.address,
     );
     await newEthereumSingleRequestProxy.deployed();
 

--- a/packages/smart-contracts/test/contracts/SingleRequestProxyFactory.test.ts
+++ b/packages/smart-contracts/test/contracts/SingleRequestProxyFactory.test.ts
@@ -83,10 +83,16 @@ describe('contract: SingleRequestProxyFactory', () => {
     expect(proxyAddress).to.not.equal(ethers.constants.AddressZero);
     expect(proxyAddress).to.be.properAddress;
 
-    // Check if the event was emitted with correct parameters
     await expect(tx)
       .to.emit(singleRequestProxyFactory, 'EthereumSingleRequestProxyCreated')
-      .withArgs(proxyAddress, payeeAddress, paymentReference);
+      .withArgs(
+        proxyAddress,
+        payeeAddress,
+        paymentReference,
+        feeRecipientAddress,
+        feeAmount,
+        ethereumFeeProxy.address,
+      );
 
     const proxy = (await ethers.getContractAt(
       'EthereumSingleRequestProxy',
@@ -119,10 +125,17 @@ describe('contract: SingleRequestProxyFactory', () => {
     expect(proxyAddress).to.not.equal(ethers.constants.AddressZero);
     expect(proxyAddress).to.be.properAddress;
 
-    // Check if the event was emitted with correct parameters
     await expect(tx)
       .to.emit(singleRequestProxyFactory, 'ERC20SingleRequestProxyCreated')
-      .withArgs(proxyAddress, payeeAddress, testToken.address, paymentReference);
+      .withArgs(
+        proxyAddress,
+        payeeAddress,
+        testToken.address,
+        paymentReference,
+        feeRecipientAddress,
+        feeAmount,
+        erc20FeeProxy.address,
+      );
 
     const proxy = (await ethers.getContractAt(
       'ERC20SingleRequestProxy',


### PR DESCRIPTION
## Problem

The payment-subgraph could not index the feeAmount, feeAddress, and feeProxyUsed because they were not included in the deployment event.

## Description of the changes

- feat: add all data to deployment events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced event emissions for proxy creation now include detailed fee information (feeAddress, feeAmount, feeProxyUsed).
	- Introduced a new public variable `paymentReference` in the `ERC20SingleRequestProxy` contract for better payment tracking.

- **Bug Fixes**
	- Improved event validation in tests to ensure all relevant parameters are correctly emitted during proxy creation.
	- Enhanced error handling in tests for unsupported payment networks and invalid configurations.

- **Chores**
	- Updated deployment details for the `sepolia` network in the artifact configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->