### PR TITLE
fix: add missing network value in conversion requests

### DIFF
--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -605,9 +605,14 @@ export default class RequestNetwork {
             receivedRefundAmount: '0',
             sentPaymentAmount: '0',
             sentRefundAmount: '0',
+            network: extension.parameters.network,
             paymentAddress: extension.parameters.paymentAddress,
             feeAddress: extension.parameters.feeAddress,
             feeAmount: extension.parameters.feeAmount,
+            feeBalance: {
+              events: [],
+              balance: '0',
+            },
           },
           version: extension.version,
         };
@@ -618,8 +623,12 @@ export default class RequestNetwork {
       ...requestData.parameters,
       requestId,
       meta: null,
-      balance: null,
-      currency: requestData.parameters.currency.type,
+      balance: {
+        balance: '0',
+        events: [],
+        escrowEvents: [],
+      },
+      currency: requestData.parameters.currency.value,
       currencyInfo: {
         type: requestData.parameters.currency.type,
         network: requestData.parameters.currency.network,


### PR DESCRIPTION
Resolves #1566 

## Issue:

InMemory requests data was missing some fields necessary for conversion payments.

### Fix:

Add network to extension values.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced payment request data structure with more detailed balance and fee information
	- Updated currency and network-related data retrieval in request processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->