### PR TITLE
chore(request-client): expose NoPersistHttpDataAccess

### DIFF
--- a/packages/request-client.js/src/index.ts
+++ b/packages/request-client.js/src/index.ts
@@ -7,6 +7,7 @@ import { default as RequestNetworkBase } from './api/request-network';
 import { default as HttpMetaMaskDataAccess } from './http-metamask-data-access';
 import { default as HttpDataAccess } from './http-data-access';
 import { NodeConnectionConfig } from './http-data-access';
+import { NoPersistHttpDataAccess } from './no-persist-http-data-access';
 import * as Types from './types';
 
 export {
@@ -19,4 +20,5 @@ export {
   NodeConnectionConfig,
   Types,
   Utils,
+  NoPersistHttpDataAccess,
 };


### PR DESCRIPTION
## Description of the changes
There is no way to use `NoPersistHttpDataAccess` without using the `RequestNetwork` class. If we want to inject `NoPersistHttpDataAccess`, we can't use it with `RequestNetworkBase`.

Example: I want to use my own custom data access or `NoPersistHttpDataAccess` depending on my use case.
- If I use `RequestNetwork`, there's no way to inject my own custom data access.
- If I use `RequestNetworkBase`, there's no option to use `skipPersistence` which uses `NoPersistHttpDataAccess`.

By exporting `NoPersistHttpDataAccess`, I can manage which Data Access I want to use (Custom/NoPersist) and inject it by myself to `RequestNetworkBase`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new data access method for handling HTTP requests without persistent storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->