### PR TITLE
chore: audit finding "Fee Address Is Using transfer"

### DIFF
--- a/packages/smart-contracts/src/contracts/BatchConversionPayments.sol
+++ b/packages/smart-contracts/src/contracts/BatchConversionPayments.sol
@@ -309,7 +309,10 @@ contract BatchConversionPayments is BatchNoConversionPayments {
     }
 
     require(address(this).balance >= batchFeeToPay, 'Not enough funds for batch conversion fees');
-    feeAddress.transfer(batchFeeToPay);
+    if (batchFeeToPay > 0) {
+      (bool feePaymentSuccess, ) = payable(feeAddress).call{value: batchFeeToPay}('');
+      require(feePaymentSuccess, 'Could not pay fees');
+    }
 
     // Batch contract transfers the remaining native tokens to the payer
     (bool sendBackSuccess, ) = payable(msg.sender).call{value: address(this).balance}('');

--- a/packages/smart-contracts/src/contracts/BatchNoConversionPayments.sol
+++ b/packages/smart-contracts/src/contracts/BatchNoConversionPayments.sol
@@ -200,7 +200,10 @@ contract BatchNoConversionPayments is Ownable {
     // Check that batch contract has enough funds to pay batch fee
     require(address(this).balance >= amount, 'Not enough funds for batch fee');
     // Batch pays batch fee
-    feeAddress.transfer(amount);
+    if (batchFeeToPay > 0) {
+      (bool feePaymentSuccess, ) = payable(feeAddress).call{value: batchFeeToPay}('');
+      require(feePaymentSuccess, 'Could not pay fees');
+    }
 
     // Batch contract transfers the remaining Native tokens to the payer
     if (transferBackRemainingNativeTokens && address(this).balance > 0) {

--- a/packages/smart-contracts/src/contracts/BatchNoConversionPayments.sol
+++ b/packages/smart-contracts/src/contracts/BatchNoConversionPayments.sol
@@ -200,8 +200,8 @@ contract BatchNoConversionPayments is Ownable {
     // Check that batch contract has enough funds to pay batch fee
     require(address(this).balance >= amount, 'Not enough funds for batch fee');
     // Batch pays batch fee
-    if (batchFeeToPay > 0) {
-      (bool feePaymentSuccess, ) = payable(feeAddress).call{value: batchFeeToPay}('');
+    if (amount > 0) {
+      (bool feePaymentSuccess, ) = payable(feeAddress).call{value: amount}('');
       require(feePaymentSuccess, 'Could not pay fees');
     }
 


### PR DESCRIPTION
## Description of the changes

Addressing the finding `[Medium] Fee Address Is Using transfer` from Creed DAO, in `BatchConversionPayments` only.

> When native funds are transferred, the EthereumFeeProxy and BatchConversionPayments smart
contracts use the transfer function to transfer the native fees. transfer allocates a fixed 2300 gas
stipend, which is subject to future changes and is not considered reliable.


> To avoid disrupting the system across gas-related protocol changes, we recommend using external calls to transfer the funds, as it is already done for recipient and caller transfers in the above functions. Additionally, we recommend checking that the fee amount is non-zero before attempting a transfer to save gas and avoid unnecessary actions.