### PR TITLE
fix: sui erc20 address validation

### DIFF
--- a/packages/currency/src/currencyManager.ts
+++ b/packages/currency/src/currencyManager.ts
@@ -360,8 +360,8 @@ export class CurrencyManager<TMeta = unknown> implements CurrencyTypes.ICurrency
    */
   validateSuiAddress(address: string): boolean {
     try {
-      if (address.includes(':')) {
-        return !!isValidSuiAddress(address.split(':')[0]);
+      if (address.includes('::')) {
+        return !!isValidSuiAddress(address.split('::')[0]);
       }
       return !!isValidSuiAddress(address);
     } catch {


### PR DESCRIPTION
## Description of the changes

Follow up on https://github.com/RequestNetwork/requestNetwork/pull/1658

On sui, erc20 addresses commonly have the following format:
`0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC`

Update the validation method so it's taken into account when validating an SUI address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address validation to properly handle namespaced addresses. Addresses containing "::" are now validated correctly by checking the portion before the delimiter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->