### PR TITLE
fix: next release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -649,7 +649,7 @@ workflows:
           filters:
             branches:
               only:
-                - 'fix/next-release'
+                - master
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ references:
   image_name: &image_name 'cimg/python:3.7'
   node_image: &node_image
     image: cimg/node:18.18
+    environment:
+      NODE_OPTIONS: '--max-old-space-size=4096'
   ipfs_image: &ipfs_image
     image: requestnetwork/request-ipfs:v0.13.0
   ganache_image: &ganache_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -649,7 +649,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - fix/next-release
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -536,7 +536,6 @@ jobs:
               --conventional-commits  \
               --conventional-prerelease \
               --exact \
-              --canary \
               --no-git-tag-version \
               --no-push \
               --preid next \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -649,7 +649,7 @@ workflows:
           filters:
             branches:
               only:
-                - fix/next-release
+                - 'fix/next-release'
 
   nightly:
     triggers:


### PR DESCRIPTION
## Problem

Next release is not working on circle ci and it seems is due to out of memory issues. Furthermore, versioning is broken on npm

## 

Add `NODE_OPTIONS: '--max-old-space-size=4096'` to the node image.

I have changed the CI release script removing the --canary option so the versions will look like that.

```
Changes:
  - @requestnetwork/advanced-logic: 0.47.0 => 0.48.0-next.0
  - @requestnetwork/currency: 0.21.0 => 0.22.0-next.0
  - @requestnetwork/data-access: 0.38.0 => 0.39.0-next.0
  - @requestnetwork/data-format: 0.19.3 => 0.19.4-next.0
  - @requestnetwork/epk-cipher: 0.3.0 => 0.4.0-next.0
  - @requestnetwork/epk-decryption: 0.7.3 => 0.7.4-next.0
  - @requestnetwork/epk-signature: 0.9.3 => 0.9.4-next.0
  - @requestnetwork/ethereum-storage: 0.38.0 => 0.39.0-next.0
  - @requestnetwork/integration-test: 0.38.3 => 0.38.4-next.0 (private)
  - @requestnetwork/lit-protocol-cipher: 0.3.0 => 0.4.0-next.0
  - @requestnetwork/multi-format: 0.21.0 => 0.22.0-next.0
  - @requestnetwork/payment-detection: 0.47.0 => 0.48.0-next.0
  - @requestnetwork/payment-processor: 0.50.0 => 0.51.0-next.0
  - @requestnetwork/request-client.js: 0.52.0 => 0.53.0-next.0
  - @requestnetwork/request-logic: 0.37.0 => 0.38.0-next.0
  - @requestnetwork/request-node: 0.38.0 => 0.39.0-next.0
  - @requestnetwork/smart-contracts: 0.41.0 => 0.42.0-next.0
  - @requestnetwork/thegraph-data-access: 0.44.0 => 0.45.0-next.0
  - @requestnetwork/toolbox: 0.15.3 => 0.15.4-next.0 (private)
  - @requestnetwork/transaction-manager: 0.38.0 => 0.39.0-next.0
  - @requestnetwork/types: 0.47.0 => 0.48.0-next.0
  - @requestnetwork/usage-examples: 0.32.3 => 0.32.4-next.0 (private)
  - @requestnetwork/utils: 0.47.0 => 0.48.0-next.0
  - @requestnetwork/web3-signature: 0.8.3 => 0.8.4-next.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a new environment variable to optimize memory usage during builds and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->