### PR TITLE
fix(payment-processor): load hinkal lib asyncronously

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,5 @@
     "semver": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/197",
     "json-schema": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/51",
     "json5": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/165"
-  },
-  "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -69,5 +69,6 @@
     "semver": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/197",
     "json-schema": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/51",
     "json5": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/165"
-  }
+  },
+  "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
 }

--- a/packages/payment-processor/src/payment/erc-20-private-payment-hinkal.ts
+++ b/packages/payment-processor/src/payment/erc-20-private-payment-hinkal.ts
@@ -18,9 +18,7 @@ import {
   validateRequest,
 } from './utils';
 import { IPreparedPrivateTransaction } from './prepared-transaction';
-
 import type { IHinkal, RelayerTransaction } from '@hinkal/common';
-import { prepareEthersHinkal } from '@hinkal/common/providers/prepareEthersHinkal';
 
 /**
  * This is a globally accessible state variable exported for use in other parts of the application or tests.
@@ -39,6 +37,7 @@ export const hinkalStore: Record<string, IHinkal> = {};
 export async function addToHinkalStore(signer: Signer): Promise<IHinkal> {
   const address = await signer.getAddress();
   if (!hinkalStore[address]) {
+    const { prepareEthersHinkal } = await import('@hinkal/common/providers/prepareEthersHinkal');
     hinkalStore[address] = await prepareEthersHinkal(signer);
   }
   return hinkalStore[address];


### PR DESCRIPTION
## Description of the changes

This is a fixup for https://github.com/RequestNetwork/requestNetwork/pull/1573. I've missed migrating one of the `@hinkal/common` imports, which means the Hinkal library is still loaded syncronously at the moment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized the payment processing module to load necessary resources as needed, ensuring improved efficiency with no change to the overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->