### PR TITLE
fix: safe eth requirement

### DIFF
--- a/packages/data-format/src/format/rnf_invoice/rnf_invoice-0.0.3.json
+++ b/packages/data-format/src/format/rnf_invoice/rnf_invoice-0.0.3.json
@@ -124,7 +124,7 @@
           },
           "unitPrice": {
             "type": "string",
-            "pattern": "^\\d+$"
+            "pattern": "^-?\\d+$"
           },
           "discount": {
             "type": "string",

--- a/packages/payment-processor/src/payment/index.ts
+++ b/packages/payment-processor/src/payment/index.ts
@@ -271,7 +271,7 @@ export async function isSolvent({
   const ethBalance = await provider.getBalance(fromAddress);
 
   if (currency.type === 'ETH') {
-    return ethBalance.gt(amount);
+    return needsGas ? ethBalance.gt(amount) : ethBalance.gte(amount);
   } else {
     const balance = await getCurrencyBalance(fromAddress, currency, provider);
     return (ethBalance.gt(0) || !needsGas) && BigNumber.from(balance).gte(amount);

--- a/packages/payment-processor/test/payment/index.test.ts
+++ b/packages/payment-processor/test/payment/index.test.ts
@@ -34,6 +34,12 @@ const nearCurrency: RequestLogicTypes.ICurrency = {
   value: 'near',
 };
 
+const ethCurrency: RequestLogicTypes.ICurrency = {
+  type: RequestLogicTypes.CURRENCY.ETH,
+  network: 'mainnet',
+  value: 'ETH',
+};
+
 describe('payRequest', () => {
   afterEach(() => {
     jest.resetAllMocks();
@@ -516,7 +522,7 @@ describe('hasSufficientFunds', () => {
     expect(solvency).toBeFalsy();
   });
 
-  it('should skip ETH balance checks when needsGas is false', async () => {
+  it('should skip ETH balance checks when needsGas is false - ERC20 payment', async () => {
     const mock = jest
       .spyOn(erc20Module, 'getAnyErc20Balance')
       .mockReturnValue(Promise.resolve(BigNumber.from('200')));
@@ -532,6 +538,34 @@ describe('hasSufficientFunds', () => {
     });
     expect(solvency).toBeTruthy();
     expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should require only the given ETH amount when needsGas is false - ETH payment', async () => {
+    // eslint-disable-next-line no-magic-numbers
+    const solvency = await isSolvent({
+      fromAddress: 'any',
+      currency: ethCurrency,
+      amount: 200,
+      providerOptions: {
+        provider: fakeProvider as any,
+      },
+      needsGas: false,
+    });
+    expect(solvency).toBeTruthy();
+  });
+
+  it('should require an excess of ETH when needsGas is true - ETH payment', async () => {
+    // eslint-disable-next-line no-magic-numbers
+    const solvency = await isSolvent({
+      fromAddress: 'any',
+      currency: ethCurrency,
+      amount: 200,
+      providerOptions: {
+        provider: fakeProvider as any,
+      },
+      needsGas: true,
+    });
+    expect(solvency).toBeFalsy();
   });
 
   it('should check ETH balance checks by default', async () => {


### PR DESCRIPTION
## Description of the changes

When checking the eth balance, we should enforce a balance higher than the given amount _only_ when `needsGas` is `true`. The current logic prevents the user from paying (e.g. from Safe) when their balance is exactly the same as the amount they have to pay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ETH payment solvency checks to correctly handle cases where gas is not required, allowing balances equal to the payment amount to be considered sufficient.
- **Tests**
  - Added test cases to verify ETH solvency logic with and without gas requirements.
  - Clarified test descriptions for ERC20 payment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->