### PR TITLE
chore: Remove sstefdev and add rodrigopavezi to the auto_assign.yml

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -11,8 +11,8 @@ reviewers:
   - alexandre-abrioux
   - leoslr
   - MantisClone
-  - sstefdev
   - aimensahnoun
+  - rodrigopavezi
 
 # A list of keywords to be skipped the process that add reviewers if pull requests include it
 skipKeywords:


### PR DESCRIPTION
## Description of the changes

* Remove sstefdev and add rodrigopavezi to the auto_assign.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the automatic assignment configuration for pull request reviews by replacing one reviewer with another to reflect the revised team composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->