### PR TITLE
chore(data-format): rnf invoice allow negative line items

### DIFF
--- a/packages/data-format/src/format/rnf_invoice/rnf_invoice-0.0.3.json
+++ b/packages/data-format/src/format/rnf_invoice/rnf_invoice-0.0.3.json
@@ -124,7 +124,7 @@
           },
           "unitPrice": {
             "type": "string",
-            "pattern": "^\\d+$"
+            "pattern": "^-?\\d+$"
           },
           "discount": {
             "type": "string",


### PR DESCRIPTION
## Description of the changes

Update the latest `rnf_invoice` data-format.
It now accepts negative line items. 