### PR TITLE
chore: revert resolution change

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "minimist": "^0.2.4",
     "semver": "^7.5.4",
     "json-schema": "^0.4.0",
-    "json5": "^2.2.1",
-    "string-width": "4.2.3"
+    "json5": "^2.2.1"
   },
   "resolutionsDocs": {
     "underscore": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/14",


### PR DESCRIPTION
Reverts RequestNetwork/requestNetwork#1498

When testing lerna locally the error happened so the resolution should not be needed.

<img width="1443" alt="Screenshot 2024-12-02 at 09 30 33" src="https://github.com/user-attachments/assets/0fa9c225-27f5-45d9-95dd-1f7ac5fc18e0">




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the `string-width` resolution entry from the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->