### PR TITLE
fix(data-format): ajv warnings

### DIFF
--- a/packages/data-format/src/format/rnf_invoice/rnf_invoice-0.0.3.json
+++ b/packages/data-format/src/format/rnf_invoice/rnf_invoice-0.0.3.json
@@ -154,6 +154,7 @@
             "then": {
               "properties": {
                 "amount": {
+                  "type": "string",
                   "pattern": "^\\d*\\.?\\d+$"
                 }
               }
@@ -161,6 +162,7 @@
             "else": {
               "properties": {
                 "amount": {
+                  "type": "string",
                   "pattern": "^\\d+$"
                 }
               }


### PR DESCRIPTION
This fixes AJV's warnings when initializing the library:
```
  console.warn
    strict mode: missing type "string" for keyword "pattern" at "#/properties/invoiceItems/items/properties/tax/else/properties/amount" (strictTypes)

      at checkStrictMode (node_modules/.pnpm/ajv@8.17.1/node_modules/ajv/lib/compile/util.ts:212:18)
      at strictTypesError (node_modules/.pnpm/ajv@8.17.1/node_modules/ajv/lib/compile/validate/index.ts:331:18)
      at checkKeywordTypes (node_modules/.pnpm/ajv@8.17.1/node_modules/ajv/lib/compile/validate/index.ts:305:9)
      ...
```
AJV warns that regex patterns only apply to strings, so they should be explicitly specified in the schema, as we already do for other patterns.