### PR TITLE
chore: rename single request proxy

### DIFF
--- a/packages/payment-processor/src/index.ts
+++ b/packages/payment-processor/src/index.ts
@@ -27,7 +27,7 @@ export * from './payment/encoder-approval';
 export * as Escrow from './payment/erc20-escrow-payment';
 export * from './payment/prepared-transaction';
 export * from './payment/utils-near';
-export * from './payment/single-request-proxy';
+export * from './payment/single-request-forwarder';
 
 import * as utils from './payment/utils';
 

--- a/packages/payment-processor/src/payment/single-request-forwarder.ts
+++ b/packages/payment-processor/src/payment/single-request-forwarder.ts
@@ -47,7 +47,7 @@ export async function deploySingleRequestForwarder(
     signer,
   );
 
-  if (!singleRequestProxyFactory.address) {
+  if (!singleRequestForwarderFactory.address) {
     throw new Error(`SingleRequestForwarderFactory not found on chain ${paymentChain}`);
   }
 
@@ -111,10 +111,10 @@ export async function deploySingleRequestForwarder(
 }
 
 /**
- * Validates that a contract is a SingleRequestProxy by checking required methods
+ * Validates that a contract is a SingleRequestForwarder by checking required methods
  * @param proxyAddress - The address of the contract to validate
  * @param signer - The Ethereum signer used to interact with the contract
- * @throws {Error} If the contract is not a valid SingleRequestProxy
+ * @throws {Error} If the contract is not a valid SingleRequestForwarder
  */
 async function validateSingleRequestForwarder(
   forwarderAddress: string,
@@ -212,11 +212,11 @@ export async function payWithEthereumSingleRequestForwarder(
     await forwarderContract.tokenAddress();
 
     // If the token address is fetched, it means the contract is an ERC20SingleRequestForwarder.
-    throw new Error('Contract is not an EthereumSingleRequestProxy');
+    throw new Error('Contract is not an EthereumSingleRequestForwarder');
   } catch (error) {
-    // If the token address is not fetched, it means the contract is an EthereumSingleRequestProxy.
-    if (error.message === 'Contract is not an EthereumSingleRequestProxy') {
-      // If the error message is 'Contract is not an EthereumSingleRequestProxy', throw the error.
+    // If the token address is not fetched, it means the contract is an EthereumSingleRequestForwarder.
+    if (error.message === 'Contract is not an EthereumSingleRequestForwarder') {
+      // If the error message is 'Contract is not an EthereumSingleRequestForwarder', throw the error.
       throw error;
     }
   }

--- a/packages/payment-processor/src/payment/single-request-forwarder.ts
+++ b/packages/payment-processor/src/payment/single-request-forwarder.ts
@@ -94,7 +94,7 @@ export async function deploySingleRequestForwarder(
   const event = receipt.events?.find(
     (e: ethers.Event) =>
       e.event ===
-      (isERC20 ? 'ERC20SingleRequestForwarderCreated' : 'EthereumSingleRequestForwarderCreated'),
+      (isERC20 ? 'ERC20SingleRequestProxyCreated' : 'EthereumSingleRequestProxyCreated'),
   );
 
   if (!event) {

--- a/packages/payment-processor/src/payment/single-request-forwarder.ts
+++ b/packages/payment-processor/src/payment/single-request-forwarder.ts
@@ -4,24 +4,24 @@ import {
   getPaymentNetworkExtension,
 } from '@requestnetwork/payment-detection';
 import { ClientTypes, ExtensionTypes, CurrencyTypes } from '@requestnetwork/types';
-import { singleRequestProxyFactoryArtifact } from '@requestnetwork/smart-contracts';
+import { singleRequestForwarderFactoryArtifact } from '@requestnetwork/smart-contracts';
 import { IERC20__factory } from '@requestnetwork/smart-contracts/types';
 
 /**
- * Deploys a Single Request Proxy contract for a given request.
+ * Deploys a Single Request Forwarder contract for a given request.
  *
  * @param request - The request data object containing payment network and currency information.
  * @param signer - The Ethereum signer used to deploy the contract.
- * @returns A Promise that resolves to the address of the deployed Single Request Proxy contract.
+ * @returns A Promise that resolves to the address of the deployed Single Request Forwarder contract.
  * @throws {Error} If the payment network is unsupported, payment chain is not found, payee is not found, or if there are invalid payment network values.
  *
  * @remarks
- * This function supports deploying proxies for ERC20_FEE_PROXY_CONTRACT and ETH_FEE_PROXY_CONTRACT payment networks.
- * It uses the SingleRequestProxyFactory contract to create either an ERC20 or Ethereum Single Request Proxy.
+ * This function supports deploying forwarders for ERC20_FEE_PROXY_CONTRACT and ETH_FEE_PROXY_CONTRACT payment networks.
+ * It uses the SingleRequestForwarderFactory contract to create either an ERC20 or Ethereum Single Request Forwarder.
  * The function calculates the payment reference and handles the deployment transaction, including waiting for confirmation.
- * The factory address is automatically determined based on the payment chain using the singleRequestProxyFactoryArtifact.
+ * The factory address is automatically determined based on the payment chain using the singleRequestForwarderFactoryArtifact.
  */
-export async function deploySingleRequestProxy(
+export async function deploySingleRequestForwarder(
   request: ClientTypes.IRequestData,
   signer: Signer,
 ): Promise<string> {
@@ -42,13 +42,13 @@ export async function deploySingleRequestProxy(
   }
 
   // Use artifact's default address for the payment chain
-  const singleRequestProxyFactory = singleRequestProxyFactoryArtifact.connect(
+  const singleRequestForwarderFactory = singleRequestForwarderFactoryArtifact.connect(
     paymentChain as CurrencyTypes.EvmChainName,
     signer,
   );
 
   if (!singleRequestProxyFactory.address) {
-    throw new Error(`SingleRequestProxyFactory not found on chain ${paymentChain}`);
+    throw new Error(`SingleRequestForwarderFactory not found on chain ${paymentChain}`);
   }
 
   const salt = requestPaymentNetwork?.values?.salt;
@@ -73,7 +73,7 @@ export async function deploySingleRequestProxy(
 
   if (isERC20) {
     const tokenAddress = request.currencyInfo.value;
-    tx = await singleRequestProxyFactory.createERC20SingleRequestProxy(
+    tx = await singleRequestForwarderFactory.createERC20SingleRequestProxy(
       paymentRecipient,
       tokenAddress,
       paymentReference,
@@ -81,7 +81,7 @@ export async function deploySingleRequestProxy(
       feeAmount,
     );
   } else {
-    tx = await singleRequestProxyFactory.createEthereumSingleRequestProxy(
+    tx = await singleRequestForwarderFactory.createEthereumSingleRequestProxy(
       paymentRecipient,
       paymentReference,
       feeAddress,
@@ -92,22 +92,22 @@ export async function deploySingleRequestProxy(
   const receipt = await tx.wait();
 
   const event = receipt.events?.find(
-    (e) =>
+    (e: ethers.Event) =>
       e.event ===
-      (isERC20 ? 'ERC20SingleRequestProxyCreated' : 'EthereumSingleRequestProxyCreated'),
+      (isERC20 ? 'ERC20SingleRequestForwarderCreated' : 'EthereumSingleRequestForwarderCreated'),
   );
 
   if (!event) {
-    throw new Error('Single request proxy creation event not found');
+    throw new Error('Single request forwarder creation event not found');
   }
 
-  const proxyAddress = event.args?.proxyAddress || event.args?.[0];
+  const forwarderAddress = event.args?.proxyAddress || event.args?.[0];
 
-  if (!proxyAddress) {
-    throw new Error('Proxy address not found in event data');
+  if (!forwarderAddress) {
+    throw new Error('Forwarder address not found in event data');
   }
 
-  return proxyAddress;
+  return forwarderAddress;
 }
 
 /**
@@ -116,37 +116,40 @@ export async function deploySingleRequestProxy(
  * @param signer - The Ethereum signer used to interact with the contract
  * @throws {Error} If the contract is not a valid SingleRequestProxy
  */
-async function validateSingleRequestProxy(proxyAddress: string, signer: Signer): Promise<void> {
-  const proxyInterface = new ethers.utils.Interface([
+async function validateSingleRequestForwarder(
+  forwarderAddress: string,
+  signer: Signer,
+): Promise<void> {
+  const forwarderInterface = new ethers.utils.Interface([
     'function payee() view returns (address)',
     'function paymentReference() view returns (bytes)',
     'function feeAddress() view returns (address)',
     'function feeAmount() view returns (uint256)',
   ]);
 
-  const proxyContract = new Contract(proxyAddress, proxyInterface, signer);
+  const forwarderContract = new Contract(forwarderAddress, forwarderInterface, signer);
 
   try {
     await Promise.all([
-      proxyContract.payee(),
-      proxyContract.paymentReference(),
-      proxyContract.feeAddress(),
-      proxyContract.feeAmount(),
+      forwarderContract.payee(),
+      forwarderContract.paymentReference(),
+      forwarderContract.feeAddress(),
+      forwarderContract.feeAmount(),
     ]);
   } catch (error) {
-    throw new Error('Invalid SingleRequestProxy contract');
+    throw new Error('Invalid SingleRequestForwarder contract');
   }
 }
 
 /**
- * Executes a payment through an ERC20SingleRequestProxy contract
- * @param proxyAddress - The address of the SingleRequestProxy contract
+ * Executes a payment through an ERC20SingleRequestForwarder contract
+ * @param forwarderAddress - The address of the SingleRequestForwarder contract
  * @param signer - The Ethereum signer used to execute the payment transaction
  * @param amount - The amount to be paid
- * @throws {Error} If the contract is not an ERC20SingleRequestProxy
+ * @throws {Error} If the contract is not an ERC20SingleRequestForwarder
  */
-export async function payWithERC20SingleRequestProxy(
-  proxyAddress: string,
+export async function payWithERC20SingleRequestForwarder(
+  forwarderAddress: string,
   signer: Signer,
   amount: string,
 ): Promise<void> {
@@ -154,43 +157,43 @@ export async function payWithERC20SingleRequestProxy(
     throw new Error('Amount must be a positive number');
   }
 
-  const proxyInterface = new ethers.utils.Interface([
+  const forwarderInterface = new ethers.utils.Interface([
     'function tokenAddress() view returns (address)',
   ]);
 
-  const proxyContract = new Contract(proxyAddress, proxyInterface, signer);
+  const forwarderContract = new Contract(forwarderAddress, forwarderInterface, signer);
 
   let tokenAddress: string;
   try {
-    // Attempt to fetch the token address from the proxy contract, to determine if it's an ERC20 SingleRequestProxy.
-    tokenAddress = await proxyContract.tokenAddress();
+    // Attempt to fetch the token address from the forwarder contract, to determine if it's an ERC20 SingleRequestForwarder.
+    tokenAddress = await forwarderContract.tokenAddress();
   } catch {
-    throw new Error('Contract is not an ERC20SingleRequestProxy');
+    throw new Error('Contract is not an ERC20SingleRequestForwarder');
   }
 
   const erc20Contract = IERC20__factory.connect(tokenAddress, signer);
 
-  // Transfer tokens to the proxy
-  const transferTx = await erc20Contract.transfer(proxyAddress, amount);
+  // Transfer tokens to the forwarder
+  const transferTx = await erc20Contract.transfer(forwarderAddress, amount);
   await transferTx.wait();
 
   // Trigger the proxy's receive function to finalize payment
   const triggerTx = await signer.sendTransaction({
-    to: proxyAddress,
+    to: forwarderAddress,
     value: ethers.constants.Zero,
   });
   await triggerTx.wait();
 }
 
 /**
- * Executes a payment through an EthereumSingleRequestProxy contract
- * @param proxyAddress - The address of the SingleRequestProxy contract
+ * Executes a payment through an EthereumSingleRequestForwarder contract
+ * @param forwarderAddress - The address of the SingleRequestForwarder contract
  * @param signer - The Ethereum signer used to execute the payment transaction
  * @param amount - The amount to be paid
- * @throws {Error} If the contract is an ERC20SingleRequestProxy
+ * @throws {Error} If the contract is an EthereumSingleRequestForwarder
  */
-export async function payWithEthereumSingleRequestProxy(
-  proxyAddress: string,
+export async function payWithEthereumSingleRequestForwarder(
+  forwarderAddress: string,
   signer: Signer,
   amount: string,
 ): Promise<void> {
@@ -198,17 +201,17 @@ export async function payWithEthereumSingleRequestProxy(
     throw new Error('Amount must be a positive number');
   }
 
-  const proxyInterface = new ethers.utils.Interface([
+  const forwarderInterface = new ethers.utils.Interface([
     'function tokenAddress() view returns (address)',
   ]);
 
-  const proxyContract = new Contract(proxyAddress, proxyInterface, signer);
+  const forwarderContract = new Contract(forwarderAddress, forwarderInterface, signer);
 
   try {
-    // Attempt to fetch the token address from the proxy contract, to determine if it's an Ethereum SingleRequestProxy.
-    await proxyContract.tokenAddress();
+    // Attempt to fetch the token address from the forwarder contract, to determine if it's an Ethereum SingleRequestForwarder.
+    await forwarderContract.tokenAddress();
 
-    // If the token address is fetched, it means the contract is an ERC20SingleRequestProxy.
+    // If the token address is fetched, it means the contract is an ERC20SingleRequestForwarder.
     throw new Error('Contract is not an EthereumSingleRequestProxy');
   } catch (error) {
     // If the token address is not fetched, it means the contract is an EthereumSingleRequestProxy.
@@ -219,7 +222,7 @@ export async function payWithEthereumSingleRequestProxy(
   }
 
   const tx = await signer.sendTransaction({
-    to: proxyAddress,
+    to: forwarderAddress,
     value: amount,
   });
   await tx.wait();
@@ -228,21 +231,21 @@ export async function payWithEthereumSingleRequestProxy(
 /**
  * Executes a payment through a Single Request Proxy contract.
  *
- * @param singleRequestProxyAddress - The address of the deployed Single Request Proxy contract.
+ * @param singleRequestForwarderAddress - The address of the deployed Single Request Forwarder contract.
  * @param signer - The Ethereum signer used to execute the payment transaction.
  * @param amount - The amount to be paid, as a string representation of the value.
  * @returns A Promise that resolves when the payment transaction is confirmed.
- * @throws {Error} If the SingleRequestProxy contract is invalid.
- * @throws {Error} If the proxy contract type cannot be determined, or if any transaction fails.
+ * @throws {Error} If the SingleRequestForwarder contract is invalid.
+ * @throws {Error} If the forwarder contract type cannot be determined, or if any transaction fails.
  *
  * @remarks
  * This function supports both ERC20 and Ethereum payments.
- * For ERC20 payments, it first transfers the tokens to the proxy contract and then triggers the payment.
+ * For ERC20 payments, it first transfers the tokens to the forwarder contract and then triggers the payment.
  * For Ethereum payments, it directly sends the Ether to the proxy contract.
  * The function automatically detects whether the proxy is for ERC20 or Ethereum based on the contract interface.
  */
-export async function payRequestWithSingleRequestProxy(
-  singleRequestProxyAddress: string,
+export async function payRequestWithSingleRequestForwarder(
+  singleRequestForwarderAddress: string,
   signer: Signer,
   amount: string,
 ): Promise<void> {
@@ -250,26 +253,26 @@ export async function payRequestWithSingleRequestProxy(
     throw new Error('Amount must be a positive number');
   }
 
-  // Validate the SingleRequestProxy contract
-  await validateSingleRequestProxy(singleRequestProxyAddress, signer);
+  // Validate the SingleRequestForwarder contract
+  await validateSingleRequestForwarder(singleRequestForwarderAddress, signer);
 
-  const proxyInterface = new ethers.utils.Interface([
+  const forwarderInterface = new ethers.utils.Interface([
     'function tokenAddress() view returns (address)',
   ]);
 
-  const proxyContract = new Contract(singleRequestProxyAddress, proxyInterface, signer);
+  const forwarderContract = new Contract(singleRequestForwarderAddress, forwarderInterface, signer);
 
   let isERC20: boolean;
   try {
-    await proxyContract.tokenAddress();
+    await forwarderContract.tokenAddress();
     isERC20 = true;
   } catch {
     isERC20 = false;
   }
 
   if (isERC20) {
-    await payWithERC20SingleRequestProxy(singleRequestProxyAddress, signer, amount);
+    await payWithERC20SingleRequestForwarder(singleRequestForwarderAddress, signer, amount);
   } else {
-    await payWithEthereumSingleRequestProxy(singleRequestProxyAddress, signer, amount);
+    await payWithEthereumSingleRequestForwarder(singleRequestForwarderAddress, signer, amount);
   }
 }

--- a/packages/payment-processor/src/payment/single-request-forwarder.ts
+++ b/packages/payment-processor/src/payment/single-request-forwarder.ts
@@ -190,7 +190,7 @@ export async function payWithERC20SingleRequestForwarder(
  * @param forwarderAddress - The address of the SingleRequestForwarder contract
  * @param signer - The Ethereum signer used to execute the payment transaction
  * @param amount - The amount to be paid
- * @throws {Error} If the contract is an EthereumSingleRequestForwarder
+ * @throws {Error} If the contract is not an EthereumSingleRequestForwarder
  */
 export async function payWithEthereumSingleRequestForwarder(
   forwarderAddress: string,

--- a/packages/payment-processor/src/payment/single-request-forwarder.ts
+++ b/packages/payment-processor/src/payment/single-request-forwarder.ts
@@ -241,7 +241,7 @@ export async function payWithEthereumSingleRequestForwarder(
  * @remarks
  * This function supports both ERC20 and Ethereum payments.
  * For ERC20 payments, it first transfers the tokens to the forwarder contract and then triggers the payment.
- * For Ethereum payments, it directly sends the Ether to the proxy contract.
+ * For Ethereum payments, it directly sends the Ether to the forwarder contract.
  * The function automatically detects whether the proxy is for ERC20 or Ethereum based on the contract interface.
  */
 export async function payRequestWithSingleRequestForwarder(

--- a/packages/payment-processor/test/payment/single-request-forwarder.test.ts
+++ b/packages/payment-processor/test/payment/single-request-forwarder.test.ts
@@ -138,7 +138,7 @@ describe('deploySingleRequestProxy', () => {
     const invalidRequestWithoutNetwork = { ...ethRequest, currencyInfo: {} };
 
     await expect(
-      // @ts-expect-error: invalid request
+      // @ts-expect-error: Request with empty currencyInfo
       deploySingleRequestForwarder(invalidRequestWithoutNetwork, wallet),
     ).rejects.toThrow('Payment chain not found');
   });

--- a/packages/payment-processor/test/payment/single-request-forwarder.test.ts
+++ b/packages/payment-processor/test/payment/single-request-forwarder.test.ts
@@ -1,4 +1,4 @@
-import { singleRequestProxyFactoryArtifact } from '@requestnetwork/smart-contracts';
+import { singleRequestForwarderFactoryArtifact } from '@requestnetwork/smart-contracts';
 import { TestERC20__factory } from '@requestnetwork/smart-contracts/types';
 import {
   ClientTypes,
@@ -138,6 +138,7 @@ describe('deploySingleRequestProxy', () => {
     const invalidRequestWithoutNetwork = { ...ethRequest, currencyInfo: {} };
 
     await expect(
+      // @ts-expect-error: invalid request
       deploySingleRequestForwarder(invalidRequestWithoutNetwork, wallet),
     ).rejects.toThrow('Payment chain not found');
   });
@@ -167,7 +168,10 @@ describe('deploySingleRequestProxy', () => {
   });
 
   it('should deploy EthereumSingleRequestProxy and emit event', async () => {
-    const singleRequestProxyFactory = singleRequestProxyFactoryArtifact.connect('private', wallet);
+    const singleRequestProxyFactory = singleRequestForwarderFactoryArtifact.connect(
+      'private',
+      wallet,
+    );
 
     const initialBlock = await provider.getBlockNumber();
 
@@ -202,7 +206,10 @@ describe('deploySingleRequestProxy', () => {
   });
 
   it('should deploy ERC20SingleRequestProxy and emit event', async () => {
-    const singleRequestProxyFactory = singleRequestProxyFactoryArtifact.connect('private', wallet);
+    const singleRequestProxyFactory = singleRequestForwarderFactoryArtifact.connect(
+      'private',
+      wallet,
+    );
 
     const initialBlock = await provider.getBlockNumber();
 

--- a/packages/payment-processor/test/payment/single-request-forwarder.test.ts
+++ b/packages/payment-processor/test/payment/single-request-forwarder.test.ts
@@ -308,7 +308,7 @@ describe('payWithEthereumSingleRequestProxy', () => {
 
     await expect(
       payWithEthereumSingleRequestForwarder(proxyAddress, wallet, '1000'),
-    ).rejects.toThrow('Contract is not an EthereumSingleRequestProxy');
+    ).rejects.toThrow('Contract is not an EthereumSingleRequestForwarder');
   });
 
   it('should successfully pay with ETH', async () => {
@@ -338,7 +338,7 @@ describe('payWithERC20SingleRequestProxy', () => {
     const proxyAddress = await deploySingleRequestForwarder(ethRequest, wallet);
 
     await expect(payWithERC20SingleRequestForwarder(proxyAddress, wallet, '1000')).rejects.toThrow(
-      'Contract is not an ERC20SingleRequestProxy',
+      'Contract is not an ERC20SingleRequestForwarder',
     );
   });
 

--- a/packages/smart-contracts/scripts-create2/contract-setup/setupSingleRequestProxyFactory.ts
+++ b/packages/smart-contracts/scripts-create2/contract-setup/setupSingleRequestProxyFactory.ts
@@ -1,5 +1,5 @@
 import { EvmChains } from '@requestnetwork/currency';
-import { singleRequestProxyFactoryArtifact } from '../../src/lib';
+import { singleRequestForwarderFactoryArtifact } from '../../src/lib';
 import { HardhatRuntimeEnvironmentExtended } from '../types';
 import {
   getSignerAndGasFees,
@@ -28,7 +28,7 @@ export const setupSRPF = async ({
       try {
         EvmChains.assertChainSupported(network);
         if (!contractAddress) {
-          contractAddress = singleRequestProxyFactoryArtifact.getAddress(network);
+          contractAddress = singleRequestForwarderFactoryArtifact.getAddress(network);
         }
         if (!contractAddress) {
           console.warn(`Missing SingleRequestProxyFactory deployment on ${network}`);
@@ -37,7 +37,7 @@ export const setupSRPF = async ({
 
         const factory = new hre.ethers.Contract(
           contractAddress,
-          singleRequestProxyFactoryArtifact.getContractAbi(),
+          singleRequestForwarderFactoryArtifact.getContractAbi(),
         );
         const { signer, txOverrides } = await getSignerAndGasFees(network, hre);
         const factoryConnected = factory.connect(signer);

--- a/packages/smart-contracts/scripts-create2/contract-setup/setupSingleRequestProxyFactory.ts
+++ b/packages/smart-contracts/scripts-create2/contract-setup/setupSingleRequestProxyFactory.ts
@@ -31,7 +31,7 @@ export const setupSRPF = async ({
           contractAddress = singleRequestForwarderFactoryArtifact.getAddress(network);
         }
         if (!contractAddress) {
-          console.warn(`Missing SingleRequestProxyFactory deployment on ${network}`);
+          console.warn(`Missing SingleRequestForwarderFactory deployment on ${network}`);
           return;
         }
 
@@ -57,10 +57,10 @@ export const setupSRPF = async ({
           signWithEoa,
         );
 
-        console.log(`Setup of SingleRequestProxyFactory successful on ${network}`);
+        console.log(`Setup of SingleRequestForwarderFactory successful on ${network}`);
       } catch (err) {
         console.warn(
-          `An error occurred during the setup of SingleRequestProxyFactory on ${network}`,
+          `An error occurred during the setup of SingleRequestForwarderFactory on ${network}`,
         );
         console.warn(err);
       }

--- a/packages/smart-contracts/scripts-create2/utils.ts
+++ b/packages/smart-contracts/scripts-create2/utils.ts
@@ -58,7 +58,7 @@ export const getArtifact = (contract: string): artifacts.ContractArtifact<Contra
     case 'ERC20TransferableReceivable':
       return artifacts.erc20TransferableReceivableArtifact;
     case 'SingleRequestProxyFactory':
-      return artifacts.singleRequestProxyFactoryArtifact;
+      return artifacts.singleRequestForwarderFactoryArtifact;
     default:
       throw new Error('Contract unknown');
   }

--- a/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/index.ts
+++ b/packages/smart-contracts/src/lib/artifacts/SingleRequestProxyFactory/index.ts
@@ -4,65 +4,66 @@ import { abi as ABI_0_1_0 } from './0.1.0.json';
 
 import type { SingleRequestProxyFactory } from '../../../types';
 
-export const singleRequestProxyFactoryArtifact = new ContractArtifact<SingleRequestProxyFactory>(
-  {
-    '0.1.0': {
-      abi: ABI_0_1_0,
-      deployment: {
-        private: {
-          address: '0x9d075ae44D859191C121d7522da0Cc3B104b8837',
-          creationBlockNumber: 0,
-        },
-        sepolia: {
-          address: '0xf8cACE7EE4c03Eb4f225434B0709527938D365b4',
-          creationBlockNumber: 7038199,
-        },
-        zksyncera: {
-          address: '0x9Fd503e723e5EfcCde3183632b443fFF49E68715',
-          creationBlockNumber: 48690095,
-        },
-        base: {
-          address: '0xAdc0001eA67Ab36D5321612c6b500572704fFF20',
-          creationBlockNumber: 22154500,
-        },
-        matic: {
-          address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
-          creationBlockNumber: 64048143,
-        },
-        avalanche: {
-          address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
-          creationBlockNumber: 52824404,
-        },
-        optimism: {
-          address: '0xf8cACE7EE4c03Eb4f225434B0709527938D365b4',
-          creationBlockNumber: 127750366,
-        },
-        'arbitrum-one': {
-          address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
-          creationBlockNumber: 272440350,
-        },
-        xdai: {
-          address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
-          creationBlockNumber: 36924272,
-        },
-        bsc: {
-          address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
-          creationBlockNumber: 43839939,
-        },
-        celo: {
-          address: '0x8d996a0591a0F9eB65301592C88303e07Ec481db',
-          creationBlockNumber: 28685655,
-        },
-        mantle: {
-          address: '0xf8cACE7EE4c03Eb4f225434B0709527938D365b4',
-          creationBlockNumber: 71485828,
-        },
-        mainnet: {
-          address: '0xD5933C74414ce80D9d7082cc89FBAdcfF4751fAF',
-          creationBlockNumber: 21145968,
+export const singleRequestForwarderFactoryArtifact =
+  new ContractArtifact<SingleRequestProxyFactory>(
+    {
+      '0.1.0': {
+        abi: ABI_0_1_0,
+        deployment: {
+          private: {
+            address: '0x9d075ae44D859191C121d7522da0Cc3B104b8837',
+            creationBlockNumber: 0,
+          },
+          sepolia: {
+            address: '0xf8cACE7EE4c03Eb4f225434B0709527938D365b4',
+            creationBlockNumber: 7038199,
+          },
+          zksyncera: {
+            address: '0x9Fd503e723e5EfcCde3183632b443fFF49E68715',
+            creationBlockNumber: 48690095,
+          },
+          base: {
+            address: '0xAdc0001eA67Ab36D5321612c6b500572704fFF20',
+            creationBlockNumber: 22154500,
+          },
+          matic: {
+            address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
+            creationBlockNumber: 64048143,
+          },
+          avalanche: {
+            address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
+            creationBlockNumber: 52824404,
+          },
+          optimism: {
+            address: '0xf8cACE7EE4c03Eb4f225434B0709527938D365b4',
+            creationBlockNumber: 127750366,
+          },
+          'arbitrum-one': {
+            address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
+            creationBlockNumber: 272440350,
+          },
+          xdai: {
+            address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
+            creationBlockNumber: 36924272,
+          },
+          bsc: {
+            address: '0x4D417AA04DBb207201a794E5B7381B3cde815281',
+            creationBlockNumber: 43839939,
+          },
+          celo: {
+            address: '0x8d996a0591a0F9eB65301592C88303e07Ec481db',
+            creationBlockNumber: 28685655,
+          },
+          mantle: {
+            address: '0xf8cACE7EE4c03Eb4f225434B0709527938D365b4',
+            creationBlockNumber: 71485828,
+          },
+          mainnet: {
+            address: '0xD5933C74414ce80D9d7082cc89FBAdcfF4751fAF',
+            creationBlockNumber: 21145968,
+          },
         },
       },
     },
-  },
-  '0.1.0',
-);
+    '0.1.0',
+  );


### PR DESCRIPTION
## Description of the changes
- Change `Single Request Proxy` to `Single Request Forwarder`

This PR does not rename the smart contracts since they are already deployed, it only effects the SDK methods that help make interactions with SRF easier for the builder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Renamed and updated payment processing functions to enhance clarity and functionality, transitioning from "Single Request Proxy" to "Single Request Forwarder."

- **Bug Fixes**
	- Improved error handling and messaging to align with the new forwarder terminology.

- **Documentation**
	- Updated documentation comments to reflect the new naming conventions and functionalities.

- **Tests**
	- Adjusted test cases to ensure compatibility with the renamed functions while maintaining existing logic and error handling.

- **Chores**
	- Refactored code to replace references from `singleRequestProxy` to `singleRequestForwarder`, ensuring consistency across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->