### PR TITLE
fix: prerelease git issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,6 +288,7 @@ jobs:
             echo $FORCE_PUBLISH
             $(yarn bin)/lerna publish \
               prerelease \
+              --no-git-tag-version \
               --no-push \
               --preid next \
               --dist-tag next \


### PR DESCRIPTION
## Problem

https://app.circleci.com/pipelines/github/RequestNetwork/requestNetwork/10432/workflows/50b5a833-a542-4b28-92db-cded685106a0/jobs/159862/parallel-runs/0/steps/0-104

## Description of the changes

fix: update lerna publish command to prevent git tagging during prerelease


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the release process to prevent Git tag creation during publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->