### PR TITLE
chore(payment-processor): load hinkal lib asyncronously

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,5 @@
     "semver": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/197",
     "json-schema": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/51",
     "json5": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/165"
-  },
-  "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -69,5 +69,6 @@
     "semver": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/197",
     "json-schema": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/51",
     "json5": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/165"
-  }
+  },
+  "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
 }

--- a/packages/payment-processor/src/payment/erc-20-private-payment-hinkal.ts
+++ b/packages/payment-processor/src/payment/erc-20-private-payment-hinkal.ts
@@ -19,7 +19,7 @@ import {
 } from './utils';
 import { IPreparedPrivateTransaction } from './prepared-transaction';
 
-import { emporiumOp, IHinkal, RelayerTransaction } from '@hinkal/common';
+import type { IHinkal, RelayerTransaction } from '@hinkal/common';
 import { prepareEthersHinkal } from '@hinkal/common/providers/prepareEthersHinkal';
 
 /**
@@ -150,6 +150,8 @@ export function prepareErc20ProxyPaymentFromHinkalShieldedAddress(
 
   const { paymentReference, paymentAddress } = getRequestPaymentValues(request);
   const amountToPay = getAmountToPay(request, amount);
+  const { emporiumOp } = await import('@hinkal/common');
+
 
   const ops = [
     emporiumOp(tokenContract, 'approve', [proxyContract.address, amountToPay]),
@@ -194,6 +196,7 @@ export function prepareErc20FeeProxyPaymentFromHinkalShieldedAddress(
   const amountToPay = getAmountToPay(request, amount);
   const feeToPay = String(feeAmountOverride || feeAmount || 0);
   const totalAmount = amountToPay.add(BigNumber.from(feeToPay));
+  const { emporiumOp } = await import('@hinkal/common');
 
   const ops = [
     emporiumOp(tokenContract, 'approve', [proxyContract.address, totalAmount]),

--- a/packages/payment-processor/src/payment/erc-20-private-payment-hinkal.ts
+++ b/packages/payment-processor/src/payment/erc-20-private-payment-hinkal.ts
@@ -1,9 +1,9 @@
-import { Contract, ContractTransaction, Signer, BigNumberish, providers, BigNumber } from 'ethers';
+import { BigNumber, BigNumberish, Contract, ContractTransaction, providers, Signer } from 'ethers';
 import { erc20FeeProxyArtifact } from '@requestnetwork/smart-contracts';
 import {
+  ERC20__factory,
   ERC20FeeProxy__factory,
   ERC20Proxy__factory,
-  ERC20__factory,
 } from '@requestnetwork/smart-contracts/types';
 import { ClientTypes, ExtensionTypes } from '@requestnetwork/types';
 import { Erc20PaymentNetwork, getPaymentNetworkExtension } from '@requestnetwork/payment-detection';
@@ -11,11 +11,11 @@ import { EvmChains } from '@requestnetwork/currency';
 import {
   getAmountToPay,
   getProvider,
+  getProxyAddress,
   getRequestPaymentValues,
   getSigner,
-  validateRequest,
   validateErc20FeeProxyRequest,
-  getProxyAddress,
+  validateRequest,
 } from './utils';
 import { IPreparedPrivateTransaction } from './prepared-transaction';
 
@@ -85,10 +85,8 @@ export async function payErc20ProxyRequestFromHinkalShieldedAddress(
   const signer = getSigner(signerOrProvider);
   const hinkalObject = await addToHinkalStore(signer);
 
-  const { amountToPay, tokenAddress, ops } = prepareErc20ProxyPaymentFromHinkalShieldedAddress(
-    request,
-    amount,
-  );
+  const { amountToPay, tokenAddress, ops } =
+    await prepareErc20ProxyPaymentFromHinkalShieldedAddress(request, amount);
 
   return hinkalObject.actionPrivateWallet(
     [tokenAddress],
@@ -114,11 +112,8 @@ export async function payErc20FeeProxyRequestFromHinkalShieldedAddress(
   const signer = getSigner(signerOrProvider);
   const hinkalObject = await addToHinkalStore(signer);
 
-  const { amountToPay, tokenAddress, ops } = prepareErc20FeeProxyPaymentFromHinkalShieldedAddress(
-    request,
-    amount,
-    feeAmount,
-  );
+  const { amountToPay, tokenAddress, ops } =
+    await prepareErc20FeeProxyPaymentFromHinkalShieldedAddress(request, amount, feeAmount);
 
   return hinkalObject.actionPrivateWallet(
     [tokenAddress],
@@ -133,10 +128,10 @@ export async function payErc20FeeProxyRequestFromHinkalShieldedAddress(
  * @param request request to pay
  * @param amount optionally, the amount to pay. Defaults to remaining amount of the request.
  */
-export function prepareErc20ProxyPaymentFromHinkalShieldedAddress(
+export async function prepareErc20ProxyPaymentFromHinkalShieldedAddress(
   request: ClientTypes.IRequestData,
   amount?: BigNumberish,
-): IPreparedPrivateTransaction {
+): Promise<IPreparedPrivateTransaction> {
   validateRequest(request, ExtensionTypes.PAYMENT_NETWORK_ID.ERC20_PROXY_CONTRACT);
 
   const { value: tokenAddress } = request.currencyInfo;
@@ -151,7 +146,6 @@ export function prepareErc20ProxyPaymentFromHinkalShieldedAddress(
   const { paymentReference, paymentAddress } = getRequestPaymentValues(request);
   const amountToPay = getAmountToPay(request, amount);
   const { emporiumOp } = await import('@hinkal/common');
-
 
   const ops = [
     emporiumOp(tokenContract, 'approve', [proxyContract.address, amountToPay]),
@@ -176,11 +170,11 @@ export function prepareErc20ProxyPaymentFromHinkalShieldedAddress(
  * @param amount optionally, the amount to pay. Defaults to remaining amount of the request.
  * @param feeAmountOverride optionally, the fee amount to pay. Defaults to the fee amount of the request.
  */
-export function prepareErc20FeeProxyPaymentFromHinkalShieldedAddress(
+export async function prepareErc20FeeProxyPaymentFromHinkalShieldedAddress(
   request: ClientTypes.IRequestData,
   amount?: BigNumberish,
   feeAmountOverride?: BigNumberish,
-): IPreparedPrivateTransaction {
+): Promise<IPreparedPrivateTransaction> {
   validateErc20FeeProxyRequest(request, amount, feeAmountOverride);
 
   const { value: tokenAddress, network } = request.currencyInfo;


### PR DESCRIPTION
## Context

The Request Network library is relatively heavy to load from a front-end point of view, more especially the `payment-processor` package. Here are some stats for a front-end that includes packages needed for payment, and built with Vite.js:
```sh
> ls -lh build/assets/@requestnetwork/
total 7,3M
308K currency-BI28kHzu.js
128K data-format-CF2Ej1ak.js
1,2M payment-detection-B7AW9tt1.js
5,7M payment-processor-COb8hmRF.js
1    smart-contracts-l0sNRNKZ.js
1    types-l0sNRNKZ.js
```

## Changes
In this PR, I introduce a quick optimization that would reduce the `payment-processor` load time and resolve a CSP warning for non-Hinkal users.

- `@hinkal/common` represents a large amount of the final code for the `payment-processor` package after transpilation. It could be loaded asynchronously to lighten frontend bundles. The picture below is a visualization of the space taken by each sub-dependency of the `payment-processor` package, according to https://github.com/btd/rollup-plugin-visualizer.

- `@hinkal/common` depends on [`libsodium`](https://www.npmjs.com/package/libsodium) (also quite heavy, see below) which runs WASM code in the browser. Loading this lib is incompatible with a `Content-Security-Policy` that does not allow `script-src 'wasm-unsafe-eval'`. For builders that do not use the Hinkal integration, it does not make sense to relax the CSP header to silence such a warning. Loading Hinkal only on-demand would not trigger such warnings for non-Hinkal users. Related: https://github.com/jedisct1/libsodium.js/issues/196


![image](https://github.com/user-attachments/assets/55b3ffaa-eba0-4865-8119-a5419304d08e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the processing of token payments by introducing improved asynchronous handling. This update ensures that all transaction details are fully resolved before proceeding, which leads to more reliable and consistent payment experiences for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->