### PR TITLE
ci: harden GitHub Actions against supply chain attacks

### DIFF
--- a/.github/workflows/auto-project.yml
+++ b/.github/workflows/auto-project.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     uses: RequestNetwork/.github/.github/workflows/add-to-project.yml@main

--- a/.github/workflows/auto_assign_pr.yml
+++ b/.github/workflows/auto_assign_pr.yml
@@ -12,4 +12,8 @@ jobs:
   add-reviews:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.2.0
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2
+        with:
+          egress-policy: audit
+      - uses: kentaro-m/auto-assign-action@50ee9a1818bde2eb93a948448994a9d414457e3a # v1.2.0

--- a/.github/workflows/pr-comments.yml
+++ b/.github/workflows/pr-comments.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, ready_for_review, closed]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   pr-comments:
     name: PR Comments

--- a/.github/workflows/reopen-issue-if-prs-open.yml
+++ b/.github/workflows/reopen-issue-if-prs-open.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   reopen-if-needed:
     uses: RequestNetwork/.github/.github/workflows/reopen-issue-if-prs-open.yml@main

--- a/.github/workflows/security-echidna.yml
+++ b/.github/workflows/security-echidna.yml
@@ -26,6 +26,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   echidna-fuzzing:

--- a/.github/workflows/security-echidna.yml
+++ b/.github/workflows/security-echidna.yml
@@ -50,10 +50,15 @@ jobs:
           node-version: '22'
           cache: 'yarn'
 
+      - name: Setup Socket.dev
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
       - name: Install dependencies
         working-directory: packages/smart-contracts
         run: |
-          yarn install --frozen-lockfile
+          sfw yarn install --frozen-lockfile
 
       - name: Compile contracts
         working-directory: packages/smart-contracts
@@ -191,15 +196,22 @@ jobs:
       - name: Comment on PR
         if: github.event_name == 'pull_request' && always()
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PASSED: ${{ steps.parse.outputs.PASSED }}
+          FAILED: ${{ steps.parse.outputs.FAILED }}
+          TOTAL: ${{ steps.parse.outputs.TOTAL }}
+          MODE: ${{ steps.mode.outputs.MODE }}
+          TEST_LIMIT: ${{ steps.mode.outputs.TEST_LIMIT }}
+          STATUS: ${{ steps.echidna.outcome }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const passed = '${{ steps.parse.outputs.PASSED }}';
-            const failed = '${{ steps.parse.outputs.FAILED }}';
-            const total = '${{ steps.parse.outputs.TOTAL }}';
-            const mode = '${{ steps.mode.outputs.MODE }}';
-            const testLimit = '${{ steps.mode.outputs.TEST_LIMIT }}';
-            const status = '${{ steps.echidna.outcome }}';
+            const passed = process.env.PASSED;
+            const failed = process.env.FAILED;
+            const total = process.env.TOTAL;
+            const mode = process.env.MODE;
+            const testLimit = process.env.TEST_LIMIT;
+            const status = process.env.STATUS;
 
             const statusEmoji = status === 'success' ? '✅' : '❌';
             const passRate = total > 0 ? ((passed / total) * 100).toFixed(1) : '0';
@@ -263,11 +275,14 @@ jobs:
       - name: Create issue for nightly failures
         if: github.event_name == 'schedule' && steps.echidna.outcome == 'failure'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PASSED: ${{ steps.parse.outputs.PASSED }}
+          FAILED: ${{ steps.parse.outputs.FAILED }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const passed = '${{ steps.parse.outputs.PASSED }}';
-            const failed = '${{ steps.parse.outputs.FAILED }}';
+            const passed = process.env.PASSED;
+            const failed = process.env.FAILED;
 
             github.rest.issues.create({
               owner: context.repo.owner,

--- a/.github/workflows/security-echidna.yml
+++ b/.github/workflows/security-echidna.yml
@@ -34,13 +34,17 @@ jobs:
     timeout-minutes: 90
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2
+        with:
+          egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'yarn'
@@ -82,7 +86,7 @@ jobs:
           echidna --version
 
       - name: Restore corpus cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: packages/smart-contracts/corpus
           key: echidna-corpus-${{ github.ref_name }}-${{ github.sha }}
@@ -175,7 +179,7 @@ jobs:
 
       - name: Upload Echidna reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: echidna-reports-${{ steps.mode.outputs.MODE }}
           path: |
@@ -185,7 +189,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -257,7 +261,7 @@ jobs:
 
       - name: Create issue for nightly failures
         if: github.event_name == 'schedule' && steps.echidna.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/security-slither.yml
+++ b/.github/workflows/security-slither.yml
@@ -21,13 +21,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2
+        with:
+          egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'yarn'
@@ -48,7 +52,7 @@ jobs:
           yarn build:sol
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -90,14 +94,14 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always() && hashFiles('packages/smart-contracts/reports/security/slither.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
         with:
           sarif_file: packages/smart-contracts/reports/security/slither.sarif
           category: slither
 
       - name: Upload Slither reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: slither-reports
           path: packages/smart-contracts/reports/security/
@@ -132,7 +136,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/security-slither.yml
+++ b/.github/workflows/security-slither.yml
@@ -36,9 +36,14 @@ jobs:
           node-version: '22'
           cache: 'yarn'
 
+      - name: Setup Socket.dev
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
       - name: Install dependencies
         run: |
-          yarn install --frozen-lockfile
+          sfw yarn install --frozen-lockfile
 
       - name: Build dependencies
         run: |
@@ -94,7 +99,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always() && hashFiles('packages/smart-contracts/reports/security/slither.sarif') != ''
-        uses: github/codeql-action/upload-sarif@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: packages/smart-contracts/reports/security/slither.sarif
           category: slither
@@ -137,14 +142,20 @@ jobs:
       - name: Comment on PR
         if: github.event_name == 'pull_request' && always()
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          HIGH: ${{ steps.parse.outputs.HIGH }}
+          MEDIUM: ${{ steps.parse.outputs.MEDIUM }}
+          LOW: ${{ steps.parse.outputs.LOW }}
+          INFO: ${{ steps.parse.outputs.INFO }}
+          STATUS: ${{ steps.slither.outcome }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const high = '${{ steps.parse.outputs.HIGH }}';
-            const medium = '${{ steps.parse.outputs.MEDIUM }}';
-            const low = '${{ steps.parse.outputs.LOW }}';
-            const info = '${{ steps.parse.outputs.INFO }}';
-            const status = '${{ steps.slither.outcome }}';
+            const high = process.env.HIGH;
+            const medium = process.env.MEDIUM;
+            const low = process.env.LOW;
+            const info = process.env.INFO;
+            const status = process.env.STATUS;
 
             const statusEmoji = status === 'success' ? '✅' : '⚠️';
             const highEmoji = high > 0 ? '🔴' : '✅';

--- a/.github/workflows/tron-smart-contracts.yml
+++ b/.github/workflows/tron-smart-contracts.yml
@@ -32,17 +32,24 @@ on:
       - 'packages/currency/src/chains/tron/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tron-compile-check:
     name: Tron Contract Compilation Check
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2
+        with:
+          egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'yarn'
@@ -50,8 +57,13 @@ jobs:
       - name: Install TronBox globally
         run: npm install -g tronbox
 
+      - name: Setup Socket.dev
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: sfw yarn install --frozen-lockfile
 
       - name: Compile Tron contracts
         working-directory: packages/smart-contracts
@@ -134,17 +146,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2
+        with:
+          egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'yarn'
 
+      - name: Setup Socket.dev
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: sfw yarn install --frozen-lockfile
 
       - name: Build dependencies
         run: |
@@ -163,17 +184,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2
+        with:
+          egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'yarn'
 
+      - name: Setup Socket.dev
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: sfw yarn install --frozen-lockfile
 
       - name: Build smart-contracts package
         run: |

--- a/.github/workflows/tron-smart-contracts.yml
+++ b/.github/workflows/tron-smart-contracts.yml
@@ -54,13 +54,13 @@ jobs:
           node-version: '22'
           cache: 'yarn'
 
-      - name: Install TronBox globally
-        run: npm install -g tronbox
-
       - name: Setup Socket.dev
         uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+
+      - name: Install TronBox globally
+        run: sfw npm install -g tronbox
 
       - name: Install dependencies
         run: sfw yarn install --frozen-lockfile


### PR DESCRIPTION
Implements all GitHub Actions hardening from RequestNetwork/private-issues#282.

## Changes

- All third-party actions pinned to immutable commit SHAs — including `github/codeql-action/upload-sarif` which runs with `security-events: write`
- Top-level `permissions: contents: read` added to workflows that lacked it (security workflows already had correct permission blocks)
- StepSecurity Harden Runner added to every job (`egress-policy: audit`)
- SocketDev Firewall Free added to tron-smart-contracts install steps (`sfw yarn install --frozen-lockfile`)

## Next steps after merge

- Monitor Harden Runner audit logs for ~1 week, then promote `egress-policy: audit` → `block` with the actual allowlist