### PR TITLE
feat: include feeAmount in batch transaction value for ETH_FEE_PROXY_CONTRACT payments

### DIFF
--- a/packages/payment-processor/src/payment/batch-conversion-proxy.ts
+++ b/packages/payment-processor/src/payment/batch-conversion-proxy.ts
@@ -310,11 +310,13 @@ const getBatchTxValue = (enrichedRequests: EnrichedRequest[]) => {
       curr.paymentNetworkId !== ExtensionTypes.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT
     )
       return prev;
-    return prev.add(
-      curr.paymentNetworkId === ExtensionTypes.PAYMENT_NETWORK_ID.ANY_TO_ETH_PROXY
-        ? curr.paymentSettings.maxToSpend
-        : getAmountToPay(curr.request),
-    );
+
+    if (curr.paymentNetworkId === ExtensionTypes.PAYMENT_NETWORK_ID.ANY_TO_ETH_PROXY) {
+      return prev.add(curr.paymentSettings.maxToSpend);
+    }
+
+    const { feeAmount } = getRequestPaymentValues(curr.request);
+    return prev.add(getAmountToPay(curr.request)).add(BigNumber.from(feeAmount || '0'));
   }, BigNumber.from(0));
 };
 


### PR DESCRIPTION
## Description of the changes

Fixed a bug in the batch conversion proxy where fee amounts were not included in the transaction value for ETH_FEE_PROXY_CONTRACT payments. The code now properly adds the fee amount to the total transaction value, ensuring that the correct amount is sent when processing payments. Added comprehensive tests to verify the fix works for both single payments and batches of payments with fees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Batch payment processing now correctly includes fee amounts in transaction value calculations for Ethereum fee proxy contracts, ensuring accurate fee accounting in multi-transaction batches.

* **Tests**
  * Added validation tests confirming fee amounts are properly included in batch payment transaction calculations across single and multiple payment scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->