### PR TITLE
feat(payment-detection): option to use TheGraph Network with API key

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,6 @@
     "semver": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/197",
     "json-schema": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/51",
     "json5": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/165"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,5 @@
     "semver": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/197",
     "json-schema": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/51",
     "json5": "https://github.com/RequestNetwork/requestNetwork/security/dependabot/165"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/packages/payment-detection/src/thegraph/client.ts
+++ b/packages/payment-detection/src/thegraph/client.ts
@@ -138,29 +138,29 @@ export const defaultGetTheGraphClientUrl = (
   network: CurrencyTypes.ChainName,
   options?: TheGraphClientOptions,
 ) => {
-  const filteredNetwork = network.replace('aurora', 'near');
-  const theGraphExplorerSubgraphId = THE_GRAPH_EXPLORER_SUBGRAPH_ID[network];
+  const chain = network.replace('aurora', 'near') as CurrencyTypes.ChainName;
+  const theGraphExplorerSubgraphId = THE_GRAPH_EXPLORER_SUBGRAPH_ID[chain];
   const { theGraphExplorerApiKey } = options || {};
 
   // build URLs
-  const theGraphStudioUrl = THE_GRAPH_STUDIO_URL.replace('$NETWORK', filteredNetwork);
+  const theGraphStudioUrl = THE_GRAPH_STUDIO_URL.replace('$NETWORK', chain);
   const theGraphExplorerUrl = THE_GRAPH_EXPLORER_URL.replace(
     '$API_KEY',
     theGraphExplorerApiKey || '',
   ).replace('$SUBGRAPH_ID', theGraphExplorerSubgraphId || '');
-  const theGraphAlchemyUrl = THE_GRAPH_ALCHEMY_URL.replace('$NETWORK', filteredNetwork);
+  const theGraphAlchemyUrl = THE_GRAPH_ALCHEMY_URL.replace('$NETWORK', chain);
 
   const shouldUseTheGraphExplorer = !!theGraphExplorerApiKey && !!theGraphExplorerSubgraphId;
-  const shouldUseAlchemy = THE_GRAPH_ALCHEMY_CHAINS.includes(network);
+  const shouldUseAlchemy = THE_GRAPH_ALCHEMY_CHAINS.includes(chain);
 
   switch (true) {
-    case network === 'private':
+    case chain === 'private':
       return;
-    case network === 'mantle':
+    case chain === 'mantle':
       return THE_GRAPH_URL_MANTLE;
-    case network === 'mantle-testnet':
+    case chain === 'mantle-testnet':
       return THE_GRAPH_URL_MANTLE_TESTNET;
-    case network === 'core':
+    case chain === 'core':
       return THE_GRAPH_URL_CORE;
     default:
       return shouldUseTheGraphExplorer

--- a/packages/payment-detection/src/thegraph/client.ts
+++ b/packages/payment-detection/src/thegraph/client.ts
@@ -139,16 +139,19 @@ export const defaultGetTheGraphClientUrl = (
   options?: TheGraphClientOptions,
 ) => {
   const filteredNetwork = network.replace('aurora', 'near');
+  const theGraphExplorerSubgraphId = THE_GRAPH_EXPLORER_SUBGRAPH_ID[network];
+  const { theGraphExplorerApiKey } = options || {};
+
+  // build URLs
   const theGraphStudioUrl = THE_GRAPH_STUDIO_URL.replace('$NETWORK', filteredNetwork);
   const theGraphExplorerUrl = THE_GRAPH_EXPLORER_URL.replace(
     '$API_KEY',
-    options?.theGraphExplorerApiKey || '',
-  ).replace('$SUBGRAPH_ID', THE_GRAPH_EXPLORER_SUBGRAPH_ID[network] || '');
+    theGraphExplorerApiKey || '',
+  ).replace('$SUBGRAPH_ID', theGraphExplorerSubgraphId || '');
   const theGraphAlchemyUrl = THE_GRAPH_ALCHEMY_URL.replace('$NETWORK', filteredNetwork);
 
-  const shouldUseTheGraphExplorer =
-    !!options?.theGraphExplorerApiKey &&
-    Object.keys(THE_GRAPH_EXPLORER_SUBGRAPH_ID).includes(network);
+  const shouldUseTheGraphExplorer = !!theGraphExplorerApiKey && !!theGraphExplorerSubgraphId;
+  const shouldUseAlchemy = THE_GRAPH_ALCHEMY_CHAINS.includes(network);
 
   switch (true) {
     case network === 'private':
@@ -162,7 +165,7 @@ export const defaultGetTheGraphClientUrl = (
     default:
       return shouldUseTheGraphExplorer
         ? theGraphExplorerUrl
-        : THE_GRAPH_ALCHEMY_CHAINS.includes(network)
+        : shouldUseAlchemy
         ? theGraphAlchemyUrl
         : theGraphStudioUrl;
   }

--- a/packages/payment-detection/src/thegraph/client.ts
+++ b/packages/payment-detection/src/thegraph/client.ts
@@ -2,12 +2,14 @@
 import { CurrencyTypes } from '@requestnetwork/types';
 import { NearChains } from '@requestnetwork/currency';
 import { GraphQLClient } from 'graphql-request';
-import { Block_Height, Maybe, getSdk } from './generated/graphql';
+import { Block_Height, getSdk, Maybe } from './generated/graphql';
 import { getSdk as getNearSdk } from './generated/graphql-near';
 import { RequestConfig } from 'graphql-request/src/types';
 
 const THE_GRAPH_STUDIO_URL =
   'https://api.studio.thegraph.com/query/67444/request-payments-$NETWORK/version/latest';
+
+const THE_GRAPH_EXPLORER_URL = 'https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$NETWORK';
 
 const THE_GRAPH_ALCHEMY_URL =
   'https://subgraph.satsuma-prod.com/e2e4905ab7c8/request-network--434873/request-payments-$NETWORK/api';
@@ -20,6 +22,26 @@ const THE_GRAPH_URL_MANTLE =
 
 const THE_GRAPH_URL_CORE =
   'https://thegraph.coredao.org/subgraphs/name/requestnetwork/request-payments-core';
+
+const THE_GRAPH_EXPLORER_SUBGRAPH_ID = {
+  mainnet: '5mXPGZRC2Caynh4NyVrTK72DAGB9dfcKmLsnxYWHQ9nd',
+  sepolia: '6e8Dcwt3cvsgNU3JYBtRQQ9Sj4P9VVVnXaPjJ3jUpYpY',
+  ['arbitrum-one']: '3MtDdHbzvBVNBpzUTYXGuDDLgTd1b8bPYwoH1Hdssgp9',
+  avalanche: 'A27V4PeZdKHeyuBkehdBJN8cxNtzVpXvYoqkjHUHRCFp',
+  base: 'CcTtKy6BustyyVZ5XvFD4nLnbkgMBT1vcAEJ3sAx6bRe',
+  bsc: '4PScFUi3CFDbop9XzT6gCDtD4RR8kRzyrzSjrHoXHZBt',
+  celo: '5ts3PHjMcH2skCgKtvLLNE64WLjbhE5ipruvEcgqyZqC',
+  fantom: '6AwmiYo5eY36W526ZDQeAkNBjXjXKYcMLYyYHeM67xAb',
+  fuse: 'EHSpUBa7PAewX7WsaU2jbCKowF5it56yStr6Zgf8aDtx',
+  matic: 'DPpU1WMxk2Z4H2TAqgwGbVBGpabjbC1972Mynak5jSuR',
+  moonbeam: '4Jo3DwA25zyVLeDhyi7cks52dNrkVCWWhQJzm1hKnCfj',
+  near: '9yEg3h46CZiv4VuSqo1erMMBx5sHxRuW5Ai2V8goSpQL',
+  ['near-testnet']: 'AusVyfndonsMVFrVzckuENLqx8t6kcXuxn6C6VbSGd7M',
+  optimism: '525fra79nG3Z1w8aPZh3nHsH5zCVetrVmceB1hKcTrTX',
+  xdai: '2UAW7B94eeeqaL5qUM5FDzTWJcmgA6ta1RcWMo3XuLmU',
+  zksyncera: 'HJNZW9vRSGXrcCVyQMdNKxxuLKeZcV6yMjTCyY6T2oon',
+  sonic: 'CQbtmuANYsChysuXTk9jWP3BD4ArncARVVw1b8JpHiTk',
+} as const satisfies Partial<Record<CurrencyTypes.ChainName, string>>;
 
 // NB: the GraphQL client is automatically generated based on files present in ./queries,
 // using graphql-codegen.
@@ -44,6 +66,8 @@ export type TheGraphQueryOptions = {
 export type TheGraphClientOptions = RequestConfig & {
   /** constraint to select indexers that have at least parsed this block */
   minIndexedBlock?: number | undefined;
+  /** API key for accessing subgraphs hosted on TheGraph Explorer */
+  theGraphExplorerApiKey?: string;
 };
 
 /** Splits the input options into "client options" to pass to the SDK, and "query options" to use in queries */
@@ -55,7 +79,13 @@ const extractClientOptions = (
 
   // build query options
   const queryOptions: TheGraphQueryOptions = {};
-  const { minIndexedBlock, ...clientOptions } = optionsObject;
+  const {
+    minIndexedBlock,
+    // ignore theGraphExplorerApiKey, it should not be part of clientOptions
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    theGraphExplorerApiKey: _theGraphExplorerApiKey,
+    ...clientOptions
+  } = optionsObject;
   if (minIndexedBlock) {
     queryOptions.blockFilter = { number_gte: minIndexedBlock };
   } else if (url.match(/^https:\/\/gateway-\w+\.network\.thegraph\.com\//)) {
@@ -94,19 +124,32 @@ export const defaultGetTheGraphClient = (
   network: CurrencyTypes.ChainName,
   options?: TheGraphClientOptions,
 ) => {
+  const filteredNetwork = network.replace('aurora', 'near');
+  const theGraphStudioUrl = THE_GRAPH_STUDIO_URL.replace('$NETWORK', filteredNetwork);
+  const theGraphExplorerUrl = THE_GRAPH_EXPLORER_URL.replace(
+    '$API_KEY',
+    options?.theGraphExplorerApiKey || '',
+  ).replace('$NETWORK', filteredNetwork);
+  const theGraphAlchemyUrl = THE_GRAPH_ALCHEMY_URL.replace('$NETWORK', filteredNetwork);
+
+  const shouldUseTheGraphExplorer =
+    !!options?.theGraphExplorerApiKey &&
+    Object.keys(THE_GRAPH_EXPLORER_SUBGRAPH_ID).includes(network);
+
   return network === 'private'
     ? undefined
     : NearChains.isChainSupported(network)
-    ? getTheGraphNearClient(
-        `${THE_GRAPH_STUDIO_URL.replace('$NETWORK', network.replace('aurora', 'near'))}`,
-        options,
-      )
+    ? shouldUseTheGraphExplorer
+      ? getTheGraphEvmClient(theGraphExplorerUrl, options)
+      : getTheGraphNearClient(theGraphStudioUrl, options)
     : network === 'mantle'
     ? getTheGraphEvmClient(THE_GRAPH_URL_MANTLE, options)
     : network === 'mantle-testnet'
     ? getTheGraphEvmClient(THE_GRAPH_URL_MANTLE_TESTNET, options)
     : network === 'core'
     ? getTheGraphEvmClient(THE_GRAPH_URL_CORE, options)
+    : shouldUseTheGraphExplorer
+    ? getTheGraphEvmClient(theGraphExplorerUrl, options)
     : network === 'mainnet' ||
       network === 'sepolia' ||
       network === 'matic' ||
@@ -117,6 +160,6 @@ export const defaultGetTheGraphClient = (
       network === 'zksyncera' ||
       network === 'avalanche' ||
       network === 'fantom'
-    ? getTheGraphEvmClient(`${THE_GRAPH_ALCHEMY_URL.replace('$NETWORK', network)}`, options)
-    : getTheGraphEvmClient(`${THE_GRAPH_STUDIO_URL.replace('$NETWORK', network)}`, options);
+    ? getTheGraphEvmClient(theGraphAlchemyUrl, options)
+    : getTheGraphEvmClient(theGraphStudioUrl, options);
 };

--- a/packages/payment-detection/test/thegraph/client.test.ts
+++ b/packages/payment-detection/test/thegraph/client.test.ts
@@ -1,0 +1,46 @@
+import { defaultGetTheGraphClientUrl } from '../../src/thegraph';
+
+describe('defaultGetTheGraphClientUrl', () => {
+  it('should build the correct URL for network supported by Alchemy', () => {
+    const url = defaultGetTheGraphClientUrl('base');
+    expect(url).toBe(
+      'https://subgraph.satsuma-prod.com/e2e4905ab7c8/request-network--434873/request-payments-base/api',
+    );
+  });
+  it('should build the correct URL when using TheGraph Explorer API key', () => {
+    const url = defaultGetTheGraphClientUrl('base', { theGraphExplorerApiKey: 'test' });
+    expect(url).toBe(
+      'https://gateway.thegraph.com/api/test/subgraphs/id/CcTtKy6BustyyVZ5XvFD4nLnbkgMBT1vcAEJ3sAx6bRe',
+    );
+  });
+  it('should build the correct URL for Mantle', () => {
+    const url = defaultGetTheGraphClientUrl('mantle');
+    expect(url).toBe(
+      'https://subgraph-api.mantle.xyz/api/public/555176e7-c1f4-49f9-9180-f2f03538b039/subgraphs/requestnetwork/request-payments-mantle/v0.1.0/gn',
+    );
+  });
+  it('should build the correct URL for Near', () => {
+    const urlNear = defaultGetTheGraphClientUrl('near');
+    expect(urlNear).toBe(
+      'https://api.studio.thegraph.com/query/67444/request-payments-near/version/latest',
+    );
+    const urlNearTestnet = defaultGetTheGraphClientUrl('near-testnet');
+    expect(urlNearTestnet).toBe(
+      'https://api.studio.thegraph.com/query/67444/request-payments-near-testnet/version/latest',
+    );
+    const urlAurora = defaultGetTheGraphClientUrl('aurora');
+    expect(urlAurora).toBe(
+      'https://api.studio.thegraph.com/query/67444/request-payments-near/version/latest',
+    );
+    const urlAuroraTestnet = defaultGetTheGraphClientUrl('aurora-testnet');
+    expect(urlAuroraTestnet).toBe(
+      'https://api.studio.thegraph.com/query/67444/request-payments-near-testnet/version/latest',
+    );
+  });
+  it('should build the correct URL for Near with TheGraph Explorer API key', () => {
+    const url = defaultGetTheGraphClientUrl('near', { theGraphExplorerApiKey: 'test' });
+    expect(url).toBe(
+      'https://gateway.thegraph.com/api/test/subgraphs/id/9yEg3h46CZiv4VuSqo1erMMBx5sHxRuW5Ai2V8goSpQL',
+    );
+  });
+});


### PR DESCRIPTION
## Description of the changes

The goal of this PR is to make it easier for builders to use TheGraph Network for payment detection with their own API key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for TheGraph Explorer as a new subgraph hosting option, including API key handling.
  - Enhanced network selection logic for subgraph endpoints, with improved modularity and clarity.

- **Tests**
  - Introduced new tests to verify correct URL generation for various networks and configurations, including TheGraph Explorer support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->