### PR TITLE
chore(typescript): change moduleResolution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
   test-unit:
     docker:
       - *node_image
-    resource_class: xlarge
+    resource_class: large
     working_directory: *working_directory
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,9 @@ jobs:
             --ignore @requestnetwork/payment-processor \
             --ignore @requestnetwork/integration-test \
             --concurrency=2
+          environment:
+            # Lerna starts 2 Jest commands at the same time (--concurrency=2), so we use 50% core for each
+            JEST_MAX_WORKERS: '50%'
       - store_test_results:
           path: packages/advance-logic/reports/
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,8 @@ jobs:
             --ignore @requestnetwork/integration-test \
             --concurrency=2
           environment:
-            # Lerna starts 2 Jest commands at the same time (--concurrency=2), so we use 50% core for each
+            # Lerna starts 2 Jest commands at the same time (see above --concurrency=2),
+            # so we use 50% of our CPU cores on each
             JEST_MAX_WORKERS: '50%'
       - store_test_results:
           path: packages/advance-logic/reports/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
   test-unit:
     docker:
       - *node_image
-    resource_class: large
+    resource_class: xlarge
     working_directory: *working_directory
     steps:
       - attach_workspace:

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,5 +17,4 @@ module.exports = {
       },
     ],
   ],
-  ...(process.env.CI === 'true' ? { maxWorkers: '50%' } : {}),
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,4 +17,5 @@ module.exports = {
       },
     ],
   ],
+  ...(process.env.JEST_MAX_WORKERS ? { maxWorkers: process.env.JEST_MAX_WORKERS } : {}),
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
       },
     ],
   ],
-  maxWorkers: process.env.CI === '1' ? '50%' : undefined,
+  ...(process.env.CI === 'true' ? { maxWorkers: '50%' } : {}),
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,4 +17,5 @@ module.exports = {
       },
     ],
   ],
+  maxWorkers: process.env.CI === '1' ? '50%' : undefined,
 };

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "npm-package-json-lint": "5.1.0",
     "prettier": "2.8.8",
     "prettier-plugin-solidity": "1.0.0-beta.19",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   },
   "resolutions": {
     "underscore": "^1.12.1",
@@ -69,5 +69,6 @@
     "semver": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/197",
     "json-schema": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/51",
     "json5": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/165"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -69,5 +69,6 @@
     "semver": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/197",
     "json-schema": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/51",
     "json5": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/165"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -71,5 +71,6 @@
     "semver": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/197",
     "json-schema": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/51",
     "json5": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/165"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,5 @@
     "semver": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/197",
     "json-schema": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/51",
     "json5": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/165"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,5 @@
     "semver": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/197",
     "json-schema": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/51",
     "json5": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/165"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/packages/advanced-logic/package.json
+++ b/packages/advanced-logic/package.json
@@ -49,7 +49,7 @@
     "@types/node": "18.11.9",
     "jest": "29.5.0",
     "jest-junit": "16.0.0",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-node": "10.9.1",
     "typescript": "5.8.3"
   },

--- a/packages/advanced-logic/package.json
+++ b/packages/advanced-logic/package.json
@@ -42,7 +42,7 @@
     "@requestnetwork/currency": "0.28.0",
     "@requestnetwork/types": "0.54.0",
     "@requestnetwork/utils": "0.54.0",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.6",

--- a/packages/advanced-logic/package.json
+++ b/packages/advanced-logic/package.json
@@ -51,7 +51,7 @@
     "jest-junit": "16.0.0",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   },
   "gitHead": "6155223cfce769e48ccae480c510b35b4f54b4d0"
 }

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -57,7 +57,7 @@
     "jest": "29.5.0",
     "jest-junit": "16.0.0",
     "source-map-support": "0.5.19",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-node": "10.9.1",
     "typescript": "5.8.3"
   }

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -59,6 +59,6 @@
     "source-map-support": "0.5.19",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   }
 }

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -47,7 +47,7 @@
     "@requestnetwork/utils": "0.54.0",
     "multicoin-address-validator": "0.5.15",
     "node-dijkstra": "2.5.0",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.6",

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -50,7 +50,7 @@
     "jest": "29.5.0",
     "jest-junit": "16.0.0",
     "source-map-support": "0.5.19",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-node": "10.9.1",
     "typescript": "5.8.3"
   },

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -42,7 +42,7 @@
     "@requestnetwork/multi-format": "0.28.0",
     "@requestnetwork/types": "0.54.0",
     "@requestnetwork/utils": "0.54.0",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.6",

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -52,7 +52,7 @@
     "source-map-support": "0.5.19",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   },
   "gitHead": "6155223cfce769e48ccae480c510b35b4f54b4d0"
 }

--- a/packages/data-access/src/index.ts
+++ b/packages/data-access/src/index.ts
@@ -3,6 +3,6 @@ export { CombinedDataAccess } from './combined-data-access';
 export { DataAccessWrite } from './data-write';
 export { DataAccessRead } from './data-read';
 export { PendingStore } from './pending-store';
-export { DataAccessBaseOptions } from './types';
+export type { DataAccessBaseOptions } from './types';
 export { MockDataAccess } from './mock-data-access';
 export { NoPersistDataWrite } from './no-persist-data-write';

--- a/packages/data-format/package.json
+++ b/packages/data-format/package.json
@@ -40,7 +40,8 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
-    "ajv": "6.12.4",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "ethers": "5.7.2",
     "tslib": "2.5.0"
   },

--- a/packages/data-format/package.json
+++ b/packages/data-format/package.json
@@ -43,7 +43,7 @@
     "ajv": "8.17.1",
     "ajv-formats": "3.0.1",
     "ethers": "5.7.2",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/node": "18.11.9",

--- a/packages/data-format/package.json
+++ b/packages/data-format/package.json
@@ -40,8 +40,8 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
-    "ajv": "^8.17.1",
-    "ajv-formats": "^3.0.1",
+    "ajv": "8.17.1",
+    "ajv-formats": "3.0.1",
     "ethers": "5.7.2",
     "tslib": "2.5.0"
   },

--- a/packages/data-format/package.json
+++ b/packages/data-format/package.json
@@ -48,7 +48,7 @@
     "@types/node": "18.11.9",
     "jest-junit": "16.0.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   },
   "gitHead": "6155223cfce769e48ccae480c510b35b4f54b4d0"
 }

--- a/packages/data-format/src/index.ts
+++ b/packages/data-format/src/index.ts
@@ -1,4 +1,4 @@
-import * as AJV from 'ajv';
+import AJV from 'ajv';
 import * as jsonSchema from 'ajv/lib/refs/json-schema-draft-06.json';
 import * as schemaAddress from './format/address.json';
 import { formats } from './format';

--- a/packages/data-format/src/index.ts
+++ b/packages/data-format/src/index.ts
@@ -1,4 +1,5 @@
-import AJV from 'ajv';
+import { Ajv } from 'ajv';
+import addFormats from 'ajv-formats';
 import * as jsonSchema from 'ajv/lib/refs/json-schema-draft-06.json';
 import * as schemaAddress from './format/address.json';
 import { formats } from './format';
@@ -9,7 +10,8 @@ import { formats } from './format';
  * @return  object.valid == true if the json is valid, object.valid == false and object.errors otherwise.
  */
 export function validate(data: any): any {
-  const validationTool = new AJV().addMetaSchema(jsonSchema).addSchema(schemaAddress);
+  const validationTool = new Ajv().addMetaSchema(jsonSchema).addSchema(schemaAddress);
+  addFormats(validationTool);
 
   // Check the meta information
   if (!data.meta) {

--- a/packages/data-format/test/test.ts
+++ b/packages/data-format/test/test.ts
@@ -30,7 +30,7 @@ describe('Request Network Data Validator', () => {
     // 'result.valid should be false'
     expect(result.valid).toBe(false);
     // 'result.errors is wrong'
-    expect(result.errors[0].message).toBe('should be string');
+    expect(result.errors[0].message).toBe('must be string');
   });
 
   it('should not validate an invalid invoice 0.0.3 format', () => {
@@ -39,7 +39,7 @@ describe('Request Network Data Validator', () => {
     // 'result.valid should be false'
     expect(result.valid).toBe(false);
     // 'result.errors is wrong'
-    expect(result.errors[0].message).toBe('should be string');
+    expect(result.errors[0].message).toBe('must be string');
   });
 
   it('should not validate a json without meta', () => {
@@ -66,7 +66,7 @@ describe('Request Network Data Validator', () => {
     // 'result.valid should be false'
     expect(result.valid).toBe(false);
     // 'result.errors is wrong'
-    expect(result.errors[0].message).toBe('should match format "date-time"');
+    expect(result.errors[0].message).toBe('must match format "date-time"');
   });
 
   it('should not validate a json with required parameter missing', () => {
@@ -75,7 +75,7 @@ describe('Request Network Data Validator', () => {
     // 'result.valid should be false'
     expect(result.valid).toBe(false);
     // 'result.errors is wrong'
-    expect(result.errors[0].message).toBe(`should have required property \'name\'`);
+    expect(result.errors[0].message).toBe(`must have required property \'name\'`);
   });
 
   it('should not validate a json with meta.format missing', () => {

--- a/packages/epk-cipher/package.json
+++ b/packages/epk-cipher/package.json
@@ -45,7 +45,7 @@
     "@requestnetwork/multi-format": "0.28.0",
     "@requestnetwork/types": "0.54.0",
     "@requestnetwork/utils": "0.54.0",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.6",

--- a/packages/epk-cipher/package.json
+++ b/packages/epk-cipher/package.json
@@ -58,7 +58,7 @@
     "source-map-support": "0.5.19",
     "stream-browserify": "3.0.0",
     "terser-webpack-plugin": "4.2.3",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-loader": "8.4.0",
     "ts-node": "10.9.1",
     "typescript": "5.8.3",

--- a/packages/epk-cipher/package.json
+++ b/packages/epk-cipher/package.json
@@ -61,7 +61,7 @@
     "ts-jest": "29.1.0",
     "ts-loader": "8.4.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3",
+    "typescript": "5.8.3",
     "webpack": "5.94.0",
     "webpack-bundle-analyzer": "4.2.0",
     "webpack-cli": "3.3.12"

--- a/packages/epk-decryption/package.json
+++ b/packages/epk-decryption/package.json
@@ -60,7 +60,7 @@
     "ts-jest": "29.1.0",
     "ts-loader": "8.4.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3",
+    "typescript": "5.8.3",
     "webpack": "5.94.0",
     "webpack-bundle-analyzer": "4.2.0",
     "webpack-cli": "3.3.12"

--- a/packages/epk-decryption/package.json
+++ b/packages/epk-decryption/package.json
@@ -57,7 +57,7 @@
     "source-map-support": "0.5.19",
     "stream-browserify": "3.0.0",
     "terser-webpack-plugin": "4.2.3",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-loader": "8.4.0",
     "ts-node": "10.9.1",
     "typescript": "5.8.3",

--- a/packages/epk-decryption/package.json
+++ b/packages/epk-decryption/package.json
@@ -44,7 +44,7 @@
     "@requestnetwork/multi-format": "0.28.0",
     "@requestnetwork/types": "0.54.0",
     "@requestnetwork/utils": "0.54.0",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.6",

--- a/packages/epk-signature/package.json
+++ b/packages/epk-signature/package.json
@@ -59,7 +59,7 @@
     "ts-jest": "29.1.0",
     "ts-loader": "8.4.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3",
+    "typescript": "5.8.3",
     "webpack": "5.94.0",
     "webpack-bundle-analyzer": "4.2.0",
     "webpack-cli": "3.3.12"

--- a/packages/epk-signature/package.json
+++ b/packages/epk-signature/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@requestnetwork/types": "0.54.0",
     "@requestnetwork/utils": "0.54.0",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.6",

--- a/packages/epk-signature/package.json
+++ b/packages/epk-signature/package.json
@@ -56,7 +56,7 @@
     "source-map-support": "0.5.19",
     "stream-browserify": "3.0.0",
     "terser-webpack-plugin": "4.2.3",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-loader": "8.4.0",
     "ts-node": "10.9.1",
     "typescript": "5.8.3",

--- a/packages/ethereum-storage/package.json
+++ b/packages/ethereum-storage/package.json
@@ -59,7 +59,7 @@
     "msw": "2.0.6",
     "solium": "1.2.5",
     "source-map-support": "0.5.19",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-node": "10.9.1",
     "typescript": "5.8.3",
     "web3-providers-http": "1.3.6"

--- a/packages/ethereum-storage/package.json
+++ b/packages/ethereum-storage/package.json
@@ -61,7 +61,7 @@
     "source-map-support": "0.5.19",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3",
+    "typescript": "5.8.3",
     "web3-providers-http": "1.3.6"
   },
   "gitHead": "6155223cfce769e48ccae480c510b35b4f54b4d0"

--- a/packages/ethereum-storage/package.json
+++ b/packages/ethereum-storage/package.json
@@ -48,7 +48,7 @@
     "form-data": "3.0.0",
     "qs": "6.11.2",
     "shelljs": "0.8.5",
-    "tslib": "2.5.0",
+    "tslib": "2.8.1",
     "yargs": "17.6.2"
   },
   "devDependencies": {

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -74,6 +74,6 @@
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
     "tslib": "2.5.0",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   }
 }

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -71,7 +71,7 @@
     "jest": "29.5.0",
     "jest-junit": "16.0.0",
     "npm-run-all": "4.1.5",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-node": "10.9.1",
     "tslib": "2.8.1",
     "typescript": "5.8.3"

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -73,7 +73,7 @@
     "npm-run-all": "4.1.5",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
-    "tslib": "2.5.0",
+    "tslib": "2.8.1",
     "typescript": "5.8.3"
   }
 }

--- a/packages/lit-protocol-cipher/package.json
+++ b/packages/lit-protocol-cipher/package.json
@@ -57,7 +57,7 @@
     "@types/node": "18.11.9",
     "jest": "29.5.0",
     "jest-junit": "16.0.0",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-node": "10.9.1",
     "typescript": "5.8.3"
   }

--- a/packages/lit-protocol-cipher/package.json
+++ b/packages/lit-protocol-cipher/package.json
@@ -59,6 +59,6 @@
     "jest-junit": "16.0.0",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   }
 }

--- a/packages/multi-format/package.json
+++ b/packages/multi-format/package.json
@@ -48,7 +48,7 @@
     "jest": "29.5.0",
     "jest-junit": "16.0.0",
     "source-map-support": "0.5.19",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-node": "10.9.1",
     "typescript": "5.8.3"
   }

--- a/packages/multi-format/package.json
+++ b/packages/multi-format/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@requestnetwork/types": "0.54.0",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.6",

--- a/packages/multi-format/package.json
+++ b/packages/multi-format/package.json
@@ -50,6 +50,6 @@
     "source-map-support": "0.5.19",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   }
 }

--- a/packages/payment-detection/package.json
+++ b/packages/payment-detection/package.json
@@ -57,7 +57,7 @@
     "@graphql-codegen/cli": "4.0.1",
     "@graphql-codegen/typescript": "4.0.1",
     "@graphql-codegen/typescript-document-nodes": "4.0.1",
-    "@graphql-codegen/typescript-graphql-request": "6.0.1",
+    "@graphql-codegen/typescript-graphql-request": "6.2.0",
     "@graphql-codegen/typescript-operations": "4.0.1",
     "@graphql-codegen/typescript-resolvers": "4.0.1",
     "@jridgewell/gen-mapping": "0.3.2",
@@ -68,6 +68,6 @@
     "source-map-support": "0.5.19",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   }
 }

--- a/packages/payment-detection/package.json
+++ b/packages/payment-detection/package.json
@@ -50,7 +50,7 @@
     "graphql-request": "6.1.0",
     "graphql-tag": "2.12.6",
     "satoshi-bitcoin": "1.0.4",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@babel/helper-get-function-arity": "7.16.7",

--- a/packages/payment-detection/package.json
+++ b/packages/payment-detection/package.json
@@ -66,7 +66,7 @@
     "jest": "29.5.0",
     "jest-junit": "16.0.0",
     "source-map-support": "0.5.19",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-node": "10.9.1",
     "typescript": "5.8.3"
   }

--- a/packages/payment-detection/src/index.ts
+++ b/packages/payment-detection/src/index.ts
@@ -34,9 +34,9 @@ import { MetaDetector } from './meta-payment-detector';
 
 export type { TheGraphClient } from './thegraph';
 
-export type {
+export type { PaymentNetworkOptions };
+export {
   PaymentNetworkFactory,
-  PaymentNetworkOptions,
   PaymentReferenceCalculator,
   BtcPaymentNetwork,
   DeclarativePaymentDetector,

--- a/packages/payment-detection/src/index.ts
+++ b/packages/payment-detection/src/index.ts
@@ -8,16 +8,17 @@ import * as PaymentReferenceCalculator from './payment-reference-calculator';
 import * as BtcPaymentNetwork from './btc';
 import { DeclarativePaymentDetector } from './declarative';
 import * as Erc20PaymentNetwork from './erc20';
+import { ERC20TransferableReceivablePaymentDetector } from './erc20';
 import { AnyToERC20PaymentDetector, AnyToEthFeeProxyPaymentDetector } from './any';
 import { EthFeeProxyPaymentDetector, EthInputDataPaymentDetector } from './eth';
 import { getTheGraphClient, getTheGraphEvmClient, getTheGraphNearClient } from './thegraph';
 import {
   calculateEscrowState,
+  flattenRequestByPnId,
   formatAddress,
   getPaymentNetworkExtension,
   getPaymentReference,
   getPaymentReferencesForMetaPnRequest,
-  flattenRequestByPnId,
   hashReference,
   padAmountForChainlink,
   parseLogArgs,
@@ -29,12 +30,11 @@ import { SuperFluidPaymentDetector } from './erc777/superfluid-detector';
 import { EscrowERC20InfoRetriever } from './erc20/escrow-info-retriever';
 import { SuperFluidInfoRetriever } from './erc777/superfluid-retriever';
 import { PaymentNetworkOptions } from './types';
-import { ERC20TransferableReceivablePaymentDetector } from './erc20';
 import { MetaDetector } from './meta-payment-detector';
 
 export type { TheGraphClient } from './thegraph';
 
-export {
+export type {
   PaymentNetworkFactory,
   PaymentNetworkOptions,
   PaymentReferenceCalculator,

--- a/packages/payment-detection/src/thegraph/client.ts
+++ b/packages/payment-detection/src/thegraph/client.ts
@@ -2,9 +2,8 @@
 import { CurrencyTypes } from '@requestnetwork/types';
 import { NearChains } from '@requestnetwork/currency';
 import { GraphQLClient } from 'graphql-request';
-import { Block_Height, Maybe, getSdk } from './generated/graphql';
+import { Block_Height, getSdk, Maybe } from './generated/graphql';
 import { getSdk as getNearSdk } from './generated/graphql-near';
-import { RequestConfig } from 'graphql-request/src/types';
 
 const THE_GRAPH_STUDIO_URL =
   'https://api.studio.thegraph.com/query/67444/request-payments-$NETWORK/version/latest';
@@ -40,6 +39,8 @@ export type TheGraphClient<TChain extends CurrencyTypes.VMChainName = CurrencyTy
 export type TheGraphQueryOptions = {
   blockFilter?: Maybe<Block_Height>;
 };
+
+type RequestConfig = (typeof GraphQLClient.prototype)['requestConfig'];
 
 export type TheGraphClientOptions = RequestConfig & {
   /** constraint to select indexers that have at least parsed this block */

--- a/packages/payment-detection/src/thegraph/superfluid.ts
+++ b/packages/payment-detection/src/thegraph/superfluid.ts
@@ -1,6 +1,5 @@
 import { GraphQLClient } from 'graphql-request';
 import { getSdk } from './generated/graphql-superfluid';
-import { RequestConfig } from 'graphql-request/src/types';
 
 const BASE_URL = `https://subgraph-endpoints.superfluid.dev`;
 const NETWORK_TO_URL: Record<string, string> = {
@@ -15,6 +14,8 @@ const NETWORK_TO_URL: Record<string, string> = {
   sepolia: 'eth-sepolia',
   xdai: 'xdai-mainnet',
 };
+
+type RequestConfig = (typeof GraphQLClient.prototype)['requestConfig'];
 
 // NB: the GraphQL client is automatically generated based on files present in ./queries,
 // using graphql-codegen.

--- a/packages/payment-processor/package.json
+++ b/packages/payment-processor/package.json
@@ -50,7 +50,7 @@
     "@superfluid-finance/sdk-core": "0.5.0",
     "ethers": "5.7.2",
     "near-api-js": "4.0.2",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",

--- a/packages/payment-processor/package.json
+++ b/packages/payment-processor/package.json
@@ -40,7 +40,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
-    "@hinkal/common": "0.2.9",
+    "@hinkal/common": "0.2.10",
     "@openzeppelin/contracts": "4.9.6",
     "@requestnetwork/currency": "0.28.0",
     "@requestnetwork/payment-detection": "0.54.0",

--- a/packages/payment-processor/package.json
+++ b/packages/payment-processor/package.json
@@ -40,7 +40,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
-    "@hinkal/common": "0.2.10",
+    "@hinkal/common": "0.2.12",
     "@openzeppelin/contracts": "4.9.6",
     "@requestnetwork/currency": "0.28.0",
     "@requestnetwork/payment-detection": "0.54.0",

--- a/packages/payment-processor/package.json
+++ b/packages/payment-processor/package.json
@@ -58,6 +58,6 @@
     "jest-junit": "16.0.0",
     "source-map-support": "0.5.19",
     "ts-jest": "29.1.0",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   }
 }

--- a/packages/payment-processor/package.json
+++ b/packages/payment-processor/package.json
@@ -57,7 +57,7 @@
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
     "source-map-support": "0.5.19",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "typescript": "5.8.3"
   }
 }

--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -1,17 +1,21 @@
-import { ContractTransaction, Signer, BigNumber, BigNumberish, providers } from 'ethers';
+import { BigNumber, BigNumberish, ContractTransaction, providers, Signer } from 'ethers';
 
-import { ClientTypes, CurrencyTypes, ExtensionTypes, TypesUtils } from '@requestnetwork/types';
+import {
+  ClientTypes,
+  CurrencyTypes,
+  ExtensionTypes,
+  RequestLogicTypes,
+  TypesUtils,
+} from '@requestnetwork/types';
 
 import { getBtcPaymentUrl } from './btc-address-based';
-import { _getErc20PaymentUrl, getAnyErc20Balance } from './erc20';
-import { payErc20Request } from './erc20';
+import { _getErc20PaymentUrl, getAnyErc20Balance, payErc20Request } from './erc20';
 import { payErc777StreamRequest } from './erc777-stream';
 import { _getEthPaymentUrl, payEthInputDataRequest } from './eth-input-data';
 import { payEthFeeProxyRequest } from './eth-fee-proxy';
 import { ITransactionOverrides } from './transaction-overrides';
 import { getNetworkProvider, getProvider, getSigner } from './utils';
 import { ISwapSettings } from './swap-erc20-fee-proxy';
-import { RequestLogicTypes } from '@requestnetwork/types';
 import { payAnyToErc20ProxyRequest } from './any-to-erc20-proxy';
 import { payAnyToEthProxyRequest } from './any-to-eth-proxy';
 import { WalletConnection } from 'near-api-js';
@@ -21,7 +25,8 @@ import { encodeRequestErc20Approval } from './encoder-approval';
 import { encodeRequestPayment } from './encoder-payment';
 import { IPreparedTransaction } from './prepared-transaction';
 import { IRequestPaymentOptions } from '../types';
-export { INearTransactionCallback } from './utils-near';
+
+export type { INearTransactionCallback } from './utils-near';
 
 export const noConversionNetworks = [
   ExtensionTypes.PAYMENT_NETWORK_ID.ERC777_STREAM,

--- a/packages/payment-processor/src/payment/swap-any-to-erc20.ts
+++ b/packages/payment-processor/src/payment/swap-any-to-erc20.ts
@@ -17,7 +17,7 @@ import { CurrencyManager, EvmChains, UnsupportedCurrencyError } from '@requestne
 import { IRequestPaymentOptions } from '../types';
 import { IPreparedTransaction } from './prepared-transaction';
 
-export { ISwapSettings } from './swap-erc20-fee-proxy';
+export type { ISwapSettings } from './swap-erc20-fee-proxy';
 
 /**
  * Processes a transaction to swap tokens and pay an ERC20 Request through a proxy with fees.

--- a/packages/request-client.js/package.json
+++ b/packages/request-client.js/package.json
@@ -56,7 +56,7 @@
     "@requestnetwork/utils": "0.54.0",
     "ethers": "5.7.2",
     "qs": "6.11.2",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@compodoc/compodoc": "1.1.11",

--- a/packages/request-client.js/package.json
+++ b/packages/request-client.js/package.json
@@ -73,7 +73,7 @@
     "ts-jest": "29.1.0",
     "ts-loader": "8.4.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3",
+    "typescript": "5.8.3",
     "webpack": "5.94.0",
     "webpack-bundle-analyzer": "4.2.0",
     "webpack-cli": "3.3.12"

--- a/packages/request-client.js/package.json
+++ b/packages/request-client.js/package.json
@@ -70,7 +70,7 @@
     "source-map-support": "0.5.19",
     "stream-browserify": "3.0.0",
     "terser-webpack-plugin": "4.2.3",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-loader": "8.4.0",
     "ts-node": "10.9.1",
     "typescript": "5.8.3",

--- a/packages/request-client.js/src/index.ts
+++ b/packages/request-client.js/src/index.ts
@@ -9,6 +9,7 @@ import { default as HttpDataAccess } from './http-data-access';
 import * as Types from './types';
 import { NodeConnectionConfig } from './http-data-access-config';
 
+export type { NodeConnectionConfig };
 export {
   PaymentReferenceCalculator,
   Request,
@@ -16,7 +17,6 @@ export {
   RequestNetworkBase,
   HttpDataAccess,
   HttpMetaMaskDataAccess,
-  NodeConnectionConfig,
   Types,
   Utils,
 };

--- a/packages/request-logic/package.json
+++ b/packages/request-logic/package.json
@@ -55,7 +55,7 @@
     "source-map-support": "0.5.19",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   },
   "gitHead": "6155223cfce769e48ccae480c510b35b4f54b4d0"
 }

--- a/packages/request-logic/package.json
+++ b/packages/request-logic/package.json
@@ -53,7 +53,7 @@
     "jest": "29.5.0",
     "jest-junit": "16.0.0",
     "source-map-support": "0.5.19",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-node": "10.9.1",
     "typescript": "5.8.3"
   },

--- a/packages/request-logic/package.json
+++ b/packages/request-logic/package.json
@@ -45,7 +45,7 @@
     "@requestnetwork/types": "0.54.0",
     "@requestnetwork/utils": "0.54.0",
     "semver": "7.5.4",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.6",

--- a/packages/request-node/package.json
+++ b/packages/request-node/package.json
@@ -87,7 +87,7 @@
     "msw": "2.0.6",
     "source-map-support": "0.5.19",
     "supertest": "5.0.0",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-node": "10.9.1",
     "ts-node-dev": "1.0.0-pre.62",
     "typescript": "5.8.3"

--- a/packages/request-node/package.json
+++ b/packages/request-node/package.json
@@ -65,7 +65,7 @@
     "http-status-codes": "2.1.4",
     "morgan": "1.10.0",
     "shelljs": "0.8.5",
-    "tslib": "2.5.0",
+    "tslib": "2.8.1",
     "yargs": "17.6.2"
   },
   "devDependencies": {

--- a/packages/request-node/package.json
+++ b/packages/request-node/package.json
@@ -56,7 +56,7 @@
     "@requestnetwork/utils": "0.54.0",
     "chalk": "4.1.0",
     "cors": "2.8.5",
-    "dotenv": "8.2.0",
+    "dotenv": "16.5.0",
     "ethers": "5.7.2",
     "express": "4.21.0",
     "graphql": "16.8.1",
@@ -90,7 +90,7 @@
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
     "ts-node-dev": "1.0.0-pre.62",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   },
   "gitHead": "6155223cfce769e48ccae480c510b35b4f54b4d0"
 }

--- a/packages/smart-contracts/package.json
+++ b/packages/smart-contracts/package.json
@@ -78,7 +78,7 @@
     "@types/mocha": "8.2.3",
     "@types/node": "18.11.9",
     "chai": "4.3.4",
-    "dotenv": "10.0.0",
+    "dotenv": "16.5.0",
     "ethereum-waffle": "3.4.4",
     "ethers": "5.7.2",
     "ganache-cli": "6.12.0",

--- a/packages/smart-contracts/package.json
+++ b/packages/smart-contracts/package.json
@@ -51,7 +51,7 @@
     "test:lib": "yarn jest test/lib"
   },
   "dependencies": {
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@ethersproject/providers": "5.7.2",

--- a/packages/thegraph-data-access/package.json
+++ b/packages/thegraph-data-access/package.json
@@ -55,7 +55,7 @@
     "source-map-support": "0.5.19",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   },
   "gitHead": "6155223cfce769e48ccae480c510b35b4f54b4d0"
 }

--- a/packages/thegraph-data-access/package.json
+++ b/packages/thegraph-data-access/package.json
@@ -53,7 +53,7 @@
     "jest": "29.5.0",
     "jest-junit": "16.0.0",
     "source-map-support": "0.5.19",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-node": "10.9.1",
     "typescript": "5.8.3"
   },

--- a/packages/thegraph-data-access/package.json
+++ b/packages/thegraph-data-access/package.json
@@ -46,7 +46,7 @@
     "@requestnetwork/utils": "0.54.0",
     "ethers": "5.7.2",
     "graphql-request": "7.1.2",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.6",

--- a/packages/thegraph-data-access/src/subgraph-client.ts
+++ b/packages/thegraph-data-access/src/subgraph-client.ts
@@ -1,5 +1,5 @@
 import { DataAccessTypes, StorageTypes } from '@requestnetwork/types';
-import { GraphQLClient } from 'graphql-request';
+import { GraphQLClient, Variables } from 'graphql-request';
 import {
   GetBlockQuery,
   GetTransactionByDataHashQuery,
@@ -10,12 +10,11 @@ import {
   Transaction,
   TransactionsBody,
 } from './queries';
-import { Variables } from 'graphql-request/build/cjs/types';
-import { RequestConfig } from 'graphql-request/build/legacy/helpers/types';
 
 // Max Int value (as supported by grapqhl types)
 const MAX_INT_VALUE = 0x7fffffff;
 
+type RequestConfig = (typeof GraphQLClient.prototype)['requestConfig'];
 type ClientConfig = Omit<RequestConfig, 'headers'> & { headers?: Record<string, string> };
 
 export class SubgraphClient implements StorageTypes.IIndexer {

--- a/packages/thegraph-data-access/src/types.ts
+++ b/packages/thegraph-data-access/src/types.ts
@@ -1,7 +1,8 @@
-import { StorageTypes } from '@requestnetwork/types';
-import { DataAccessBaseOptions } from '@requestnetwork/data-access';
-import { RequestConfig } from 'graphql-request/build/legacy/helpers/types';
+import type { StorageTypes } from '@requestnetwork/types';
+import type { DataAccessBaseOptions } from '@requestnetwork/data-access';
+import type { GraphQLClient } from 'graphql-request';
 
+type RequestConfig = (typeof GraphQLClient.prototype)['requestConfig'];
 export type TheGraphDataAccessOptions = DataAccessBaseOptions & {
   graphql: { url: string } & Omit<RequestConfig, 'headers'> & { headers?: Record<string, string> };
   storage?: StorageTypes.IStorageWrite;

--- a/packages/toolbox/package.json
+++ b/packages/toolbox/package.json
@@ -61,6 +61,6 @@
     "@types/yargs": "17.0.14",
     "cross-env": "7.0.2",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   }
 }

--- a/packages/toolbox/package.json
+++ b/packages/toolbox/package.json
@@ -52,7 +52,7 @@
     "@requestnetwork/utils": "0.54.0",
     "ethers": "5.7.2",
     "inquirer": "8.2.0",
-    "tslib": "2.5.0",
+    "tslib": "2.8.1",
     "yargs": "17.6.2"
   },
   "devDependencies": {

--- a/packages/transaction-manager/package.json
+++ b/packages/transaction-manager/package.json
@@ -49,7 +49,7 @@
     "jest": "29.5.0",
     "jest-junit": "16.0.0",
     "source-map-support": "0.5.19",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-node": "10.9.1",
     "typescript": "5.8.3"
   },

--- a/packages/transaction-manager/package.json
+++ b/packages/transaction-manager/package.json
@@ -51,7 +51,7 @@
     "source-map-support": "0.5.19",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   },
   "gitHead": "6155223cfce769e48ccae480c510b35b4f54b4d0"
 }

--- a/packages/transaction-manager/package.json
+++ b/packages/transaction-manager/package.json
@@ -42,7 +42,7 @@
     "@requestnetwork/multi-format": "0.28.0",
     "@requestnetwork/types": "0.54.0",
     "@requestnetwork/utils": "0.54.0",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.6",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "ts-node": "10.9.1",
     "typed-emitter": "2.1.0",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   },
   "gitHead": "6155223cfce769e48ccae480c510b35b4f54b4d0"
 }

--- a/packages/types/src/data-access-types.ts
+++ b/packages/types/src/data-access-types.ts
@@ -1,6 +1,7 @@
 import * as StorageTypes from './storage-types';
 import { ConfirmationEventEmitter } from './events';
 import { AuthSig } from '@lit-protocol/types';
+
 /** Data Access Layer */
 export interface IDataRead {
   initialize: () => Promise<void>;
@@ -165,4 +166,4 @@ export interface IPendingStore {
   remove(channelId: string): void;
 }
 
-export { AuthSig };
+export type { AuthSig };

--- a/packages/types/src/extensions/pn-any-fee-reference-based-types.ts
+++ b/packages/types/src/extensions/pn-any-fee-reference-based-types.ts
@@ -1,5 +1,6 @@
-import { PnReferenceBased, IAction } from '../extension-types';
-export {
+import { IAction, PnReferenceBased } from '../extension-types';
+
+export type {
   IAddPaymentAddressParameters,
   IAddRefundAddressParameters,
 } from './pn-any-reference-based-types';

--- a/packages/types/src/extensions/pn-any-reference-based-types.ts
+++ b/packages/types/src/extensions/pn-any-reference-based-types.ts
@@ -1,8 +1,8 @@
 import { PnAddressBased } from '../extension-types';
 import { ChainName } from '../currency-types';
 
+export { ACTION } from './pn-any-address-based-types';
 export type {
-  ACTION,
   IAddPaymentAddressParameters,
   IAddRefundAddressParameters,
 } from './pn-any-address-based-types';

--- a/packages/types/src/extensions/pn-any-reference-based-types.ts
+++ b/packages/types/src/extensions/pn-any-reference-based-types.ts
@@ -1,6 +1,7 @@
 import { PnAddressBased } from '../extension-types';
 import { ChainName } from '../currency-types';
-export {
+
+export type {
   ACTION,
   IAddPaymentAddressParameters,
   IAddRefundAddressParameters,

--- a/packages/types/src/extensions/pn-any-stream-reference-based-types.ts
+++ b/packages/types/src/extensions/pn-any-stream-reference-based-types.ts
@@ -1,7 +1,7 @@
 import { PnReferenceBased } from '../extension-types';
 
+export { ACTION } from './pn-any-reference-based-types';
 export type {
-  ACTION,
   IAddPaymentAddressParameters,
   IAddRefundAddressParameters,
 } from './pn-any-reference-based-types';

--- a/packages/types/src/extensions/pn-any-stream-reference-based-types.ts
+++ b/packages/types/src/extensions/pn-any-stream-reference-based-types.ts
@@ -1,5 +1,6 @@
 import { PnReferenceBased } from '../extension-types';
-export {
+
+export type {
   ACTION,
   IAddPaymentAddressParameters,
   IAddRefundAddressParameters,

--- a/packages/types/src/extensions/pn-any-to-any-conversion-types.ts
+++ b/packages/types/src/extensions/pn-any-to-any-conversion-types.ts
@@ -1,6 +1,7 @@
 import { PnFeeReferenceBased } from '../extension-types';
 import { ChainName } from '../currency-types';
-export {
+
+export type {
   IAddPaymentAddressParameters,
   IAddRefundAddressParameters,
   IAddFeeParameters,

--- a/packages/usage-examples/package.json
+++ b/packages/usage-examples/package.json
@@ -39,7 +39,7 @@
     "@requestnetwork/types": "0.54.0",
     "@requestnetwork/utils": "0.54.0",
     "ethers": "5.7.2",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "ts-node": "10.9.1",

--- a/packages/usage-examples/package.json
+++ b/packages/usage-examples/package.json
@@ -43,6 +43,6 @@
   },
   "devDependencies": {
     "ts-node": "10.9.1",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -53,7 +53,7 @@
     "source-map-support": "0.5.19",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3"
+    "typescript": "5.8.3"
   },
   "gitHead": "6155223cfce769e48ccae480c510b35b4f54b4d0"
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -44,7 +44,7 @@
     "@toruslabs/eccrypto": "4.0.0",
     "ethers": "5.7.2",
     "secp256k1": "4.0.4",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.6",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -51,7 +51,7 @@
     "jest": "29.5.0",
     "jest-junit": "16.0.0",
     "source-map-support": "0.5.19",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-node": "10.9.1",
     "typescript": "5.8.3"
   },

--- a/packages/web3-signature/package.json
+++ b/packages/web3-signature/package.json
@@ -60,7 +60,7 @@
     "ts-jest": "29.1.0",
     "ts-loader": "8.4.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3",
+    "typescript": "5.8.3",
     "webpack": "5.94.0",
     "webpack-bundle-analyzer": "4.2.0",
     "webpack-cli": "3.3.12"

--- a/packages/web3-signature/package.json
+++ b/packages/web3-signature/package.json
@@ -44,7 +44,7 @@
     "@requestnetwork/types": "0.54.0",
     "@requestnetwork/utils": "0.54.0",
     "ethers": "5.7.2",
-    "tslib": "2.5.0"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.6",

--- a/packages/web3-signature/package.json
+++ b/packages/web3-signature/package.json
@@ -57,7 +57,7 @@
     "source-map-support": "0.5.19",
     "stream-browserify": "3.0.0",
     "terser-webpack-plugin": "4.2.3",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.3.2",
     "ts-loader": "8.4.0",
     "ts-node": "10.9.1",
     "typescript": "5.8.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2015",
     "module": "nodenext",
     "moduleResolution": "nodenext",
+    "esModuleInterop": true,
     "importHelpers": true,
     "composite": true,
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es2015",
     "module": "commonjs",
+    "moduleResolution": "node16",
     "importHelpers": true,
     "composite": true,
     "declaration": true,
@@ -10,7 +11,6 @@
     "strict": true,
     "baseUrl": "./packages",
     "skipLibCheck": true,
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "useUnknownInCatchVariables": false,
     "lib": ["es2019"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2015",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "importHelpers": true,
     "composite": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2015",
     "module": "commonjs",
-    "moduleResolution": "node16",
+    "moduleResolution": "nodenext",
     "importHelpers": true,
     "composite": true,
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "esModuleInterop": true,
+    "isolatedModules": true,
     "importHelpers": true,
     "composite": true,
     "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3789,10 +3789,10 @@
   resolved "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@hinkal/common@0.2.9":
-  version "0.2.9"
-  resolved "https://registry.npmjs.org/@hinkal/common/-/common-0.2.9.tgz"
-  integrity sha512-rlzjeQ7obtil+tu4Bg28rUcmlLEGD8F/HFCIuuTlNFvlPq5rHROjqOQb9OAxnf12ID/IMNP7LT9s6LvoSYUbcA==
+"@hinkal/common@0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@hinkal/common/-/common-0.2.10.tgz#64d234ba10e8d050134a31dfe974cee6ec7abc6d"
+  integrity sha512-RcMNVOr69WA6qao5OIpfxyHtCnIuk/a4RmXAzIDkFWB+mmyeqtm83rZ6J6lYMn+7JFGP9zi3eX+wfWwTsHddKA==
   dependencies:
     async-mutex "^0.4.0"
     axios "^1.6.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7705,20 +7705,17 @@ ajv-errors@^1.0.1:
   resolved "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
+ajv-formats@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
-
-ajv@6.12.4:
-  version "6.12.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
-  integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
 
 ajv@^5.2.2:
   version "5.5.2"
@@ -7750,6 +7747,16 @@ ajv@^7.0.2:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+ajv@^8.0.0, ajv@^8.12.0, ajv@^8.17.1:
+  version "8.17.1"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
 ajv@^8.0.1:
   version "8.11.0"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz"
@@ -7759,16 +7766,6 @@ ajv@^8.0.1:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
-
-ajv@^8.12.0:
-  version "8.17.1"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz"
-  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    fast-uri "^3.0.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
 
 amd-loader@0.0.8:
   version "0.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,10 +3411,10 @@
     auto-bind "~4.0.0"
     tslib "~2.5.0"
 
-"@graphql-codegen/typescript-graphql-request@6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/@graphql-codegen/typescript-graphql-request/-/typescript-graphql-request-6.0.1.tgz"
-  integrity sha512-aScw7ICyscW7bYLh2HyjQU3geCAjvFy6sRIlzgdkeFvcKBdjCil69upkyZAyntnSno2C4ZoUv7sHOpyQ9hQmFQ==
+"@graphql-codegen/typescript-graphql-request@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-graphql-request/-/typescript-graphql-request-6.2.0.tgz#db3bd90cd9070d446b8039384476cc1029929617"
+  integrity sha512-nkp5tr4PrC/+2QkQqi+IB+bc7AavUnUvXPW8MC93HZRvwfMGy6m2Oo7b9JCPZ3vhNpqT2VDWOn/zIZXKz6zJAw==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^3.0.0"
     "@graphql-codegen/visitor-plugin-common" "2.13.1"
@@ -11991,15 +11991,10 @@ dot@^1.1.3:
   resolved "https://registry.npmjs.org/dot/-/dot-1.1.3.tgz"
   integrity sha512-/nt74Rm+PcfnirXGEdhZleTwGC2LMnuKTeeTIlI82xb5loBBoXNYzr2ezCroPSMtilK8EZIfcNZwOcHN+ib1Lg==
 
-dotenv@10.0.0, dotenv@~10.0.0:
-  version "10.0.0"
-  resolved "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz"
-  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
-
-dotenv@8.2.0:
-  version "8.2.0"
-  resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+dotenv@16.5.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.5.0.tgz#092b49f25f808f020050051d1ff258e404c78692"
+  integrity sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==
 
 dotenv@^16.0.0:
   version "16.3.1"
@@ -12010,6 +12005,11 @@ dotenv@^16.4.5:
   version "16.4.5"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
+dotenv@~10.0.0:
+  version "10.0.0"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
 dotignore@~0.1.2:
   version "0.1.2"
@@ -23650,7 +23650,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -23667,15 +23667,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
@@ -23811,7 +23802,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -23845,13 +23836,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -25067,10 +25051,10 @@ typescript@2.9.1:
   resolved "https://registry.npmjs.org/typescript/-/typescript-2.9.1.tgz"
   integrity sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA==
 
-typescript@5.1.3:
-  version "5.1.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz"
-  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
+typescript@5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 "typescript@^3 || ^4":
   version "4.9.5"
@@ -27046,7 +27030,7 @@ workerpool@6.2.1:
   resolved "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -27076,15 +27060,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7712,7 +7712,7 @@ ajv-keywords@^3.5.2:
 
 ajv@6.12.4:
   version "6.12.4"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
   integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
   dependencies:
     fast-deep-equal "^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9543,9 +9543,9 @@ browserslist@^4.24.0, browserslist@^4.24.4:
     node-releases "^2.0.19"
     update-browserslist-db "^1.1.1"
 
-bs-logger@0.x:
+bs-logger@^0.2.6:
   version "0.2.6"
-  resolved "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
   integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
   dependencies:
     fast-json-stable-stringify "2.x"
@@ -12072,7 +12072,7 @@ ee-first@1.1.1:
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-ejs@^3.1.6, ejs@^3.1.7:
+ejs@^3.1.10, ejs@^3.1.6, ejs@^3.1.7:
   version "3.1.10"
   resolved "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz"
   integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
@@ -18289,10 +18289,10 @@ lodash.ismatch@^4.4.0:
   resolved "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
 
-lodash.memoize@4.x:
+lodash.memoize@^4.1.2:
   version "4.1.2"
-  resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
-  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
 
 lodash.memoize@~3.0.3:
   version "3.0.4"
@@ -18514,7 +18514,7 @@ make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-error@1.x, make-error@^1.1.1:
+make-error@^1.1.1, make-error@^1.3.6:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -22607,7 +22607,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", semver@7.3.8, semver@7.5.4, semver@7.x, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^6.0.0, semver@^6.1.0, semver@^6.3.0, semver@^6.3.1, semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.1, semver@^7.5.3, semver@^7.5.4, semver@~5.4.1:
+"semver@2 || 3 || 4 || 5", semver@7.3.8, semver@7.5.4, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^6.0.0, semver@^6.1.0, semver@^6.3.0, semver@^6.3.1, semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.1, semver@^7.5.3, semver@^7.5.4, semver@^7.7.1, semver@~5.4.1:
   version "7.5.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -24539,19 +24539,21 @@ ts-generator@^0.1.1:
     resolve "^1.8.1"
     ts-essentials "^1.0.0"
 
-ts-jest@29.1.0:
-  version "29.1.0"
-  resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.0.tgz"
-  integrity sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==
+ts-jest@29.3.2:
+  version "29.3.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.3.2.tgz#0576cdf0a507f811fe73dcd16d135ce89f8156cb"
+  integrity sha512-bJJkrWc6PjFVz5g2DGCNUo8z7oFEYaz1xP1NpeDU7KNLMWPpEyV8Chbpkn8xjzgRDpQhnGMyvyldoL7h8JXyug==
   dependencies:
-    bs-logger "0.x"
-    fast-json-stable-stringify "2.x"
+    bs-logger "^0.2.6"
+    ejs "^3.1.10"
+    fast-json-stable-stringify "^2.1.0"
     jest-util "^29.0.0"
     json5 "^2.2.3"
-    lodash.memoize "4.x"
-    make-error "1.x"
-    semver "7.x"
-    yargs-parser "^21.0.1"
+    lodash.memoize "^4.1.2"
+    make-error "^1.3.6"
+    semver "^7.7.1"
+    type-fest "^4.39.1"
+    yargs-parser "^21.1.1"
 
 ts-loader@8.4.0:
   version "8.4.0"
@@ -24696,10 +24698,10 @@ tslib@1.14.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz"
-  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+tslib@2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@^2.0.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.1, tslib@^2.6.2, tslib@~2.6.0:
   version "2.6.2"
@@ -24852,6 +24854,11 @@ type-fest@^2.19.0:
   version "2.19.0"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
+type-fest@^4.39.1:
+  version "4.40.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.40.0.tgz#62bc09caccb99a75e1ad6b9b4653e8805e5e1eee"
+  integrity sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -27258,7 +27265,7 @@ yargs-parser@20.2.4:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
-yargs-parser@21.1.1, yargs-parser@^21.0.1, yargs-parser@^21.1.1:
+yargs-parser@21.1.1, yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3789,10 +3789,10 @@
   resolved "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@hinkal/common@0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@hinkal/common/-/common-0.2.10.tgz#64d234ba10e8d050134a31dfe974cee6ec7abc6d"
-  integrity sha512-RcMNVOr69WA6qao5OIpfxyHtCnIuk/a4RmXAzIDkFWB+mmyeqtm83rZ6J6lYMn+7JFGP9zi3eX+wfWwTsHddKA==
+"@hinkal/common@0.2.12":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@hinkal/common/-/common-0.2.12.tgz#27ced11251cc8926187f582333d7fb13d7d028fe"
+  integrity sha512-kpaS8E6jn9/m0OEQU6zcIXbfxqolycVSCNAHwBWadTQm6OGf9DfUq/Fwjdnr+fHI+aRI8EYBZeyB4+sG7SquQw==
   dependencies:
     async-mutex "^0.4.0"
     axios "^1.6.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7705,7 +7705,7 @@ ajv-errors@^1.0.1:
   resolved "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
-ajv-formats@^3.0.1:
+ajv-formats@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
   integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
@@ -7716,6 +7716,16 @@ ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
+
+ajv@8.17.1, ajv@^8.0.0, ajv@^8.0.1, ajv@^8.12.0:
+  version "8.17.1"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 ajv@^5.2.2:
   version "5.5.2"
@@ -7741,26 +7751,6 @@ ajv@^7.0.2:
   version "7.2.1"
   resolved "https://registry.npmjs.org/ajv/-/ajv-7.2.1.tgz"
   integrity sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-    uri-js "^4.2.2"
-
-ajv@^8.0.0, ajv@^8.12.0, ajv@^8.17.1:
-  version "8.17.1"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz"
-  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    fast-uri "^3.0.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-
-ajv@^8.0.1:
-  version "8.11.0"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz"
-  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"


### PR DESCRIPTION
In this PR, I'm proposing to change TypeScript's `module` and `moduleResolution` to the latest recommended versions (see the section below for TypeScript recommendations). This would allow us to use ESM features in CommonJS, and forbid us to use non-ESM compatible imports, which should ease the transition to ESM later on. We would also gain:
- Support for `import ... from "esm"`: allows to import ESM modules synchronously in CommonJS, without the need to use `await import()`
- Support for the new package.json's `exports` property, which allows importing part of a module with `import {} from module/part`. e.g. `dotenv/config`. This change is required for https://github.com/RequestNetwork/requestNetwork/pull/1236
- Support for code splitting in consumer code: dynamic imports `await import('module')` will be kept as-is during transpilation to CommonJS, instead of being converted to `yield Promise.resolve().then(() => require('module'));`, which was preventing code splitting with consuming bundlers.

## TypeScript tsconfig.json Documentation

#### "module": "commonjs" is deprecated
https://www.typescriptlang.org/docs/handbook/modules/reference.html#commonjs
> commonjs
>
> You probably shouldn’t use this. Use node16, node18, or nodenext to emit CommonJS modules

#### "moduleResolution": "node" is deprecated
https://www.typescriptlang.org/docs/handbook/modules/reference.html#node10-formerly-known-as-node
> node10 (formerly known as node)
>
> --moduleResolution node ... should no longer be used.

## Issue to address before merge

- [x] ~~`@hinkal/common` does not export types, the `types` field is missing in the `package.json`:
https://cdn.jsdelivr.net/npm/@hinkal/common@0.2.9/package.json~~
  Fixed in `0.2.12`, https://cdn.jsdelivr.net/npm/@hinkal/common@0.2.12/package.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved validation format support by integrating ajv-formats for enhanced data validation.
  - Jest test execution now adapts to available system resources for better performance during testing.

- **Bug Fixes**
  - Updated test assertions to match new validation error message formats.

- **Chores**
  - Upgraded multiple dependencies across packages, including TypeScript, tslib, dotenv, ajv, and ts-jest, for improved compatibility and security.
  - Updated TypeScript configuration for modern module resolution and interoperability.
  - Refined type imports and type aliasing to reduce reliance on internal module paths.
  - Clarified type-only exports across various modules to improve type safety and code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->