### PR TITLE
refactor: rename decryption enable method

### DIFF
--- a/packages/epk-cipher/src/ethereum-private-key-cipher-provider.ts
+++ b/packages/epk-cipher/src/ethereum-private-key-cipher-provider.ts
@@ -52,7 +52,7 @@ export default class EthereumPrivateKeyCipherProvider
    *
    * @param option
    */
-  public switchOnOffDecryption(option: boolean): void {
+  public enableDecryption(option: boolean): void {
     this.isDecryptionOn = option;
   }
   /**

--- a/packages/lit-protocol-cipher/src/lit-protocol-cipher-provider.ts
+++ b/packages/lit-protocol-cipher/src/lit-protocol-cipher-provider.ts
@@ -283,7 +283,7 @@ export default class LitProvider implements CipherProviderTypes.ICipherProvider 
    *
    * @param option
    */
-  public switchOnOffDecryption(option: boolean): void {
+  public enableDecryption(option: boolean): void {
     this.isDecryptionOn = option;
   }
 

--- a/packages/transaction-manager/test/unit/utils/test-data.ts
+++ b/packages/transaction-manager/test/unit/utils/test-data.ts
@@ -106,7 +106,7 @@ export const fakeDecryptionProvider: DecryptionProviderTypes.IDecryptionProvider
 };
 
 export class FakeEpkCipherProvider implements CipherProviderTypes.ICipherProvider {
-  switchOnOffDecryption(option: boolean): void {
+  enableDecryption(option: boolean): void {
     throw new Error('Method not implemented.');
   }
   isEncryptionAvailable(): boolean {
@@ -177,7 +177,7 @@ export class FakeLitProtocolProvider implements CipherProviderTypes.ICipherProvi
   constructor() {
     this.storedRawData = '';
   }
-  switchOnOffDecryption(option: boolean): void {
+  enableDecryption(option: boolean): void {
     throw new Error('Method not implemented.');
   }
   isEncryptionAvailable(): boolean {

--- a/packages/types/src/cipher-provider-types.ts
+++ b/packages/types/src/cipher-provider-types.ts
@@ -34,5 +34,5 @@ export interface ICipherProvider {
    * Switches on/off decryption.
    * @param option - A boolean indicating if decryption should be switched on/off.
    */
-  switchOnOffDecryption(option: boolean): void;
+  enableDecryption(option: boolean): void;
 }


### PR DESCRIPTION
## Description of the changes

I change the name of the method which enables and disables decryption as I believe calling it enableDecryption is better than switchOnOffDecryption