### PR TITLE
chore: update auto-assign reviewers to RF-specific accounts

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -6,10 +6,10 @@ addAssignees: false
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
-  - yomarion
-  - kevindavee
-  - alexandre-abrioux
-  - leoslr
+  - yomarion-rf
+  - dave-rf
+  - alexandre-abrioux-rf
+  - LeoSlrRf
   - MantisClone
   - aimensahnoun
   - rodrigopavezi


### PR DESCRIPTION
# Problem

RF employees decided to replace personal accounts with RF-specific accounts on the RN organization for security.

# Proposed Solution

Update the auto-assign configuration with the new RF-specific GitHub accounts:
- `yomarion` → `yomarion-rf`
- `kevindavee` → `dave-rf`
- `alexandre-abrioux` → `alexandre-abrioux-rf`
- `leoslr` → `LeoSlrRf`

# Considerations

Other reviewers remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub reviewer automation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->