### PR TITLE
chore(smart-contracts): remove unused commerce-payments git dependency

### DIFF
--- a/packages/payment-detection/codegen-near.yml
+++ b/packages/payment-detection/codegen-near.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'https://api.studio.thegraph.com/query/67444/request-payments-near-testnet/version/latest'
+schema: 'src/thegraph/queries/near/schema.graphql'
 documents: src/thegraph/queries/near/*.graphql
 generates:
   src/thegraph/generated/graphql-near.ts:

--- a/packages/payment-detection/src/thegraph/queries/near/schema.graphql
+++ b/packages/payment-detection/src/thegraph/queries/near/schema.graphql
@@ -1,0 +1,92 @@
+# GraphQL schema for Request Network NEAR payments
+# This schema is used for generating TypeScript types for The Graph queries
+
+type Query {
+  payments(
+    where: Payment_filter
+    orderBy: Payment_orderBy
+    orderDirection: OrderDirection
+  ): [Payment!]!
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
+enum Payment_orderBy {
+  timestamp
+  block
+  amount
+}
+
+input Payment_filter {
+  reference: String
+  to: String
+  tokenAddress: String
+  contractAddress: String
+  currency: String
+  maxRateTimespan_gte: Int
+}
+
+type Payment {
+  "Unique identifier"
+  id: ID!
+
+  "The payment recipient address"
+  to: String!
+
+  "The payment amount"
+  amount: BigInt!
+
+  "The indexed payment reference"
+  reference: String!
+
+  "The fee amount"
+  feeAmount: BigInt
+
+  "The fee recipient address"
+  feeAddress: String
+
+  "The sender address"
+  from: String!
+
+  "Block number"
+  block: Int!
+
+  "Block timestamp (Unix seconds)"
+  timestamp: Int!
+
+  "Receipt ID (NEAR transaction identifier)"
+  receiptId: String!
+
+  "Transaction hash"
+  txHash: String
+
+  "Gas price"
+  gasPrice: String
+
+  "Gas used"
+  gasUsed: String
+
+  "The contract address"
+  contractAddress: String!
+
+  "The token address (null for native NEAR payments)"
+  tokenAddress: String
+
+  "The currency symbol (for conversion payments)"
+  currency: String
+
+  "Amount in crypto (for conversion payments)"
+  amountInCrypto: String
+
+  "Fee amount in crypto (for conversion payments)"
+  feeAmountInCrypto: String
+
+  "Max rate timespan (for conversion payments)"
+  maxRateTimespan: Int
+}
+
+scalar BigInt
+scalar Bytes

--- a/packages/smart-contracts/package.json
+++ b/packages/smart-contracts/package.json
@@ -72,7 +72,6 @@
     "tron:deploy:test-token": "node scripts/tron/deploy-test-token.js"
   },
   "dependencies": {
-    "commerce-payments": "git+https://github.com/base/commerce-payments.git#v1.0.0",
     "tslib": "2.8.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10158,10 +10158,6 @@ comment-parser@1.1.2:
   resolved "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.2.tgz"
   integrity sha512-AOdq0i8ghZudnYv8RUnHrhTgafUGs61Rdz9jemU5x2lnZwAWyOq7vySo626K59e1fVKH1xSRorJwPVRLSWOoAQ==
 
-"commerce-payments@git+https://github.com/base/commerce-payments.git#v1.0.0":
-  version "0.0.0"
-  resolved "git+https://github.com/base/commerce-payments.git#d33b5d5f74fff55f1c0857b1cb6fb4995949330b"
-
 common-ancestor-path@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz"


### PR DESCRIPTION
## Summary

- Removes the `commerce-payments` git dependency (`git+https://github.com/base/commerce-payments.git#v1.0.0`) from `@requestnetwork/smart-contracts`
- Fixes a broken CI build caused by the NEAR testnet subgraph no longer existing on The Graph Studio

### commerce-payments removal

The package is a Solidity-only repo with no npm publication; it was listed as a runtime dependency but has **zero TypeScript/JavaScript imports** anywhere in the codebase. All interfaces needed by `ERC20CommerceEscrowWrapper.sol` are already copied locally at `src/contracts/interfaces/IAuthCaptureEscrow.sol`. Removing it allows re-enabling `blockExoticSubdeps` for stronger supply-chain attack protection.

### NEAR GraphQL codegen fix

`codegen-near.yml` was fetching the GraphQL schema live from `https://api.studio.thegraph.com/query/67444/request-payments-near-testnet/version/latest`, which no longer exists. This caused codegen to fail, `graphql-near.ts` to never be generated, and the TypeScript build for `@requestnetwork/payment-detection` to break.

Fix follows the existing pattern used by the TRON codegen: a local `schema.graphql` SDL file is committed to the repo (`src/thegraph/queries/near/schema.graphql`) so the build is fully offline and not gated on an external endpoint being live.

## Test plan

- [x] `yarn workspace @requestnetwork/smart-contracts build:sol` — 81 Solidity files compiled successfully
- [x] `yarn workspace @requestnetwork/payment-detection codegen` — all four codegen targets pass (graphql.ts, graphql-superfluid.ts, graphql-near.ts, graphql-tron.ts)
- [x] `yarn workspace @requestnetwork/payment-detection build` — TypeScript build passes cleanly
- [x] `yarn install` — lockfile updates cleanly