### PR TITLE
fix: add deprecation, isDecryptionEnabled function and lerna caching

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,7 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["^build", "test"]
+        "cacheableOperations": ["build", "clean", "test"]
       }
     }
   },
@@ -12,7 +12,10 @@
       "dependsOn": ["^build"]
     },
     "test": {
-      "dependsOn": ["build"]
+      "dependsOn": ["clean", "build"]
+    },
+    "clean": {
+      "dependsOn": ["^clean"]
     }
   }
 }

--- a/packages/epk-cipher/src/ethereum-private-key-cipher-provider.ts
+++ b/packages/epk-cipher/src/ethereum-private-key-cipher-provider.ts
@@ -20,7 +20,7 @@ export default class EthereumPrivateKeyCipherProvider
   /** Dictionary containing all the private keys indexed by address */
   private decryptionParametersDictionary: IDecryptionParametersDictionary;
 
-  private isDecryptionOn = false;
+  private decryptionEnabled = true;
 
   constructor(decryptionParameters?: EncryptionTypes.IDecryptionParameters) {
     this.decryptionParametersDictionary = new Map<string, EncryptionTypes.IDecryptionParameters>();
@@ -44,7 +44,7 @@ export default class EthereumPrivateKeyCipherProvider
    * @returns true if decryption is available
    */
   public isDecryptionAvailable(): boolean {
-    return this.decryptionParametersDictionary.size > 0 && this.isDecryptionOn;
+    return this.decryptionParametersDictionary.size > 0 && this.decryptionEnabled;
   }
 
   /**
@@ -53,8 +53,17 @@ export default class EthereumPrivateKeyCipherProvider
    * @param option
    */
   public enableDecryption(option: boolean): void {
-    this.isDecryptionOn = option;
+    this.decryptionEnabled = option;
   }
+
+  /**
+   * Checks if decryption is enabled.
+   * @returns A boolean indicating if decryption is enabled.
+   */
+  public isDecryptionEnabled(): boolean {
+    return this.decryptionEnabled;
+  }
+
   /**
    * Encrypts data
    *

--- a/packages/epk-decryption/src/ethereum-private-key-decryption-provider.ts
+++ b/packages/epk-decryption/src/ethereum-private-key-decryption-provider.ts
@@ -8,6 +8,7 @@ type IDecryptionParametersDictionary = Map<string, EncryptionTypes.IDecryptionPa
 /**
  * Implementation of the decryption provider from private key
  * Allows to decrypt() with "ethereumAddress" identities thanks to their private key given in constructor() or addDecryptionParameters()
+ * @deprecated Use EthereumPrivateKeyCipherProvider instead
  */
 export default class EthereumPrivateKeyDecryptionProvider
   implements DecryptionProviderTypes.IDecryptionProvider
@@ -21,6 +22,9 @@ export default class EthereumPrivateKeyDecryptionProvider
   private decryptionParametersDictionary: IDecryptionParametersDictionary;
 
   constructor(decryptionParameters?: EncryptionTypes.IDecryptionParameters) {
+    console.warn(
+      'EthereumPrivateKeyDecryptionProvider is deprecated. Use EthereumPrivateKeyCipherProvider instead.',
+    );
     this.decryptionParametersDictionary = new Map<string, EncryptionTypes.IDecryptionParameters>();
     if (decryptionParameters) {
       this.addDecryptionParameters(decryptionParameters);

--- a/packages/lit-protocol-cipher/src/lit-protocol-cipher-provider.ts
+++ b/packages/lit-protocol-cipher/src/lit-protocol-cipher-provider.ts
@@ -63,7 +63,7 @@ export default class LitProvider implements CipherProviderTypes.ICipherProvider 
   /**
    * @property {boolean} isDecryptionOn - A boolean indicating if decryption is enabled.
    */
-  private isDecryptionOn = false;
+  private decryptionEnabled = false;
 
   /**
    * @constructor
@@ -284,7 +284,15 @@ export default class LitProvider implements CipherProviderTypes.ICipherProvider 
    * @param option
    */
   public enableDecryption(option: boolean): void {
-    this.isDecryptionOn = option;
+    this.decryptionEnabled = option;
+  }
+
+  /**
+   * Checks if decryption is enabled.
+   * @returns A boolean indicating if decryption is enabled.
+   */
+  public isDecryptionEnabled(): boolean {
+    return this.decryptionEnabled;
   }
 
   /**
@@ -334,7 +342,7 @@ export default class LitProvider implements CipherProviderTypes.ICipherProvider 
    * @returns {boolean} A boolean indicating if decryption is available.
    */
   public isDecryptionAvailable(): boolean {
-    return this.client !== null && this.sessionSigs !== null && this.isDecryptionOn;
+    return this.client !== null && this.sessionSigs !== null && this.decryptionEnabled;
   }
 
   /**

--- a/packages/types/src/cipher-provider-types.ts
+++ b/packages/types/src/cipher-provider-types.ts
@@ -35,4 +35,10 @@ export interface ICipherProvider {
    * @param option - A boolean indicating if decryption should be switched on/off.
    */
   enableDecryption(option: boolean): void;
+
+  /**
+   * Checks if decryption is enabled.
+   * @returns A boolean indicating if decryption is enabled.
+   */
+  isDecryptionEnabled(): boolean;
 }


### PR DESCRIPTION
## Description of the changes

After reviewing the changes with @MantisClone we decided to
- add isDecryptionEnabled function to the cipher provider
- Change default `EthereumPrivateKeyCipherProvider.isDecryptionEnabled` to True, to match legacy behavior of `EthereumPrivateKeyDecryptionProvider`
- add deprecation for the epk decryption provider
- fix lerna caching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method `isDecryptionEnabled()` across various providers to check if decryption is enabled.
	- Added a new `clean` task to enhance task management.

- **Deprecations**
	- Marked `EthereumPrivateKeyDecryptionProvider` as deprecated, recommending the use of `EthereumPrivateKeyCipherProvider` instead.

- **Bug Fixes**
	- Updated logic for decryption state management for clarity and consistency in multiple classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->