### PR TITLE
chore: tighten topic parameter types in request client API

### DIFF
--- a/packages/request-client.js/src/api/request-network.ts
+++ b/packages/request-client.js/src/api/request-network.ts
@@ -341,7 +341,7 @@ export default class RequestNetwork {
    * @returns the Requests
    */
   public async fromTopic(
-    topic: any,
+    topic: IdentityTypes.IIdentity | string,
     updatedBetween?: Types.ITimestampBoundaries,
     options?: {
       disablePaymentDetection?: boolean;
@@ -413,7 +413,7 @@ export default class RequestNetwork {
    * @returns the Requests
    */
   public async fromMultipleTopics(
-    topics: any[],
+    topics: Array<IdentityTypes.IIdentity | string>,
     updatedBetween?: Types.ITimestampBoundaries,
     options?: {
       disablePaymentDetection?: boolean;


### PR DESCRIPTION
This improves type safety for (fromTopic) and (fromMultipleTopics) by replacing any with the actual supported input types IdentityTypes.IIdentity | string


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RequestNetwork methods now accept Identity objects in addition to strings, providing greater flexibility in specifying topics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->