### PR TITLE
feat: add Tron chain definitions for currency package

### DIFF
--- a/packages/currency/src/chains/declarative/data/nile.ts
+++ b/packages/currency/src/chains/declarative/data/nile.ts
@@ -1,0 +1,10 @@
+export const chainId = 'nile';
+
+// Nile is Tron's test network
+export const testnet = true;
+
+// Test tokens on Nile testnet
+// Note: These are testnet token addresses, not mainnet
+export const currencies = {
+  // Add testnet token addresses as needed
+};

--- a/packages/currency/src/chains/declarative/data/tron.ts
+++ b/packages/currency/src/chains/declarative/data/tron.ts
@@ -1,1 +1,20 @@
 export const chainId = 'tron';
+
+// Tron mainnet configuration
+export const testnet = false;
+
+// Common TRC20 tokens on Tron
+export const currencies = {
+  // USDT-TRC20 - the most widely used stablecoin on Tron
+  TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t: {
+    name: 'Tether USD',
+    symbol: 'USDT',
+    decimals: 6,
+  },
+  // USDC on Tron
+  TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8: {
+    name: 'USD Coin',
+    symbol: 'USDC',
+    decimals: 6,
+  },
+};


### PR DESCRIPTION
## Description of the changes

Added support for Tron blockchain and its Nile testnet:

- Created new Tron chain configuration with USDT and USDC token definitions
- Added Nile testnet configuration for Tron
- Implemented TronChains class for handling Tron-specific chain operations
- Updated type definitions to include Tron chains in the supported VM chains
- Added Tron chains to the exports for use throughout the application

---
Closes RequestNetwork/private-issues#223
Closes RequestNetwork/private-issues#224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Nile testnet network configuration
  * Added support for Tron network with testnet toggle capability
  * Introduced token catalog for Tron network featuring USDT-TRC20 and USDC tokens with metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->