### PR TITLE
fix: next release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,7 @@ jobs:
     docker:
       - *node_image
     working_directory: *working_directory
+    resource_class: large
     steps:
       - attach_workspace:
           at: *working_directory
@@ -280,9 +281,6 @@ jobs:
       - run:
           name: 'Authenticate with registry'
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
-      - run:
-          name: 'Build all packages with lerna'
-          command: 'yarn build --skip-nx-cache'
       - run:
           name: 'Publish'
           command: |


### PR DESCRIPTION
## Problem
Calling clean build again in the next-release job is necessary. Also the container needs more resource.

## Description of the changes
update CircleCI config to use large resource class and remove lerna build step


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security for the release process with the addition of SSH known hosts entry for GitHub.
  
- **Improvements**
	- Updated resource allocation for the `next-release` job to optimize performance.
	- Streamlined the build process by removing the step that built all packages with Lerna.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->