### PR TITLE
chore: fix circle ci build and test on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
   test-unit:
     docker:
       - *node_image
-    resource_class: large
+    resource_class: xlarge
     working_directory: *working_directory
     steps:
       - attach_workspace:
@@ -152,7 +152,7 @@ jobs:
       - *ganache_image
       - *postgres_image
       - *graph_image
-    resource_class: large
+    resource_class: xlarge
     working_directory: *working_directory
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
   test-unit:
     docker:
       - *node_image
-    resource_class: xlarge
+    resource_class: large
     working_directory: *working_directory
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             - ~/.cache/yarn
       - run:
           name: Build all packages with lerna
-          command: 'yarn build --skip-nx-cache'
+          command: 'yarn build --since master'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -108,6 +108,7 @@ jobs:
           name: 'Test unit'
           command: |
             yarn test \
+            --since master \
             --ignore @requestnetwork/request-client.js \
             --ignore @requestnetwork/smart-contracts \
             --ignore @requestnetwork/payment-detection \
@@ -157,6 +158,9 @@ jobs:
       - attach_workspace:
           at: *working_directory
       - run:
+          name: 'Build smart-contracts'
+          command: 'yarn build --scope @requestnetwork/smart-contracts'
+      - run:
           name: 'Deploy test contract from smart-contracts'
           command: 'yarn deploy:contracts'
       - run: *step_graph_deploy
@@ -164,6 +168,7 @@ jobs:
           name: 'Test request-client.js, smart-contracts, payment-detection and payment-processor'
           command: |
             yarn test \
+              --since master \
               --scope @requestnetwork/request-client.js \
               --scope @requestnetwork/smart-contracts \
               --scope @requestnetwork/payment-detection \
@@ -189,6 +194,9 @@ jobs:
       - attach_workspace:
           at: *working_directory
       - run:
+          name: 'Build smart-contracts'
+          command: 'yarn build --scope @requestnetwork/smart-contracts'
+      - run:
           name: 'Deploy test contract from smart-contracts'
           command: 'yarn deploy:contracts'
       - run: *step_graph_deploy
@@ -201,6 +209,7 @@ jobs:
           name: 'Test integration-test'
           command: |
             yarn test \
+              --since master \
               --scope @requestnetwork/integration-test
       - store_test_results:
           path: packages/integration-test/reports/
@@ -271,6 +280,9 @@ jobs:
       - run:
           name: 'Authenticate with registry'
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
+      - run:
+          name: 'Build all packages with lerna'
+          command: 'yarn build --skip-nx-cache'
       - run:
           name: 'Publish'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,9 +155,6 @@ jobs:
       - attach_workspace:
           at: *working_directory
       - run:
-          name: 'Build smart-contracts'
-          command: 'yarn build --scope @requestnetwork/smart-contracts'
-      - run:
           name: 'Deploy test contract from smart-contracts'
           command: 'yarn deploy:contracts'
       - run: *step_graph_deploy
@@ -195,9 +192,6 @@ jobs:
     steps:
       - attach_workspace:
           at: *working_directory
-      - run:
-          name: 'Build smart-contracts'
-          command: 'yarn build --scope @requestnetwork/smart-contracts'
       - run:
           name: 'Deploy test contract from smart-contracts'
           command: 'yarn deploy:contracts'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
   test-unit:
     docker:
       - *node_image
-    resource_class: xlarge
+    resource_class: large
     working_directory: *working_directory
     steps:
       - attach_workspace:
@@ -108,6 +108,8 @@ jobs:
           name: 'Test unit'
           command: |
             yarn test \
+            --ignore @requestnetwork/request-node \
+            --ignore @requestnetwork/ethereum-storage \
             --ignore @requestnetwork/request-client.js \
             --ignore @requestnetwork/smart-contracts \
             --ignore @requestnetwork/payment-detection \
@@ -126,15 +128,11 @@ jobs:
       - store_test_results:
           path: packages/epk-decryption/reports/
       - store_test_results:
-          path: packages/ethereum-storage/reports/
-      - store_test_results:
           path: packages/lit-protocol-cipher/reports/
       - store_test_results:
           path: packages/multi-format/reports/
       - store_test_results:
           path: packages/request-logic/reports/
-      - store_test_results:
-          path: packages/request-node/reports/
       - store_test_results:
           path: packages/thegraph-data-access/reports/
       - store_test_results:
@@ -151,7 +149,7 @@ jobs:
       - *ganache_image
       - *postgres_image
       - *graph_image
-    resource_class: xlarge
+    resource_class: large
     working_directory: *working_directory
     steps:
       - attach_workspace:
@@ -167,10 +165,14 @@ jobs:
           name: 'Test request-client.js, smart-contracts, payment-detection and payment-processor'
           command: |
             yarn test \
+              --scope @requestnetwork/request-node \
+              --scope @requestnetwork/ethereum-storage \
               --scope @requestnetwork/request-client.js \
               --scope @requestnetwork/smart-contracts \
               --scope @requestnetwork/payment-detection \
               --scope @requestnetwork/payment-processor
+      - store_test_results:
+          path: packages/request-node/reports/
       - store_test_results:
           path: packages/request-client.js/reports/
       - store_test_results:
@@ -179,6 +181,8 @@ jobs:
           path: packages/payment-detection/reports/
       - store_test_results:
           path: packages/payment-processor/reports/
+      - store_test_results:
+          path: packages/ethereum-storage/reports/
   test-integration-with-request-node:
     docker:
       - *node_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,9 @@ jobs:
           root: *working_directory
           paths:
             - ./
+            - ./.nx-cache
+            - packages/*/dist
+            - packages/*/*.tsbuildinfo
   lint:
     docker:
       - *node_image
@@ -99,7 +102,7 @@ jobs:
   test-unit:
     docker:
       - *node_image
-    resource_class: xlarge
+    resource_class: large
     working_directory: *working_directory
     steps:
       - attach_workspace:
@@ -149,7 +152,7 @@ jobs:
       - *ganache_image
       - *postgres_image
       - *graph_image
-    resource_class: xlarge
+    resource_class: large
     working_directory: *working_directory
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
   test-unit:
     docker:
       - *node_image
-    resource_class: large
+    resource_class: xlarge
     working_directory: *working_directory
     steps:
       - attach_workspace:
@@ -149,7 +149,7 @@ jobs:
       - *ganache_image
       - *postgres_image
       - *graph_image
-    resource_class: large
+    resource_class: xlarge
     working_directory: *working_directory
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
               --scope @requestnetwork/smart-contracts \
               --scope @requestnetwork/payment-detection \
               --scope @requestnetwork/payment-processor \
-              --concurrency=2
+              --concurrency=1
       - store_test_results:
           path: packages/request-node/reports/
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,8 @@ jobs:
             --ignore @requestnetwork/smart-contracts \
             --ignore @requestnetwork/payment-detection \
             --ignore @requestnetwork/payment-processor \
-            --ignore @requestnetwork/integration-test
+            --ignore @requestnetwork/integration-test \
+            --concurrency=2
       - store_test_results:
           path: packages/advance-logic/reports/
       - store_test_results:
@@ -170,7 +171,8 @@ jobs:
               --scope @requestnetwork/request-client.js \
               --scope @requestnetwork/smart-contracts \
               --scope @requestnetwork/payment-detection \
-              --scope @requestnetwork/payment-processor
+              --scope @requestnetwork/payment-processor \
+              --concurrency=2
       - store_test_results:
           path: packages/request-node/reports/
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
   build:
     docker:
       - *node_image
-    resource_class: large
+    resource_class: xlarge
     working_directory: *working_directory
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             - ~/.cache/yarn
       - run:
           name: Build all packages with lerna
-          command: 'yarn build --since master'
+          command: 'yarn build --skip-nx-cache'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -108,7 +108,6 @@ jobs:
           name: 'Test unit'
           command: |
             yarn test \
-            --since master \
             --ignore @requestnetwork/request-client.js \
             --ignore @requestnetwork/smart-contracts \
             --ignore @requestnetwork/payment-detection \
@@ -168,7 +167,6 @@ jobs:
           name: 'Test request-client.js, smart-contracts, payment-detection and payment-processor'
           command: |
             yarn test \
-              --since master \
               --scope @requestnetwork/request-client.js \
               --scope @requestnetwork/smart-contracts \
               --scope @requestnetwork/payment-detection \
@@ -209,7 +207,6 @@ jobs:
           name: 'Test integration-test'
           command: |
             yarn test \
-              --since master \
               --scope @requestnetwork/integration-test
       - store_test_results:
           path: packages/integration-test/reports/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             - ~/.cache/yarn
       - run:
           name: Build all packages with lerna
-          command: 'yarn build --skip-nx-cache'
+          command: 'yarn build'
       - persist_to_workspace:
           root: *working_directory
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             - ~/.cache/yarn
       - run:
           name: Build all packages with lerna
-          command: 'yarn build --since master'
+          command: 'yarn build --skip-nx-cache'
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -108,7 +108,6 @@ jobs:
           name: 'Test unit'
           command: |
             yarn test \
-            --since master \
             --ignore @requestnetwork/request-client.js \
             --ignore @requestnetwork/smart-contracts \
             --ignore @requestnetwork/payment-detection \
@@ -165,7 +164,6 @@ jobs:
           name: 'Test request-client.js, smart-contracts, payment-detection and payment-processor'
           command: |
             yarn test \
-              --since master \
               --scope @requestnetwork/request-client.js \
               --scope @requestnetwork/smart-contracts \
               --scope @requestnetwork/payment-detection \
@@ -203,7 +201,6 @@ jobs:
           name: 'Test integration-test'
           command: |
             yarn test \
-              --since master \
               --scope @requestnetwork/integration-test
       - store_test_results:
           path: packages/integration-test/reports/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
   test-unit:
     docker:
       - *node_image
-    resource_class: large
+    resource_class: xlarge
     working_directory: *working_directory
     steps:
       - attach_workspace:
@@ -151,7 +151,7 @@ jobs:
       - *ganache_image
       - *postgres_image
       - *graph_image
-    resource_class: large
+    resource_class: xlarge
     working_directory: *working_directory
     steps:
       - attach_workspace:

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ tsconfig.build.tsbuildinfo
 /packages/smart-contracts/src/types/
 /packages/smart-contracts/build-zk/
 /packages/smart-contracts/cache-zk/
+
+.nx-cache/

--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,10 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build", "test", "lint:check"]
+        "cacheableOperations": ["build", "test", "lint:check"],
+        "cacheDirectory": ".nx-cache",
+        "parallel": 3,
+        "fileHashVersion": 2
       }
     }
   },


### PR DESCRIPTION
## Problem

Integration tests which requires smart contracts deployed are failing as smart contract packages is not built.

## Description of the changes

- Increase resource class for `build` job and `test-integration-test-smart-contracts` job to `xlarge`
- Update CircleCI configuration to skip Nx cache during next release
- build smart contract before test commands
- set unit test concurrency to 2, integration test concurrency to 1
- move test-request-node and test-ethereum-storage from unit test job to integration test job



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced build and testing processes for improved efficiency.
	- Added new steps to build smart contracts in integration testing jobs.
	- Introduced a step to build all packages in the release job.
	- Updated build command for optimization in the build job.
- **Improvements**
	- Increased resource allocation for build and testing jobs.
	- Simplified test commands by removing unnecessary flags.
	- Added caching configuration to improve task execution speed.
	- Enhanced ignore rules for specific directories related to smart contracts and caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->