### PR TITLE
ci: fix next release exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "packageJsonLint": "npmPkgJsonLint ./packages",
     "publish-npm": "lerna publish --conventional-commits --exact --message \"chore(release): publish %s\" --no-changelog --yes",
     "publish-manual-prerelease": "lerna publish prerelease --no-git-tag-version --no-push --preid next.$(git rev-parse --short HEAD) --exact --dist-tag next",
-    "publish-prerelease": "FORCE_PUBLISH=$(lerna changed --json | jq '. | map(.name) | join (\",\")' -r) && echo $FORCE_PUBLISH && lerna publish prerelease --no-git-tag-version --no-push --preid next.$(git rev-parse --short HEAD) --dist-tag next --yes --force-publish=${FORCE_PUBLISH}",
+    "publish-prerelease": "FORCE_PUBLISH=$(lerna changed --json | jq '. | map(.name) | join (\",\")' -r) && echo $FORCE_PUBLISH && lerna publish prerelease --no-git-tag-version --no-push --preid next.$(git rev-parse --short HEAD) --exact --dist-tag next --yes --force-publish=${FORCE_PUBLISH}",
     "deploy:contracts": "yarn workspace @requestnetwork/smart-contracts deploy",
     "start:request-node": "LIT_PROTOCOL_NETWORK=datil-dev yarn workspace @requestnetwork/request-node start",
     "test": "lerna run test",


### PR DESCRIPTION
## Context

Prereleases currently contain version attributes like so in their `package.json` file ([see example](https://www.npmjs.com/package/@requestnetwork/request-client.js/v/0.59.1-next.99afa915.0?activeTab=code)):

```json
"dependencies": {
    "@requestnetwork/advanced-logic": "^0.54.1-next.99afa915.0",
    "@requestnetwork/currency": "^0.28.1-next.99afa915.0",
    "@requestnetwork/data-access": "^0.45.1-next.99afa915.0",
    ...
```

## Issue

Package managers do not correctly update transitive dependencies when bumping from one prerelease to another, as only the hash changes, but the semantic versioning (semver) part remains the same.

## Change

Prerelease versions should contain exact attributes like so:

```json
"dependencies": {
    "@requestnetwork/advanced-logic": "0.54.1-next.99afa915.0",
    "@requestnetwork/currency": "0.28.1-next.99afa915.0",
    "@requestnetwork/data-access": "0.45.1-next.99afa915.0",
    ...
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-release publishing scripts to include exact version matching configuration for improved release consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->