### PR TITLE
fix: remove node-localstorage, add StorageProvider interface

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,8 @@ services:
     restart: on-failure:20
   graph-deploy:
     build:
-      context: https://github.com/RequestNetwork/docker-images.git#main
-      dockerfile: request-subgraph-storage/Dockerfile
+      context: https://github.com/RequestNetwork/docker-images.git#main:request-subgraph-storage
+      dockerfile: ./Dockerfile
     depends_on:
       - ipfs
       - postgres
@@ -61,7 +61,7 @@ services:
       - ganache
     environment:
       GRAPH_NODE: 'http://graph-node:8020'
-      IPFS_HOST: 'ipfs:5001'
+      IPFS_HOST: 'http://ipfs:5001'
       KEEP_ALIVE: 0
       SUBGRAPH_FILE: 'subgraph-private.yaml'
     restart: on-failure:20

--- a/packages/lit-protocol-cipher/package.json
+++ b/packages/lit-protocol-cipher/package.json
@@ -50,12 +50,10 @@
     "@requestnetwork/request-client.js": "0.51.0",
     "@requestnetwork/types": "0.46.0",
     "@walletconnect/modal": "2.7.0",
-    "ethers": "5.7.2",
-    "node-localstorage": "3.0.5"
+    "ethers": "5.7.2"
   },
   "devDependencies": {
     "@types/node": "18.11.9",
-    "@types/node-localstorage": "1.3.3",
     "jest-junit": "16.0.0",
     "ts-node": "10.9.1",
     "typescript": "5.1.3"

--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -40,6 +40,8 @@ export default class RequestNetwork {
   private contentData: ContentDataExtension;
   private currencyManager: CurrencyTypes.ICurrencyManager;
 
+  private cipherProvider?: CipherProviderTypes.ICipherProvider;
+
   /**
    * @param dataAccess instance of data-access layer
    * @param signatureProvider module in charge of the signatures
@@ -72,6 +74,23 @@ export default class RequestNetwork {
       this.currencyManager,
       paymentOptions,
     );
+    this.cipherProvider = cipherProvider;
+  }
+
+  /**
+   * Get the cipher provider
+   * @returns the cipher provider
+   */
+  public getCipherProvider(): CipherProviderTypes.ICipherProvider | undefined {
+    return this.cipherProvider;
+  }
+
+  /**
+   * Set the cipher provider
+   * @param cipherProvider the cipher provider
+   */
+  public setCipherProvider(cipherProvider: CipherProviderTypes.ICipherProvider): void {
+    this.cipherProvider = cipherProvider;
   }
 
   /**

--- a/packages/request-node/test/getTransactionsByChannelId.test.ts
+++ b/packages/request-node/test/getTransactionsByChannelId.test.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 import { getRequestNode } from '../src/server';
 import { RequestNode } from '../src/requestNode';
 
-jest.setTimeout(20000);
+jest.setTimeout(30000);
 const time = Date.now();
 const channelId = `01aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa${time}`;
 const anotherChannelId = `01bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb${time}`;

--- a/packages/request-node/test/persistTransaction.test.ts
+++ b/packages/request-node/test/persistTransaction.test.ts
@@ -18,6 +18,8 @@ const badlyFormattedTransactionData = { not: 'a transaction' };
 let requestNodeInstance: RequestNode;
 let server: any;
 
+jest.setTimeout(30000);
+
 const mockServer = setupServer();
 
 /* eslint-disable no-magic-numbers */

--- a/packages/thegraph-data-access/src/queries.ts
+++ b/packages/thegraph-data-access/src/queries.ts
@@ -79,14 +79,17 @@ ${TransactionsBodyFragment}
 
 query GetTransactionsByTopics($topics: [String!]!, $first: Int!, $skip: Int!) {
   ${metaQueryBody}
-  transactions(
+  channels(
     where: { topics_contains: $topics }
-    first: $first
-    skip: $skip
-    orderBy: blockTimestamp
-    orderDirection: asc
-  ) {
-    ...TransactionsBody
+  ){
+    transactions(
+      orderBy: blockTimestamp, 
+      orderDirection: asc
+      first: $first
+      skip: $skip
+    ) {
+      ...TransactionsBody
+    }
   }
 }`;
 

--- a/packages/thegraph-data-access/src/queries.ts
+++ b/packages/thegraph-data-access/src/queries.ts
@@ -80,7 +80,7 @@ ${TransactionsBodyFragment}
 query GetTransactionsByTopics($topics: [String!]!, $first: Int!, $skip: Int!) {
   ${metaQueryBody}
   transactions(
-    where: { topics_contains_nocase: $topics }
+    where: { topics_contains: $topics }
     first: $first
     skip: $skip
     orderBy: blockTimestamp

--- a/packages/thegraph-data-access/src/queries.ts
+++ b/packages/thegraph-data-access/src/queries.ts
@@ -79,17 +79,14 @@ ${TransactionsBodyFragment}
 
 query GetTransactionsByTopics($topics: [String!]!, $first: Int!, $skip: Int!) {
   ${metaQueryBody}
-  channels(
-    where: { topics_contains: $topics }
+  transactions(
+    where: { topics_contains_nocase: $topics }
     first: $first
     skip: $skip
-  ){
-    transactions(
-      orderBy: blockTimestamp, 
-      orderDirection: asc
-    ) {
-      ...TransactionsBody
-    }
+    orderBy: blockTimestamp
+    orderDirection: asc
+  ) {
+    ...TransactionsBody
   }
 }`;
 

--- a/packages/thegraph-data-access/src/subgraph-client.ts
+++ b/packages/thegraph-data-access/src/subgraph-client.ts
@@ -71,10 +71,12 @@ export class SubgraphClient implements StorageTypes.IIndexer {
     const effectivePage = page ?? 1;
     const skip = (effectivePage - 1) * effectivePageSize;
 
+    const topicsArray = Array.isArray(topics) ? topics : [topics];
+
     const response = await this.graphql.request<Meta & { transactions: Transaction[] }>(
       GetTransactionsByTopics,
       {
-        topics,
+        topics: topicsArray,
         first: effectivePageSize,
         skip,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5921,13 +5921,6 @@
     "@types/node" "*"
     form-data "^4.0.0"
 
-"@types/node-localstorage@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@types/node-localstorage/-/node-localstorage-1.3.3.tgz#b221f1bd6c61a2cc6b16c9934f2110779568f185"
-  integrity sha512-Wkn5g4eM5x10UNV9Xvl9K6y6m0zorocuJy4WjB5muUdyMZuPbZpSJG3hlhjGHe1HGxbOQO7RcB+jlHcNwkh+Jw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*":
   version "14.14.35"
   resolved "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz"
@@ -18615,13 +18608,6 @@ node-int64@^0.4.0:
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
-node-localstorage@3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/node-localstorage/-/node-localstorage-3.0.5.tgz#4acda05bb7d3fffaa477f13c028d105866bb43ad"
-  integrity sha512-GCwtK33iwVXboZWYcqQHu3aRvXEBwmPkAMRBLeaX86ufhqslyUkLGsi4aW3INEfdQYpUB5M9qtYf3eHvAk2VBg==
-  dependencies:
-    write-file-atomic "^5.0.1"
-
 node-releases@^2.0.18:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
@@ -25866,7 +25852,7 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-write-file-atomic@^5.0.0, write-file-atomic@^5.0.1:
+write-file-atomic@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-5.0.1.tgz#68df4717c55c6fa4281a7860b4c2ba0a6d2b11e7"
   integrity sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==


### PR DESCRIPTION

## Description of the changes

Fixes #1501 

refactor: remove node-localstorage dependency and update storage handling in LitProvider

- Removed node-localstorage from package.json and yarn.lock.
- Updated LitProvider to use a new StorageProvider interface.
- Refactored storage handling logic to improve compatibility with Node.js.
- Enhanced the RequestNetwork class to include getter and setter for cipherProvider.
- Modified GraphQL queries to improve transaction retrieval logic and pagination settings.

This change streamlines storage management and enhances the overall architecture of the project.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced `LitProvider` class with improved type safety for storage providers.
  - Introduced optional `cipherProvider` functionality in the `RequestNetwork` class, allowing better management of encryption features.

- **Improvements**
  - Updated GraphQL queries to focus on transactions directly, improving data retrieval efficiency.
  - Increased pagination limits for transaction retrieval, allowing for larger data sets to be handled in a single request.

- **Bug Fixes**
  - Adjusted Jest test timeouts to ensure tests complete successfully without premature termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->